### PR TITLE
Update scraper options to make it headless

### DIFF
--- a/scrapers/ariba/rfp_scraper.py
+++ b/scrapers/ariba/rfp_scraper.py
@@ -163,6 +163,7 @@ if __name__ == "__main__":
     finished = False
     clicked = set()
     chrome_options = webdriver.ChromeOptions()
+    chrome_options.add_argument('--headless')
     prefs = {"download.default_directory": str(DOWNLOAD_DIRECTORY)}
     chrome_options.add_experimental_option("prefs", prefs)
     driver = Ariba(


### PR DESCRIPTION
Turns out it was just a single line change to make the scraper headless. Seeing an issue running this on an Ubuntu OS through WSL where the scraper will pause after parsing a few documents?