### PR TITLE
P3: Export/publish seam (tb export, nested JSON)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-toronto-bids-scraper-p2-ariba-discovery.md
+++ b/docs/superpowers/plans/2026-07-15-toronto-bids-scraper-p2-ariba-discovery.md
@@ -1,0 +1,843 @@
+# Toronto Bids Scraper — P2: Ariba Discovery JSON Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Archive currently-open City-of-Toronto SAP Ariba Discovery postings (which vanish when they close) into a new `ariba_posting` table, bridging each to its `document_number` where possible — using only public JSON APIs, no auth, no browser.
+
+**Architecture:** A new source adapter (`AribaDiscoverySource`) follows the established `fetch() → normalize()` pattern. `fetch()` does all network I/O: it POSTs the public `doIndexedSearch` feed, keeps the City-of-Toronto postings, then GETs the `/rfx/{rfxID}` detail for each — wrapping each detail call in its own try/except so a failing posting yields `detail=None` and is still archived from its search metadata. `normalize()` is pure: it builds `AribaPosting` rows and bridges `rfxID → document_number` via the detail's `externalRfxId` (with a title-embedded `Doc##########` fallback). Idempotent upserts with `overwrite=True` mean a later successful run fills gaps left by a transient 500 without wiping an earlier snapshot.
+
+**Tech Stack:** Python 3.12+, `uv`, `httpx` (existing `HttpClient` with retry-on-500), SQLite, `pytest`. No browser, no auth in this scope.
+
+## Global Constraints
+
+- **Python 3.12+**, managed with **uv** only (`uv add`, `uv run`). All `uv`/`pytest` commands run from inside `scrapers/`. Package import name `toronto_bids`.
+- **Builds on the merged P0/P1 package.** Reuse, do not duplicate: `models.py` dataclasses, `config.py`, `http.HttpClient` (has `get_json(url, params=None)`, `post_json(url, json=None, params=None)`, retries on 5xx via `config.HTTP_RETRIES`), `store/db.py` (`upsert_row(conn, row, *, overwrite)`, `_upsert_keyed`, `counts`, `init_db`), `store/schema.sql`, `sources/base.Source` protocol (`name`, `overwrite`, `fetch`, `normalize`), `pipeline.py` (`default_sources`, `run_source`, `sync`), `linking/document_number.normalize_document_number`.
+- **Bridge is LEAN and reliable-only:** `rfxID → document_number` comes from (1) the detail's `externalRfxId` run through `normalize_document_number`, and (2) a `Doc(\d{10})` regex on the title. **No OData `Ariba_Discovery_Posting_Link` fallback** (verified live: the search/detail rfxID namespace `1110xxxxxx` and OData's link-id namespace do not overlap — 0/42 match). **No fuzzy title→solicitation matching** (risks wrong bridges). An un-bridged posting is still archived.
+- **Archive always, never delete.** Every City-of-Toronto posting produces exactly one `ariba_posting` row (bridged or not). `raw_json` holds the detail JSON snapshot, or `NULL` when the detail call failed. `first_seen`/`last_seen` (TEXT, `datetime('now')`) give archive timing; upserts touch `last_seen`.
+- **`AribaDiscoverySource.overwrite = True`.** With the store's `overwrite=True` COALESCE (`COALESCE(excluded.col, table.col)`), a later successful detail fills columns that were NULL, and a later 500 (all-NULL detail fields) does **not** wipe an earlier captured snapshot. This is the archival guarantee.
+- **Per-posting isolation inside `fetch()`:** a detail-call exception yields `detail=None` and continues; it must never abort the source. (The pipeline's per-source isolation is already in place separately.)
+- **Endpoints (verified live 2026-07-15):**
+  - Search: `POST https://service.ariba.com/Network/discoveryweb/search/public/v1/doIndexedSearch` with query `?siteName=Quote` and JSON body `{"pageSize":1000,"pageNum":0,"searchType":"Quote","sortBy":"RESPONSE_DEAD_LINE","filters":[]}`. Returns `{"totalNumberOfRecords":N, "solarRecords":[...]}`. ~835 global records, **42 with `customerName == "City of Toronto"`**. Single page suffices (total < pageSize).
+  - Detail: `GET https://service.ariba.com/Network/discoveryweb/api/public/v1/rfx/{rfxID}` with header `Accept: application/json`. ~60% return 200; **~40% return HTTP 500 persistently** on any given run (transient across runs). 200 body carries `externalRfxId` (e.g. `"Doc5672751291"`), `categories`, `territories`, `opportunityAmount`, `status`, `publicPostingUrl`, `sourcingUrl`.
+- **Filter to City of Toronto:** keep only search records where `customerName == "City of Toronto"`.
+
+**Reference spec:** `docs/superpowers/specs/2026-07-14-toronto-bids-scraper-rewrite-design.md` (§2.1 sources #6/#7, §3.2 bridge joins, §5 `ariba_posting`, §10 P2).
+
+---
+
+## File Structure
+
+New and modified files (all under `scrapers/`):
+
+```
+scrapers/
+  toronto_bids/
+    models.py                     # MODIFY: add AribaPosting dataclass
+    config.py                     # MODIFY: add Ariba search/detail URLs, body, params, customer name
+    http.py                       # MODIFY: add optional headers= to get_json/post_json
+    pipeline.py                   # MODIFY: add AribaDiscoverySource to default_sources
+    store/
+      schema.sql                  # MODIFY: add ariba_posting table + index
+      db.py                       # MODIFY: _ARIBA_POSTING_COLS, upsert_row branch, counts()
+    linking/
+      document_number.py          # MODIFY: add bridge_document_number(external_rfx_id, title)
+    sources/
+      ariba.py                    # CREATE: AribaDiscoverySource (fetch + normalize) + helpers
+  tests/
+    fixtures/
+      ariba_search_record.json    # CREATE: one real City-of-Toronto search record
+      ariba_detail.json           # CREATE: its real /rfx detail response (trimmed)
+    test_document_number.py       # MODIFY: add bridge_document_number tests
+    test_db.py                    # MODIFY: add ariba_posting upsert/counts tests
+    test_http.py                  # MODIFY: add headers pass-through test
+    test_ariba.py                 # CREATE: fetch (search+detail+500 isolation) + normalize tests
+    test_pipeline_integration.py  # MODIFY: add ariba fetch→normalize→upsert integration test
+```
+
+---
+
+### Task 1: `AribaPosting` model + `ariba_posting` table + store wiring
+
+**Files:**
+- Modify: `scrapers/toronto_bids/models.py`
+- Modify: `scrapers/toronto_bids/store/schema.sql`
+- Modify: `scrapers/toronto_bids/store/db.py`
+- Modify: `scrapers/tests/test_db.py`
+
+**Interfaces:**
+- Consumes: `db.upsert_row(conn, row, *, overwrite)`, `db.counts(conn)`.
+- Produces:
+  - `models.AribaPosting` (frozen dataclass; fields below, `rfx_id` required, rest default `None`, `source: str = ""`).
+  - `ariba_posting` table keyed on `rfx_id`.
+  - `db.upsert_row` dispatches `AribaPosting` to the `ariba_posting` table (conflict key `rfx_id`).
+  - `db.counts(conn)` includes `"ariba_posting"`.
+
+- [ ] **Step 1: Add the `AribaPosting` dataclass**
+
+Append to `scrapers/toronto_bids/models.py`:
+
+```python
+@dataclass(frozen=True)
+class AribaPosting:
+    rfx_id: str
+    document_number: str | None = None
+    title: str | None = None
+    posting_type: str | None = None      # detail 'type' field — unreliable (often "RFI")
+    status: str | None = None
+    customer_name: str | None = None
+    posted_date: str | None = None
+    close_date: str | None = None
+    categories: str | None = None        # JSON array of category names
+    amount_min: str | None = None
+    amount_max: str | None = None
+    currency: str | None = None
+    public_posting_url: str | None = None
+    sourcing_url: str | None = None      # authenticated event URL (for a later attachments phase)
+    external_rfx_id: str | None = None   # raw e.g. "Doc5672751291"
+    raw_json: str | None = None          # detail JSON snapshot, or None if the detail call failed
+    source: str = ""
+```
+
+- [ ] **Step 2: Add the `ariba_posting` table**
+
+Append to `scrapers/toronto_bids/store/schema.sql`:
+
+```sql
+
+-- ariba_posting archives open SAP Ariba Discovery postings (which disappear when they close).
+-- overwrite=True upserts fill NULL columns on later runs; a later 500 (all-NULL) never wipes an
+-- earlier captured snapshot. document_number is bridged best-effort and may be NULL.
+CREATE TABLE IF NOT EXISTS ariba_posting (
+    rfx_id              TEXT PRIMARY KEY,
+    document_number     TEXT,
+    title               TEXT,
+    posting_type        TEXT,
+    status              TEXT,
+    customer_name       TEXT,
+    posted_date         TEXT,
+    close_date          TEXT,
+    categories          TEXT,
+    amount_min          TEXT,
+    amount_max          TEXT,
+    currency            TEXT,
+    public_posting_url  TEXT,
+    sourcing_url        TEXT,
+    external_rfx_id     TEXT,
+    raw_json            TEXT,
+    source              TEXT,
+    first_seen          TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ariba_posting_docnum ON ariba_posting (document_number);
+```
+
+- [ ] **Step 3: Write the failing store tests**
+
+Add to `scrapers/tests/test_db.py` (the file already imports from `toronto_bids.models` and `toronto_bids.store`; add `AribaPosting` to the models import):
+
+```python
+def test_upsert_ariba_posting_is_idempotent(conn):
+    from toronto_bids.models import AribaPosting
+    p = AribaPosting(rfx_id="1110015885", document_number="5672751291",
+                     title="RFT Watermain", raw_json="{}", source="ariba_discovery")
+    db.upsert_row(conn, p, overwrite=True)
+    db.upsert_row(conn, p, overwrite=True)
+    assert db.counts(conn)["ariba_posting"] == 1
+
+
+def test_ariba_posting_later_500_does_not_wipe_snapshot(conn):
+    from toronto_bids.models import AribaPosting
+    # Run 1: detail succeeded -> raw_json + document_number captured.
+    db.upsert_row(conn, AribaPosting(rfx_id="1110015885", document_number="5672751291",
+                                     raw_json="{\"x\":1}", source="ariba_discovery"), overwrite=True)
+    # Run 2: detail 500'd -> those fields arrive as None. overwrite=True must NOT clobber them.
+    db.upsert_row(conn, AribaPosting(rfx_id="1110015885", document_number=None,
+                                     raw_json=None, source="ariba_discovery"), overwrite=True)
+    row = conn.execute(
+        "SELECT document_number, raw_json FROM ariba_posting WHERE rfx_id='1110015885'"
+    ).fetchone()
+    assert row["document_number"] == "5672751291"
+    assert row["raw_json"] == "{\"x\":1}"
+
+
+def test_counts_includes_ariba_posting(conn):
+    assert "ariba_posting" in db.counts(conn)
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_db.py -k ariba -v`
+Expected: FAIL — `AribaPosting` not importable / `counts` has no `ariba_posting` key.
+
+- [ ] **Step 5: Wire the store**
+
+In `scrapers/toronto_bids/store/db.py`:
+
+Add `AribaPosting` to the models import:
+```python
+from toronto_bids.models import Award, NonCompetitive, Solicitation, AribaPosting
+```
+
+Add the column list after `_NONCOMP_COLS`:
+```python
+_ARIBA_POSTING_COLS = [
+    "rfx_id", "document_number", "title", "posting_type", "status", "customer_name",
+    "posted_date", "close_date", "categories", "amount_min", "amount_max", "currency",
+    "public_posting_url", "sourcing_url", "external_rfx_id", "raw_json", "source",
+]
+```
+
+Add a branch in `upsert_row` (before the final `else`):
+```python
+    elif isinstance(row, AribaPosting):
+        values = [getattr(row, c) for c in _ARIBA_POSTING_COLS]
+        _upsert_keyed(conn, "ariba_posting", _ARIBA_POSTING_COLS, values,
+                      ["rfx_id"], overwrite)
+```
+
+Add `"ariba_posting"` to the `counts` table list:
+```python
+def counts(conn) -> dict:
+    tables = ["solicitation", "award", "noncompetitive", "ariba_posting", "sync_run"]
+    return {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd scrapers && uv run pytest tests/test_db.py -v`
+Expected: all PASS (existing + 3 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scrapers/toronto_bids/models.py scrapers/toronto_bids/store scrapers/tests/test_db.py
+git commit -m "feat(scraper): add ariba_posting table, model, and store wiring"
+```
+
+---
+
+### Task 2: `bridge_document_number` helper
+
+The pure rfxID→document_number bridge: try the detail's `externalRfxId`, then a title-embedded `Doc##########`.
+
+**Files:**
+- Modify: `scrapers/toronto_bids/linking/document_number.py`
+- Modify: `scrapers/tests/test_document_number.py`
+
+**Interfaces:**
+- Consumes: `normalize_document_number(raw) -> str | None` (same module).
+- Produces: `bridge_document_number(external_rfx_id: str | None, title: str | None) -> str | None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `scrapers/tests/test_document_number.py`:
+
+```python
+from toronto_bids.linking.document_number import bridge_document_number
+
+
+def test_bridge_uses_external_rfx_id():
+    # "Doc5672751291" -> strip -> "5672751291"
+    assert bridge_document_number("Doc5672751291", "some title") == "5672751291"
+
+
+def test_bridge_falls_back_to_title_embedded_doc():
+    title = "Doc5581608073 - Request for Quotations for the non-exclusive supply"
+    assert bridge_document_number(None, title) == "5581608073"
+
+
+def test_bridge_prefers_external_rfx_id_over_title():
+    assert bridge_document_number("Doc5672751291", "Doc9999999999 - other") == "5672751291"
+
+
+def test_bridge_returns_none_when_neither_resolves():
+    assert bridge_document_number(None, "Request for Tenders for Road Resurfacing") is None
+    assert bridge_document_number("", "") is None
+    assert bridge_document_number(None, None) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_document_number.py -k bridge -v`
+Expected: FAIL — `bridge_document_number` not defined.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `scrapers/toronto_bids/linking/document_number.py` (after `normalize_document_number`):
+
+```python
+_TITLE_DOC = re.compile(r"Doc(\d{10})")
+
+
+def bridge_document_number(external_rfx_id: str | None, title: str | None) -> str | None:
+    """Bridge an Ariba posting to its 10-digit document_number.
+
+    Primary: the detail endpoint's externalRfxId (e.g. "Doc5672751291").
+    Fallback: a "Doc##########" token embedded in the posting title.
+    Returns None if neither yields a valid document number.
+    """
+    doc = normalize_document_number(external_rfx_id)
+    if doc is not None:
+        return doc
+    if title:
+        match = _TITLE_DOC.search(title)
+        if match:
+            return normalize_document_number(match.group(1))
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scrapers && uv run pytest tests/test_document_number.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/linking/document_number.py scrapers/tests/test_document_number.py
+git commit -m "feat(scraper): add rfxID->document_number bridge helper"
+```
+
+---
+
+### Task 3: HTTP header support + config + Ariba `fetch()`
+
+Add optional headers to the HTTP client, the Ariba endpoint config, and the source's network half (search + per-posting detail with 500 isolation).
+
+**Files:**
+- Modify: `scrapers/toronto_bids/http.py`
+- Modify: `scrapers/toronto_bids/config.py`
+- Create: `scrapers/toronto_bids/sources/ariba.py`
+- Modify: `scrapers/tests/test_http.py`
+- Create: `scrapers/tests/test_ariba.py`
+
+**Interfaces:**
+- Consumes: `HttpClient.post_json`, `HttpClient.get_json`, `config.*`.
+- Produces:
+  - `HttpClient.get_json(url, params=None, headers=None)` and `HttpClient.post_json(url, json=None, params=None, headers=None)`.
+  - `config.ARIBA_SEARCH_URL`, `config.ARIBA_DETAIL_URL`, `config.ARIBA_SEARCH_BODY`, `config.ARIBA_SEARCH_PARAMS`, `config.ARIBA_CUSTOMER_NAME`.
+  - `ariba.AribaDiscoverySource` with `name="ariba_discovery"`, `overwrite=True`, `fetch(http) -> Iterable[dict]` yielding `{"search": <record>, "detail": <dict|None>}`. (`normalize` is added in Task 4.)
+
+- [ ] **Step 1: Add `headers` pass-through to the HTTP client**
+
+In `scrapers/toronto_bids/http.py`, thread an optional `headers` through `_request` and both public methods:
+
+```python
+    def _request(self, method, url, headers=None, **kwargs):
+        last_exc = None
+        for attempt in range(self._retries + 1):
+            try:
+                resp = self._client.request(method, url, headers=headers, **kwargs)
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code < 500:
+                    raise
+                last_exc = exc
+            except httpx.TransportError as exc:
+                last_exc = exc
+            if attempt < self._retries:
+                time.sleep(self._backoff * (2 ** attempt))
+        raise last_exc
+
+    def get_json(self, url, params=None, headers=None):
+        return self._request("GET", url, params=params, headers=headers).json()
+
+    def post_json(self, url, json=None, params=None, headers=None):
+        return self._request("POST", url, json=json, params=params, headers=headers).json()
+```
+
+- [ ] **Step 2: Write the failing headers test**
+
+Add to `scrapers/tests/test_http.py`:
+
+```python
+def test_get_json_sends_custom_headers():
+    seen = {}
+    def handler(request):
+        seen["accept"] = request.headers.get("Accept")
+        return httpx.Response(200, json={"ok": True})
+    client = _client(handler)
+    client.get_json("https://example.test/x", headers={"Accept": "application/json"})
+    assert seen["accept"] == "application/json"
+```
+
+(The `_client` helper already exists at the top of `test_http.py`.)
+
+- [ ] **Step 3: Run the headers test to verify it fails**
+
+Run: `cd scrapers && uv run pytest tests/test_http.py -k custom_headers -v`
+Expected: FAIL — `get_json()` got an unexpected keyword argument `headers` (before edit) or assertion error.
+
+Note: apply Step 1 to make it pass. Run: `cd scrapers && uv run pytest tests/test_http.py -v` → all PASS.
+
+- [ ] **Step 4: Add Ariba config**
+
+Append to `scrapers/toronto_bids/config.py`:
+
+```python
+# SAP Ariba Discovery public JSON APIs (no auth).
+ARIBA_SEARCH_URL = "https://service.ariba.com/Network/discoveryweb/search/public/v1/doIndexedSearch"
+ARIBA_DETAIL_URL = "https://service.ariba.com/Network/discoveryweb/api/public/v1/rfx/{rfx_id}"
+ARIBA_SEARCH_PARAMS = {"siteName": "Quote"}
+ARIBA_SEARCH_BODY = {
+    "pageSize": 1000,
+    "pageNum": 0,
+    "searchType": "Quote",
+    "sortBy": "RESPONSE_DEAD_LINE",
+    "filters": [],
+}
+ARIBA_CUSTOMER_NAME = "City of Toronto"
+```
+
+- [ ] **Step 5: Write the failing `fetch` tests**
+
+Create `scrapers/tests/test_ariba.py`:
+
+```python
+import httpx
+
+from toronto_bids.http import HttpClient
+from toronto_bids.sources.ariba import AribaDiscoverySource
+
+
+def _http(handler):
+    return HttpClient(client=httpx.Client(transport=httpx.MockTransport(handler)), backoff=0.0)
+
+
+SEARCH_BODY = {
+    "totalNumberOfRecords": 3,
+    "solarRecords": [
+        {"rfxID": "1110015885", "customerName": "City of Toronto", "title": "RFT Watermain"},
+        {"rfxID": "1110099999", "customerName": "City of Toronto", "title": "RFQ Widgets"},
+        {"rfxID": "1110000001", "customerName": "TransLink", "title": "Other buyer"},
+    ],
+}
+
+
+def test_fetch_keeps_only_toronto_and_pairs_detail():
+    def handler(request):
+        if "doIndexedSearch" in str(request.url):
+            return httpx.Response(200, json=SEARCH_BODY)
+        # detail: 1110015885 succeeds, 1110099999 500s persistently
+        if request.url.path.endswith("1110015885"):
+            return httpx.Response(200, json={"id": "1110015885", "externalRfxId": "Doc5672751291"})
+        return httpx.Response(500, text="boom")
+    raws = list(AribaDiscoverySource().fetch(_http(handler)))
+    # TransLink record dropped; two Toronto records kept.
+    assert len(raws) == 2
+    by_id = {r["search"]["rfxID"]: r for r in raws}
+    assert by_id["1110015885"]["detail"]["externalRfxId"] == "Doc5672751291"
+    # The 500'd posting is still yielded, with detail=None (per-posting isolation).
+    assert by_id["1110099999"]["detail"] is None
+
+
+def test_fetch_does_not_raise_when_all_details_fail():
+    def handler(request):
+        if "doIndexedSearch" in str(request.url):
+            return httpx.Response(200, json=SEARCH_BODY)
+        return httpx.Response(500, text="boom")
+    raws = list(AribaDiscoverySource().fetch(_http(handler)))
+    assert len(raws) == 2
+    assert all(r["detail"] is None for r in raws)
+
+
+def test_source_attributes():
+    src = AribaDiscoverySource()
+    assert src.name == "ariba_discovery"
+    assert src.overwrite is True
+```
+
+- [ ] **Step 6: Run the fetch tests to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_ariba.py -v`
+Expected: FAIL — `toronto_bids.sources.ariba` not importable.
+
+- [ ] **Step 7: Implement `fetch` (normalize comes in Task 4)**
+
+Create `scrapers/toronto_bids/sources/ariba.py`:
+
+```python
+from typing import Iterable
+
+from toronto_bids import config
+from toronto_bids.sources.base import Row
+
+
+class AribaDiscoverySource:
+    """Archives open City-of-Toronto SAP Ariba Discovery postings via public JSON APIs."""
+
+    name = "ariba_discovery"
+    overwrite = True  # later successful detail fills NULLs; a later 500 never wipes a snapshot.
+
+    def fetch(self, http) -> Iterable[dict]:
+        data = http.post_json(
+            config.ARIBA_SEARCH_URL,
+            json=config.ARIBA_SEARCH_BODY,
+            params=config.ARIBA_SEARCH_PARAMS,
+        )
+        for record in data.get("solarRecords", []):
+            if record.get("customerName") != config.ARIBA_CUSTOMER_NAME:
+                continue
+            detail = None
+            try:
+                detail = http.get_json(
+                    config.ARIBA_DETAIL_URL.format(rfx_id=record["rfxID"]),
+                    headers={"Accept": "application/json"},
+                )
+            except Exception:
+                # Per-posting isolation: ~40% of details 500. Archive the search
+                # metadata anyway; a later run's detail call fills the gap.
+                detail = None
+            yield {"search": record, "detail": detail}
+
+    def normalize(self, raw: dict) -> Iterable[Row]:  # implemented in Task 4
+        raise NotImplementedError
+```
+
+Note: `normalize` is intentionally a stub here and is completed in Task 4; it is not exercised by this task's tests.
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd scrapers && uv run pytest tests/test_ariba.py tests/test_http.py -v`
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scrapers/toronto_bids/http.py scrapers/toronto_bids/config.py scrapers/toronto_bids/sources/ariba.py scrapers/tests/test_http.py scrapers/tests/test_ariba.py
+git commit -m "feat(scraper): add Ariba Discovery search+detail fetch with per-posting 500 isolation"
+```
+
+---
+
+### Task 4: Ariba `normalize()` + bridge + fixtures
+
+Turn each `{"search", "detail"}` raw into one `AribaPosting`, bridging the document number and snapshotting the detail JSON.
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/ariba.py` (implement `normalize` + a module `normalize_posting`)
+- Create: `scrapers/tests/fixtures/ariba_search_record.json`
+- Create: `scrapers/tests/fixtures/ariba_detail.json`
+- Modify: `scrapers/tests/test_ariba.py`
+
+**Interfaces:**
+- Consumes: `bridge_document_number`, `models.AribaPosting`.
+- Produces: `ariba.normalize_posting(raw: dict) -> Iterable[AribaPosting]`; `AribaDiscoverySource.normalize` delegates to it.
+
+- [ ] **Step 1: Create the real fixtures**
+
+`scrapers/tests/fixtures/ariba_search_record.json` (one real City-of-Toronto search record):
+
+```json
+{
+  "productsAndServicesCategories": [
+    "Sidewalk construction and repair service",
+    "Sewer line construction service"
+  ],
+  "shipToOrServiceLocations": ["Toronto (Mississauga) - Ontario"],
+  "title": "Request for Tenders for Watermain and Sewer Replacement on various roads",
+  "rfxID": "1110015885",
+  "minAmount": "712.5552230298",
+  "maxAmount": "70542967.0799487",
+  "customerName": "City of Toronto",
+  "rfxType": "RFI",
+  "datePosted": "2026-06-16T12:16:17-07:00",
+  "endDate": "2026-07-17T09:00:00-07:00"
+}
+```
+
+`scrapers/tests/fixtures/ariba_detail.json` (its real `/rfx` detail, trimmed):
+
+```json
+{
+  "id": "1110015885",
+  "type": "RFI",
+  "title": "Request for Tenders for Watermain and Sewer Replacement on various roads",
+  "status": "PUBLISHED",
+  "startDate": "2026-06-16T12:16:17",
+  "endDate": "2026-07-17T09:00:00",
+  "externalRfxId": "Doc5672751291",
+  "publicPostingUrl": "https://discovery.ariba.com/rfx/1110015885",
+  "sourcingUrl": "https://s1.ariba.com/Sourcing/Main/ad/gotoEvent/NetworkRFQDirectAction?rfxId=Doc5672751291&realm=toronto",
+  "companyInfo": {"companyName": "City of Toronto"},
+  "categories": [
+    {"categoryCode": 72141105, "categoryName": "Sidewalk construction and repair service"},
+    {"categoryCode": 72141121, "categoryName": "Water main construction service"}
+  ],
+  "opportunityAmount": {"maxAmount": 99000000, "minAmount": 1000, "currency": "CAD"}
+}
+```
+
+- [ ] **Step 2: Write the failing normalize tests**
+
+Add to `scrapers/tests/test_ariba.py`:
+
+```python
+import json
+from pathlib import Path
+
+from toronto_bids.models import AribaPosting
+from toronto_bids.sources import ariba
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fixture(name):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_normalize_with_detail_bridges_and_snapshots():
+    raw = {"search": _fixture("ariba_search_record.json"), "detail": _fixture("ariba_detail.json")}
+    posts = list(ariba.normalize_posting(raw))
+    assert len(posts) == 1
+    p = posts[0]
+    assert isinstance(p, AribaPosting)
+    assert p.rfx_id == "1110015885"
+    assert p.document_number == "5672751291"          # bridged from externalRfxId
+    assert p.external_rfx_id == "Doc5672751291"
+    assert p.status == "PUBLISHED"
+    assert p.customer_name == "City of Toronto"
+    assert p.close_date == "2026-07-17T09:00:00-07:00"  # search endDate preferred
+    assert p.currency == "CAD"
+    assert p.amount_max == "99000000"                 # from detail opportunityAmount
+    assert p.public_posting_url == "https://discovery.ariba.com/rfx/1110015885"
+    assert "s1.ariba.com" in p.sourcing_url
+    assert json.loads(p.categories) == ["Sidewalk construction and repair service",
+                                        "Water main construction service"]
+    assert json.loads(p.raw_json)["externalRfxId"] == "Doc5672751291"  # snapshot present
+    assert p.source == "ariba_discovery"
+
+
+def test_normalize_without_detail_archives_search_only():
+    raw = {"search": _fixture("ariba_search_record.json"), "detail": None}
+    p = list(ariba.normalize_posting(raw))[0]
+    assert p.rfx_id == "1110015885"
+    assert p.document_number is None          # no externalRfxId, no Doc in this title
+    assert p.raw_json is None                 # nothing to snapshot
+    assert p.external_rfx_id is None
+    assert p.title == "Request for Tenders for Watermain and Sewer Replacement on various roads"
+    assert p.customer_name == "City of Toronto"
+    assert p.amount_max == "70542967.0799487"  # falls back to search maxAmount
+    assert p.currency is None
+    assert json.loads(p.categories) == ["Sidewalk construction and repair service",
+                                        "Sewer line construction service"]
+
+
+def test_normalize_without_detail_bridges_title_embedded_doc():
+    search = dict(_fixture("ariba_search_record.json"))
+    search["title"] = "Doc5581608073 - Request for Quotations for supplies"
+    p = list(ariba.normalize_posting({"search": search, "detail": None}))[0]
+    assert p.document_number == "5581608073"   # bridged from the title
+```
+
+- [ ] **Step 3: Run the normalize tests to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_ariba.py -k normalize -v`
+Expected: FAIL — `ariba.normalize_posting` not defined / `NotImplementedError`.
+
+- [ ] **Step 4: Implement `normalize_posting`**
+
+In `scrapers/toronto_bids/sources/ariba.py`, add imports at the top:
+
+```python
+import json
+
+from toronto_bids.linking.document_number import bridge_document_number
+from toronto_bids.models import AribaPosting
+```
+
+Add helpers and the normalizer above the class:
+
+```python
+def _clean(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _categories(search: dict, detail: dict | None) -> str | None:
+    if detail and detail.get("categories"):
+        names = [c.get("categoryName") for c in detail["categories"] if c.get("categoryName")]
+        return json.dumps(names) if names else None
+    cats = search.get("productsAndServicesCategories")
+    return json.dumps(cats) if cats else None
+
+
+def normalize_posting(raw: dict):
+    search = raw["search"]
+    detail = raw.get("detail")
+    rfx_id = str(search["rfxID"])
+    title = _clean(search.get("title")) or (_clean(detail.get("title")) if detail else None)
+    external = _clean(detail.get("externalRfxId")) if detail else None
+
+    if detail and detail.get("opportunityAmount"):
+        amt = detail["opportunityAmount"]
+        amount_min, amount_max = _clean(amt.get("minAmount")), _clean(amt.get("maxAmount"))
+        currency = _clean(amt.get("currency"))
+    else:
+        amount_min, amount_max = _clean(search.get("minAmount")), _clean(search.get("maxAmount"))
+        currency = None
+
+    yield AribaPosting(
+        rfx_id=rfx_id,
+        document_number=bridge_document_number(external, title),
+        title=title,
+        posting_type=_clean(detail.get("type")) if detail else _clean(search.get("rfxType")),
+        status=_clean(detail.get("status")) if detail else None,
+        customer_name=_clean(search.get("customerName")),
+        posted_date=_clean(search.get("datePosted")) or (_clean(detail.get("startDate")) if detail else None),
+        close_date=_clean(search.get("endDate")) or (_clean(detail.get("endDate")) if detail else None),
+        categories=_categories(search, detail),
+        amount_min=amount_min,
+        amount_max=amount_max,
+        currency=currency,
+        public_posting_url=_clean(detail.get("publicPostingUrl")) if detail else None,
+        sourcing_url=_clean(detail.get("sourcingUrl")) if detail else None,
+        external_rfx_id=external,
+        raw_json=json.dumps(detail) if detail else None,
+        source="ariba_discovery",
+    )
+```
+
+Replace the `normalize` stub in the class with:
+
+```python
+    def normalize(self, raw: dict) -> Iterable[Row]:
+        yield from normalize_posting(raw)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd scrapers && uv run pytest tests/test_ariba.py -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/ariba.py scrapers/tests/test_ariba.py scrapers/tests/fixtures/ariba_search_record.json scrapers/tests/fixtures/ariba_detail.json
+git commit -m "feat(scraper): add Ariba posting normalizer with document_number bridge"
+```
+
+---
+
+### Task 5: Wire into pipeline + integration test + live smoke + docs
+
+**Files:**
+- Modify: `scrapers/toronto_bids/pipeline.py`
+- Modify: `scrapers/tests/test_pipeline_integration.py`
+- Modify: `scrapers/README.md`
+
+**Interfaces:**
+- Consumes: `AribaDiscoverySource`, `db.upsert_row`, the `conn` test fixture.
+- Produces: `ariba_discovery` in `default_sources()`; `tb sync`/`tb status` include `ariba_posting`.
+
+- [ ] **Step 1: Add the source to the pipeline**
+
+In `scrapers/toronto_bids/pipeline.py`, import and append it:
+
+```python
+from toronto_bids.sources.ariba import AribaDiscoverySource
+```
+
+Append to the `default_sources()` return list (after the CKAN sources):
+```python
+        AribaDiscoverySource(),
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+Add to `scrapers/tests/test_pipeline_integration.py`:
+
+```python
+def test_ariba_fetch_normalize_upsert_bridges_and_archives(conn):
+    from toronto_bids.sources.ariba import normalize_posting
+    from toronto_bids.store import db
+
+    search = _load("ariba_search_record.json")
+    detail = _load("ariba_detail.json")
+    # Simulate the fetch output: one detail-200 posting, one detail-500 posting.
+    raws = [
+        {"search": search, "detail": detail},
+        {"search": {**search, "rfxID": "1110099999", "title": "no doc here"}, "detail": None},
+    ]
+    for raw in raws:
+        for row in normalize_posting(raw):
+            db.upsert_row(conn, row, overwrite=True)
+    conn.commit()
+
+    assert db.counts(conn)["ariba_posting"] == 2
+    bridged = conn.execute(
+        "SELECT document_number, raw_json FROM ariba_posting WHERE rfx_id='1110015885'"
+    ).fetchone()
+    assert bridged["document_number"] == "5672751291"   # linked to the OData/CKAN spine
+    assert bridged["raw_json"] is not None               # snapshot archived
+    unbridged = conn.execute(
+        "SELECT document_number, raw_json FROM ariba_posting WHERE rfx_id='1110099999'"
+    ).fetchone()
+    assert unbridged["document_number"] is None          # archived even though un-bridged
+    assert unbridged["raw_json"] is None
+```
+
+(`_load` and the `conn` fixture already exist in this file / conftest. The fixtures live in `tests/fixtures/`, which `_load` reads.)
+
+- [ ] **Step 3: Run the integration test to verify it fails, then passes**
+
+Run: `cd scrapers && uv run pytest tests/test_pipeline_integration.py -v`
+Expected: the new test initially fails only if Step 1/prior tasks are incomplete; with Tasks 1–4 done it PASSES. Then run the full suite:
+
+Run: `cd scrapers && uv run pytest -v`
+Expected: every test PASSES, output pristine.
+
+- [ ] **Step 4: Live end-to-end smoke check (network — manual, not a test)**
+
+Run:
+```bash
+cd scrapers && TB_DATA_DIR=/tmp/tb-p2 uv run tb sync --only ariba_discovery && uv run tb status
+```
+Expected: completes without error; `tb status` shows `ariba_posting` in the low tens (~42). Then inspect the split:
+```bash
+sqlite3 /tmp/tb-p2/bids.sqlite "SELECT COUNT(*) total, COUNT(document_number) bridged, COUNT(raw_json) with_detail FROM ariba_posting;"
+sqlite3 /tmp/tb-p2/bids.sqlite "SELECT status FROM sync_run WHERE source='ariba_discovery';"
+```
+Expected: `total` ≈ 42; `bridged` and `with_detail` are a majority but < total (the ~40% that 500'd are archived with NULL doc/raw_json); `sync_run` status `ok`. Record the actual numbers in the report. Do **not** block the commit on the exact bridged ratio — it varies per run by design.
+
+- [ ] **Step 5: Update the README**
+
+In `scrapers/README.md`, add `ariba_discovery` to the sources list and note the archive semantics. Under the sources section, add:
+
+```markdown
+- **SAP Ariba Discovery** (`ariba_discovery`) — archives currently-open City-of-Toronto
+  Ariba postings (`ariba_posting` table) before they close, via public JSON APIs (no auth).
+  Each posting is bridged to its `document_number` where the detail endpoint resolves
+  (~40% return HTTP 500 on a given run and are archived un-bridged; idempotent re-runs fill
+  the gap). The `sourcing_url` column is the authenticated event link for a future
+  attachments phase.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scrapers/toronto_bids/pipeline.py scrapers/tests/test_pipeline_integration.py scrapers/README.md
+git commit -m "feat(scraper): wire ariba_discovery into pipeline; integration test + docs"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (design §2.1 #6/#7, §3.2, §5, §10 P2):**
+- Search API `doIndexedSearch` + City-of-Toronto filter → Task 3 (`fetch`). ✓
+- Detail API `/rfx/{id}` with `Accept: application/json`, ~40% 500 handled by retry-then-skip → Task 3 (`fetch` per-posting try/except; `HttpClient` retries). ✓
+- rfxID→document_number bridge via `externalRfxId` (strip) + title `Doc\d{10}` fallback; **no** OData-link / fuzzy → Task 2 + Task 4. ✓
+- `ariba_posting` table with raw JSON snapshot + archive timing (design §5) → Task 1. ✓
+- Archive every posting whether bridged or not; never delete; overwrite=True keeps snapshot across a later 500 → Tasks 1, 4 (+ `test_ariba_posting_later_500_does_not_wipe_snapshot`, `test_normalize_without_detail_archives_search_only`). ✓
+- Wire into `default_sources` → Task 5. ✓
+- `sourcing_url` retained for the later attachments phase (design §2.2) → Task 1 model + Task 4. ✓
+- Out of scope by design (authenticated attachment fetch = P4; TMMIS/PDF = P5; export seam = P3) → not in this plan. ✓
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N". Every code step shows complete code. The only `NotImplementedError` (Task 3 `AribaDiscoverySource.normalize`) is explicitly completed in Task 4 and not exercised before then. ✓
+
+**3. Type consistency:** `AribaPosting` field names match across models (Task 1), `_ARIBA_POSTING_COLS` (Task 1), and the normalizer (Task 4). `bridge_document_number(external_rfx_id, title)` signature matches between Task 2 and its Task 4 caller. `fetch` yields `{"search", "detail"}` dicts (Task 3) exactly as `normalize_posting` consumes them (Task 4). `AribaDiscoverySource` attributes (`name="ariba_discovery"`, `overwrite=True`) are consistent across Tasks 3, 5 and the `Source` protocol. `HttpClient.get_json/post_json` gain `headers=` consistently (Task 3) and the sole new caller passes `headers={"Accept": "application/json"}`. `db.counts` gains `"ariba_posting"` (Task 1), which `tb status` renders automatically. ✓

--- a/docs/superpowers/plans/2026-07-15-toronto-bids-scraper-p3-export-seam.md
+++ b/docs/superpowers/plans/2026-07-15-toronto-bids-scraper-p3-export-seam.md
@@ -1,0 +1,540 @@
+# Toronto Bids Scraper — P3: Export / Publish Seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish the local SQLite store to a self-contained, solicitation-centric nested JSON document, behind a destination-agnostic `Exporter` interface, exposed as `tb export`.
+
+**Architecture:** A pure builder (`build_export_document(conn) -> dict`) reads the store in one pass and assembles the nested shape — awards and Ariba postings nested under their solicitation by `document_number`, un-bridged postings and non-competitive contracts as their own top-level collections. An `Exporter` protocol is the publish seam; `JsonExporter` is its first implementation (serialize the document to a file). Later destinations (Parquet, a static site, an HTTP API) implement the same interface without touching the builder.
+
+**Tech Stack:** Python 3.12+, `uv`, stdlib `json`/`sqlite3`, `pytest`. No new dependencies, no network — this reads the local store only.
+
+## Global Constraints
+
+- **Python 3.12+**, managed with **uv** only. All `uv`/`pytest` commands run from inside `scrapers/`. Package import name `toronto_bids`.
+- **Builds on the merged P0/P1 + P2 package.** Reuse, do not duplicate: `store/db.py` (`connect`, `init_db`, `counts(conn) -> dict`), `config.py` (`DATA_DIR`, `DB_PATH`), the `cli.py` structure (`build_parser`, `_open_db`, `main` dispatch). The store's `conn` uses `row_factory = sqlite3.Row`, so `dict(row)` works.
+- **Store tables** (columns are authoritative — read them from `store/schema.sql` if unsure): `solicitation` (PK `document_number`), `award` (`id`, `document_number`, `supplier_name_raw`, `supplier_id`, `award_amount`, `award_date`, `source`, `first_seen`, `last_seen`), `noncompetitive` (PK `workspace_number`), `ariba_posting` (PK `rfx_id`, has nullable `document_number`, and `raw_json`, `categories`), `sync_run`.
+- **Export shape = solicitation-centric nested** (the approved decision):
+  ```
+  { "meta": { "generated_at", "counts", "sources" },
+    "solicitations": [ { ...solicitation cols, "awards": [...], "ariba_postings": [...] } ],
+    "noncompetitive": [ { ...noncompetitive cols } ],
+    "unlinked_ariba_postings": [ { ...ariba_posting cols } ] }
+  ```
+- **Nest by `document_number`:** each award and each Ariba posting whose `document_number` matches a solicitation is nested under it. An Ariba posting with **NULL `document_number`** goes into top-level `unlinked_ariba_postings` — **nothing is dropped** (preserves the P2 archive-always guarantee through the export).
+- **Non-competitive is a separate top-level array** (separate keyspace — never nested under a solicitation).
+- **Column hygiene:** drop internal/surrogate columns from exported records — `award.id`, `*.supplier_id`, `*.odata_id`, and `ariba_posting.raw_json` (the bulky detail snapshot stays in the DB, not the published artifact). Drop the redundant `document_number` from a *nested* award/posting (it's implied by the parent). Parse `ariba_posting.categories` (a JSON-string column) back into a real array in the export.
+- **Determinism:** `build_export_document(conn, generated_at=None)` accepts an optional `generated_at` so tests pin it; production defaults to `datetime.now(timezone.utc).isoformat()`. No other nondeterminism — order every query (`ORDER BY`).
+- **The seam:** `Exporter` is a `runtime_checkable` `Protocol` with `name: str` and `export(self, conn, out_path, generated_at=None) -> Path`. `build_export_document` is the shared, format-independent source of truth; exporters differ by destination/format, not shape.
+- **No new dependencies.**
+
+**Reference spec:** `docs/superpowers/specs/2026-07-14-toronto-bids-scraper-rewrite-design.md` (§5 linking model, §10 P3).
+
+**Base branch:** `p2-ariba-discovery` (P3 stacks on P2).
+
+---
+
+## File Structure
+
+New and modified files (all under `scrapers/`):
+
+```
+scrapers/
+  toronto_bids/
+    export/
+      __init__.py          # CREATE: empty package marker
+      document.py          # CREATE: build_export_document(conn, generated_at=None) -> dict (pure)
+      base.py              # CREATE: Exporter protocol
+      json_export.py       # CREATE: JsonExporter(Exporter)
+    cli.py                 # MODIFY: add `export` subcommand
+  tests/
+    test_export_document.py  # CREATE: builder tests (seeded in-memory DB)
+    test_json_export.py      # CREATE: JsonExporter file-write tests
+    test_smoke.py            # MODIFY: add `tb export` CLI wiring test
+```
+
+---
+
+### Task 1: `build_export_document` (pure nested builder)
+
+The heart of P3: read the store in one pass and assemble the nested document. Pure and deterministic — no file I/O, no network.
+
+**Files:**
+- Create: `scrapers/toronto_bids/export/__init__.py` (empty)
+- Create: `scrapers/toronto_bids/export/document.py`
+- Create: `scrapers/tests/test_export_document.py`
+
+**Interfaces:**
+- Consumes: `db.counts(conn)`; a `conn` with `row_factory = sqlite3.Row`.
+- Produces: `document.build_export_document(conn, generated_at: str | None = None) -> dict` with top-level keys `meta`, `solicitations`, `noncompetitive`, `unlinked_ariba_postings`. `meta` has `generated_at` (str), `counts` (dict), `sources` (list of `{source, status, finished_at, rows_fetched, rows_upserted}` ordered by `sync_run.id`). Each solicitation dict carries its own columns (minus `odata_id`) plus `awards` (list; each drops `id`/`supplier_id`/`document_number`) and `ariba_postings` (list; each drops `raw_json`/`document_number`, with `categories` parsed to a list). `noncompetitive` items drop `supplier_id`/`odata_id`. `unlinked_ariba_postings` items drop `raw_json` (but keep `document_number`, which is NULL), with `categories` parsed.
+
+- [ ] **Step 1: Write the failing tests**
+
+`scrapers/tests/test_export_document.py`:
+
+```python
+import json
+
+import pytest
+
+from toronto_bids.export.document import build_export_document
+from toronto_bids.models import AribaPosting, Award, NonCompetitive, Solicitation
+from toronto_bids.store import db
+
+
+@pytest.fixture
+def seeded(conn):
+    # One solicitation with an award and a bridged Ariba posting.
+    db.upsert_row(conn, Solicitation(document_number="5672751291", status="Open",
+                                     title="RFT Watermain", source="odata"), overwrite=True)
+    db.upsert_row(conn, Award(document_number="5672751291", supplier_name_raw="Acme Co",
+                              award_amount="1000", source="odata"), overwrite=True)
+    db.upsert_row(conn, AribaPosting(rfx_id="1110015885", document_number="5672751291",
+                                     title="RFT Watermain", categories='["Sidewalk"]',
+                                     raw_json='{"big":"blob"}', source="ariba_discovery"), overwrite=True)
+    # An Ariba posting that never bridged (document_number is NULL).
+    db.upsert_row(conn, AribaPosting(rfx_id="1110099999", document_number=None,
+                                     title="Unbridged posting", categories='["Water"]',
+                                     source="ariba_discovery"), overwrite=True)
+    # A non-competitive contract (separate keyspace).
+    db.upsert_row(conn, NonCompetitive(workspace_number="8614", supplier_name_raw="Sole Source Inc",
+                                       reason="Emergency", source="odata"), overwrite=True)
+    conn.commit()
+    return conn
+
+
+def test_meta_has_generated_at_counts_and_sources(seeded):
+    db.finish_sync_run(seeded, db.start_sync_run(seeded, "odata_solicitations"),
+                       status="ok", rows_fetched=5, rows_upserted=5)
+    doc = build_export_document(seeded, generated_at="2026-07-15T00:00:00Z")
+    assert doc["meta"]["generated_at"] == "2026-07-15T00:00:00Z"
+    assert doc["meta"]["counts"]["solicitation"] == 1
+    assert doc["meta"]["sources"][-1]["source"] == "odata_solicitations"
+    assert doc["meta"]["sources"][-1]["status"] == "ok"
+
+
+def test_award_and_posting_nested_under_solicitation(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    sols = doc["solicitations"]
+    assert len(sols) == 1
+    sol = sols[0]
+    assert sol["document_number"] == "5672751291"
+    assert "odata_id" not in sol
+    # award nested, internal cols dropped, redundant document_number dropped
+    assert len(sol["awards"]) == 1
+    assert sol["awards"][0]["supplier_name_raw"] == "Acme Co"
+    assert "id" not in sol["awards"][0]
+    assert "document_number" not in sol["awards"][0]
+    # ariba posting nested, raw_json dropped, categories parsed to a list
+    assert len(sol["ariba_postings"]) == 1
+    assert sol["ariba_postings"][0]["rfx_id"] == "1110015885"
+    assert "raw_json" not in sol["ariba_postings"][0]
+    assert sol["ariba_postings"][0]["categories"] == ["Sidewalk"]
+    assert "document_number" not in sol["ariba_postings"][0]
+
+
+def test_unbridged_posting_goes_to_unlinked_not_dropped(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    unlinked = doc["unlinked_ariba_postings"]
+    assert len(unlinked) == 1
+    assert unlinked[0]["rfx_id"] == "1110099999"
+    assert unlinked[0]["categories"] == ["Water"]
+    assert "raw_json" not in unlinked[0]
+    # It must NOT appear under any solicitation.
+    assert all(p["rfx_id"] != "1110099999"
+               for s in doc["solicitations"] for p in s["ariba_postings"])
+
+
+def test_noncompetitive_is_separate_top_level(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    assert len(doc["noncompetitive"]) == 1
+    assert doc["noncompetitive"][0]["workspace_number"] == "8614"
+    assert "supplier_id" not in doc["noncompetitive"][0]
+
+
+def test_document_is_json_serializable(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    json.dumps(doc)  # must not raise
+
+
+def test_empty_store_produces_empty_collections(conn):
+    doc = build_export_document(conn, generated_at="t")
+    assert doc["solicitations"] == []
+    assert doc["noncompetitive"] == []
+    assert doc["unlinked_ariba_postings"] == []
+    assert doc["meta"]["counts"]["solicitation"] == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_export_document.py -v`
+Expected: FAIL — `toronto_bids.export.document` not importable.
+
+- [ ] **Step 3: Implement the builder**
+
+`scrapers/toronto_bids/export/__init__.py`: empty file.
+
+`scrapers/toronto_bids/export/document.py`:
+
+```python
+import json
+from datetime import datetime, timezone
+
+from toronto_bids.store import db
+
+
+def _rows(conn, sql):
+    return [dict(r) for r in conn.execute(sql).fetchall()]
+
+
+def _drop(record: dict, *keys) -> dict:
+    return {k: v for k, v in record.items() if k not in keys}
+
+
+def _parse_categories(posting: dict) -> dict:
+    raw = posting.get("categories")
+    if raw:
+        try:
+            posting["categories"] = json.loads(raw)
+        except (TypeError, ValueError):
+            pass  # leave the raw string if it isn't valid JSON
+    return posting
+
+
+def build_export_document(conn, generated_at: str | None = None) -> dict:
+    """Assemble the solicitation-centric nested export document from the store.
+
+    Pure and deterministic: no file I/O, every query ordered. Awards and Ariba
+    postings are nested under their solicitation by document_number; postings
+    with a NULL document_number go to unlinked_ariba_postings (nothing dropped).
+    """
+    generated_at = generated_at or datetime.now(timezone.utc).isoformat()
+
+    awards_by_doc: dict[str, list] = {}
+    for award in _rows(conn, "SELECT * FROM award ORDER BY document_number, id"):
+        awards_by_doc.setdefault(award["document_number"], []).append(
+            _drop(award, "id", "supplier_id", "document_number")
+        )
+
+    postings_by_doc: dict[str, list] = {}
+    unlinked: list = []
+    for posting in _rows(conn, "SELECT * FROM ariba_posting ORDER BY rfx_id"):
+        posting = _parse_categories(_drop(posting, "raw_json"))
+        doc = posting.get("document_number")
+        if doc:
+            postings_by_doc.setdefault(doc, []).append(_drop(posting, "document_number"))
+        else:
+            unlinked.append(posting)
+
+    solicitations = []
+    for sol in _rows(conn, "SELECT * FROM solicitation ORDER BY document_number"):
+        sol = _drop(sol, "odata_id")
+        doc = sol["document_number"]
+        sol["awards"] = awards_by_doc.get(doc, [])
+        sol["ariba_postings"] = postings_by_doc.get(doc, [])
+        solicitations.append(sol)
+
+    noncompetitive = [
+        _drop(nc, "supplier_id", "odata_id")
+        for nc in _rows(conn, "SELECT * FROM noncompetitive ORDER BY workspace_number")
+    ]
+
+    sources = _rows(
+        conn,
+        "SELECT source, status, finished_at, rows_fetched, rows_upserted "
+        "FROM sync_run ORDER BY id",
+    )
+
+    return {
+        "meta": {
+            "generated_at": generated_at,
+            "counts": db.counts(conn),
+            "sources": sources,
+        },
+        "solicitations": solicitations,
+        "noncompetitive": noncompetitive,
+        "unlinked_ariba_postings": unlinked,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scrapers && uv run pytest tests/test_export_document.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/export/__init__.py scrapers/toronto_bids/export/document.py scrapers/tests/test_export_document.py
+git commit -m "feat(scraper): add solicitation-centric export document builder"
+```
+
+---
+
+### Task 2: `Exporter` protocol + `JsonExporter`
+
+The publish seam and its first implementation.
+
+**Files:**
+- Create: `scrapers/toronto_bids/export/base.py`
+- Create: `scrapers/toronto_bids/export/json_export.py`
+- Create: `scrapers/tests/test_json_export.py`
+
+**Interfaces:**
+- Consumes: `build_export_document(conn, generated_at=None)`.
+- Produces:
+  - `base.Exporter` (`runtime_checkable` Protocol): `name: str`; `export(self, conn, out_path, generated_at=None) -> Path`.
+  - `json_export.JsonExporter` with `name = "json"`; `export(conn, out_path, generated_at=None) -> Path` writes the document as indented UTF-8 JSON, creating parent dirs, and returns the resolved `Path`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`scrapers/tests/test_json_export.py`:
+
+```python
+import json
+
+from toronto_bids.export.base import Exporter
+from toronto_bids.export.json_export import JsonExporter
+from toronto_bids.models import Solicitation
+from toronto_bids.store import db
+
+
+def test_jsonexporter_satisfies_protocol():
+    assert isinstance(JsonExporter(), Exporter)
+    assert JsonExporter().name == "json"
+
+
+def test_export_writes_valid_json_file(conn, tmp_path):
+    db.upsert_row(conn, Solicitation(document_number="5672751291", title="RFT", source="odata"),
+                  overwrite=True)
+    conn.commit()
+    out = tmp_path / "nested" / "bids.json"
+    result = JsonExporter().export(conn, out, generated_at="2026-07-15T00:00:00Z")
+    assert result == out
+    assert out.exists()  # parent dir created
+    doc = json.loads(out.read_text())
+    assert doc["meta"]["generated_at"] == "2026-07-15T00:00:00Z"
+    assert doc["solicitations"][0]["document_number"] == "5672751291"
+
+
+def test_export_writes_utf8_content(conn, tmp_path):
+    db.upsert_row(conn, Solicitation(document_number="5672751291", title="Café Réno",
+                                     source="odata"), overwrite=True)
+    conn.commit()
+    out = tmp_path / "bids.json"
+    JsonExporter().export(conn, out, generated_at="t")
+    # ensure_ascii=False keeps accented characters literal, not \u-escaped
+    assert "Café Réno" in out.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_json_export.py -v`
+Expected: FAIL — `toronto_bids.export.base` / `json_export` not importable.
+
+- [ ] **Step 3: Implement the protocol and exporter**
+
+`scrapers/toronto_bids/export/base.py`:
+
+```python
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Exporter(Protocol):
+    """The publish seam: turn the store into a published artifact at out_path.
+
+    Implementations differ by destination/format, not by document shape — they
+    all serialize build_export_document(conn). Future: Parquet, static site, API.
+    """
+
+    name: str
+
+    def export(self, conn, out_path, generated_at: str | None = None) -> Path:
+        ...
+```
+
+`scrapers/toronto_bids/export/json_export.py`:
+
+```python
+import json
+from pathlib import Path
+
+from toronto_bids.export.document import build_export_document
+
+
+class JsonExporter:
+    name = "json"
+
+    def export(self, conn, out_path, generated_at: str | None = None) -> Path:
+        document = build_export_document(conn, generated_at)
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(document, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        return out_path
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scrapers && uv run pytest tests/test_json_export.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/export/base.py scrapers/toronto_bids/export/json_export.py scrapers/tests/test_json_export.py
+git commit -m "feat(scraper): add Exporter seam and JsonExporter"
+```
+
+---
+
+### Task 3: `tb export` CLI + live export + docs
+
+Wire the exporter to the CLI, verify against the real store, and document it.
+
+**Files:**
+- Modify: `scrapers/toronto_bids/cli.py`
+- Modify: `scrapers/tests/test_smoke.py`
+- Modify: `scrapers/README.md`
+
+**Interfaces:**
+- Consumes: `JsonExporter`, `_open_db`, `config.DATA_DIR`.
+- Produces: `tb export [--out PATH]`; default output `config.DATA_DIR / "export" / "bids.json"`. `cli.main` returns 0.
+
+- [ ] **Step 1: Write the failing CLI test**
+
+Add to `scrapers/tests/test_smoke.py`:
+
+```python
+def test_export_writes_default_path(tmp_path, monkeypatch, capsys):
+    from toronto_bids.models import Solicitation
+    monkeypatch.setattr("toronto_bids.config.DB_PATH", tmp_path / "bids.sqlite")
+    monkeypatch.setattr("toronto_bids.config.DATA_DIR", tmp_path)
+    # Seed one row via a sync-less direct write path: open the db the CLI will use.
+    from toronto_bids.store import db
+    conn = db.connect(tmp_path / "bids.sqlite")
+    db.init_db(conn)
+    db.upsert_row(conn, Solicitation(document_number="5672751291", source="odata"), overwrite=True)
+    conn.commit()
+    conn.close()
+
+    assert main(["export"]) == 0
+    import json
+    out = tmp_path / "export" / "bids.json"
+    assert out.exists()
+    doc = json.loads(out.read_text())
+    assert doc["solicitations"][0]["document_number"] == "5672751291"
+    assert "Exported" in capsys.readouterr().out
+```
+
+(`main` is already imported at the top of `test_smoke.py`.)
+
+- [ ] **Step 2: Run the CLI test to verify it fails**
+
+Run: `cd scrapers && uv run pytest tests/test_smoke.py -k export -v`
+Expected: FAIL — argparse rejects the `export` subcommand / `main` falls through to help.
+
+- [ ] **Step 3: Implement the `export` command**
+
+In `scrapers/toronto_bids/cli.py`:
+
+Add the import near the top:
+```python
+from toronto_bids.export.json_export import JsonExporter
+```
+
+Register the subcommand in `build_parser` (after the `status` parser):
+```python
+    p_export = sub.add_parser("export", help="Write the store to a nested JSON artifact")
+    p_export.add_argument("--out", help="Output path (default: <DATA_DIR>/export/bids.json)")
+```
+
+Add the command handler (after `_cmd_status`):
+```python
+def _cmd_export(args) -> int:
+    from pathlib import Path
+
+    conn = _open_db()
+    try:
+        out_path = Path(args.out) if args.out else config.DATA_DIR / "export" / "bids.json"
+        written = JsonExporter().export(conn, out_path)
+        counts = db.counts(conn)
+        print(f"Exported {counts['solicitation']} solicitations to {written}")
+    finally:
+        conn.close()
+    return 0
+```
+
+Add the dispatch in `main` (before the `parser.print_help()` fallthrough):
+```python
+    if args.command == "export":
+        return _cmd_export(args)
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cd scrapers && uv run pytest -v`
+Expected: every test PASSES, output pristine.
+
+- [ ] **Step 5: Live export smoke check (reads a real synced DB — manual, not a test)**
+
+Run (populates a real DB, then exports it):
+```bash
+cd scrapers && TB_DATA_DIR=/tmp/tb-p3 uv run tb sync && TB_DATA_DIR=/tmp/tb-p3 uv run tb export
+```
+Expected: `tb sync` completes (all sources); `tb export` prints `Exported <N> solicitations to /tmp/tb-p3/export/bids.json`. Then sanity-check the artifact:
+```bash
+python3 - <<'PY'
+import json
+d = json.load(open("/tmp/tb-p3/export/bids.json"))
+print("solicitations:", len(d["solicitations"]))
+print("noncompetitive:", len(d["noncompetitive"]))
+print("unlinked_ariba_postings:", len(d["unlinked_ariba_postings"]))
+s = next(x for x in d["solicitations"] if x["ariba_postings"])
+print("example nested posting rfx_id:", s["ariba_postings"][0]["rfx_id"],
+      "| categories is list:", isinstance(s["ariba_postings"][0]["categories"], list))
+PY
+```
+(If `python3` is unavailable, use `uv run python - <<'PY' ... PY` instead.) Expected: solicitations in the thousands; some solicitations carry nested `ariba_postings`; `unlinked_ariba_postings` holds the un-bridged ones; `categories` is a list. Record the numbers in the report. Do not block the commit on exact counts.
+
+- [ ] **Step 6: Update the README**
+
+In `scrapers/README.md`, under the Usage section (near `tb sync` / `tb status`), add:
+
+```markdown
+- `uv run tb export [--out PATH]` — write the whole store to a single
+  solicitation-centric nested JSON artifact (default `<DATA_DIR>/export/bids.json`):
+  each solicitation with its `awards` and `ariba_postings` nested by `document_number`,
+  plus top-level `noncompetitive` and `unlinked_ariba_postings` (Ariba postings that
+  never bridged to a document number). This is the publish seam — the `Exporter`
+  interface lets other destinations/formats be added without changing the document shape.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scrapers/toronto_bids/cli.py scrapers/tests/test_smoke.py scrapers/README.md
+git commit -m "feat(scraper): add tb export command and document the publish seam"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (design §5, §10 P3):**
+- Solicitation-centric nested shape with awards + ariba_postings nested by `document_number` → Task 1. ✓
+- Un-bridged postings preserved in `unlinked_ariba_postings` (archive-always through export) → Task 1 + `test_unbridged_posting_goes_to_unlinked_not_dropped`. ✓
+- Non-competitive as a separate top-level array (separate keyspace) → Task 1 + `test_noncompetitive_is_separate_top_level`. ✓
+- Column hygiene (drop `award.id`/`supplier_id`/`odata_id`/`raw_json`, redundant nested `document_number`; parse `categories`) → Task 1. ✓
+- `meta` with `generated_at`/`counts`/`sources` → Task 1. ✓
+- Destination-agnostic `Exporter` seam + JSON first implementation → Task 2. ✓
+- `tb export` CLI → Task 3. ✓
+- Deterministic tests via `generated_at` → Tasks 1–3. ✓
+- Out of scope by design (P4 attachments, P5 TMMIS/PDF, and non-JSON exporters like Parquet/Azure/static-site — the seam exists for them but they are not built here) → not in this plan. ✓
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N". Every code step shows complete code; every command shows expected output. No `NotImplementedError` stubs in this plan. ✓
+
+**3. Type consistency:** `build_export_document(conn, generated_at=None) -> dict` signature identical across Tasks 1, 2, 3. `JsonExporter.export(conn, out_path, generated_at=None) -> Path` matches the `Exporter` protocol (Task 2) and the CLI caller (Task 3). Top-level document keys (`meta`, `solicitations`, `noncompetitive`, `unlinked_ariba_postings`) and nested keys (`awards`, `ariba_postings`) are used identically in the builder (Task 1), the exporter tests (Task 2), and the CLI/live checks (Task 3). `db.counts` returns a dict keyed by table name (`counts["solicitation"]`), consistent across Tasks 1 and 3. ✓

--- a/scrapers/README.md
+++ b/scrapers/README.md
@@ -28,8 +28,16 @@ uv sync
 uv run tb sync            # fetch all sources into files/bids.sqlite
 uv run tb sync --only odata_solicitations,ckan_awarded
 uv run tb status          # row counts
+uv run tb export [--out PATH]  # write the whole store to a single JSON artifact
 uv run pytest             # tests (offline; uses fixtures)
 ```
+
+- `uv run tb export [--out PATH]` — write the whole store to a single
+  solicitation-centric nested JSON artifact (default `<DATA_DIR>/export/bids.json`):
+  each solicitation with its `awards` and `ariba_postings` nested by `document_number`,
+  plus top-level `noncompetitive` and `unlinked_ariba_postings` (Ariba postings that
+  never bridged to a document number). This is the publish seam — the `Exporter`
+  interface lets other destinations/formats be added without changing the document shape.
 
 Set `TB_DATA_DIR` to change where `bids.sqlite` and downloads live (default `scrapers/files/`).
 

--- a/scrapers/README.md
+++ b/scrapers/README.md
@@ -35,9 +35,11 @@ uv run pytest             # tests (offline; uses fixtures)
 - `uv run tb export [--out PATH]` — write the whole store to a single
   solicitation-centric nested JSON artifact (default `<DATA_DIR>/export/bids.json`):
   each solicitation with its `awards` and `ariba_postings` nested by `document_number`,
-  plus top-level `noncompetitive` and `unlinked_ariba_postings` (Ariba postings that
-  never bridged to a document number). This is the publish seam — the `Exporter`
-  interface lets other destinations/formats be added without changing the document shape.
+  plus top-level `noncompetitive`, `unlinked_ariba_postings` (Ariba postings whose
+  document_number never bridged to a solicitation), and `unlinked_awards` (awards
+  whose document_number matches no solicitation). This is the publish seam — the
+  `Exporter` interface lets other destinations/formats be added without changing the
+  document shape.
 
 Set `TB_DATA_DIR` to change where `bids.sqlite` and downloads live (default `scrapers/files/`).
 

--- a/scrapers/README.md
+++ b/scrapers/README.md
@@ -10,6 +10,12 @@ local SQLite store. No browser, no login, no cloud.
 - **OData `feis_non_competitive_published`** — non-competitive (sole-source) awards.
 - **CKAN `tobids-awarded-contracts` / `tobids-all-open-solicitations` /
   `tobids-non-competitive-contracts`** — backfill for the spine.
+- **SAP Ariba Discovery** (`ariba_discovery`) — archives currently-open City-of-Toronto
+  Ariba postings (`ariba_posting` table) before they close, via public JSON APIs (no auth).
+  Each posting is bridged to its `document_number` where the detail endpoint resolves
+  (~40% return HTTP 500 on a given run and are archived un-bridged; idempotent re-runs fill
+  the gap). The `sourcing_url` column is the authenticated event link for a future
+  attachments phase.
 
 Everything competitive is keyed on the normalized 10-digit `document_number`.
 Non-competitive awards are a separate keyspace (`workspace_number`).

--- a/scrapers/tests/fixtures/ariba_detail.json
+++ b/scrapers/tests/fixtures/ariba_detail.json
@@ -1,0 +1,17 @@
+{
+  "id": "1110015885",
+  "type": "RFI",
+  "title": "Request for Tenders for Watermain and Sewer Replacement on various roads",
+  "status": "PUBLISHED",
+  "startDate": "2026-06-16T12:16:17",
+  "endDate": "2026-07-17T09:00:00",
+  "externalRfxId": "Doc5672751291",
+  "publicPostingUrl": "https://discovery.ariba.com/rfx/1110015885",
+  "sourcingUrl": "https://s1.ariba.com/Sourcing/Main/ad/gotoEvent/NetworkRFQDirectAction?rfxId=Doc5672751291&realm=toronto",
+  "companyInfo": {"companyName": "City of Toronto"},
+  "categories": [
+    {"categoryCode": 72141105, "categoryName": "Sidewalk construction and repair service"},
+    {"categoryCode": 72141121, "categoryName": "Water main construction service"}
+  ],
+  "opportunityAmount": {"maxAmount": 99000000, "minAmount": 1000, "currency": "CAD"}
+}

--- a/scrapers/tests/fixtures/ariba_search_record.json
+++ b/scrapers/tests/fixtures/ariba_search_record.json
@@ -1,0 +1,15 @@
+{
+  "productsAndServicesCategories": [
+    "Sidewalk construction and repair service",
+    "Sewer line construction service"
+  ],
+  "shipToOrServiceLocations": ["Toronto (Mississauga) - Ontario"],
+  "title": "Request for Tenders for Watermain and Sewer Replacement on various roads",
+  "rfxID": "1110015885",
+  "minAmount": "712.5552230298",
+  "maxAmount": "70542967.0799487",
+  "customerName": "City of Toronto",
+  "rfxType": "RFI",
+  "datePosted": "2026-06-16T12:16:17-07:00",
+  "endDate": "2026-07-17T09:00:00-07:00"
+}

--- a/scrapers/tests/test_ariba.py
+++ b/scrapers/tests/test_ariba.py
@@ -1,7 +1,18 @@
+import json
+from pathlib import Path
+
 import httpx
 
 from toronto_bids.http import HttpClient
+from toronto_bids.models import AribaPosting
+from toronto_bids.sources import ariba
 from toronto_bids.sources.ariba import AribaDiscoverySource
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fixture(name):
+    return json.loads((FIXTURES / name).read_text())
 
 
 def _http(handler):
@@ -49,3 +60,47 @@ def test_source_attributes():
     src = AribaDiscoverySource()
     assert src.name == "ariba_discovery"
     assert src.overwrite is True
+
+
+def test_normalize_with_detail_bridges_and_snapshots():
+    raw = {"search": _fixture("ariba_search_record.json"), "detail": _fixture("ariba_detail.json")}
+    posts = list(ariba.normalize_posting(raw))
+    assert len(posts) == 1
+    p = posts[0]
+    assert isinstance(p, AribaPosting)
+    assert p.rfx_id == "1110015885"
+    assert p.document_number == "5672751291"          # bridged from externalRfxId
+    assert p.external_rfx_id == "Doc5672751291"
+    assert p.status == "PUBLISHED"
+    assert p.customer_name == "City of Toronto"
+    assert p.close_date == "2026-07-17T09:00:00-07:00"  # search endDate preferred
+    assert p.currency == "CAD"
+    assert p.amount_max == "99000000"                 # from detail opportunityAmount
+    assert p.public_posting_url == "https://discovery.ariba.com/rfx/1110015885"
+    assert "s1.ariba.com" in p.sourcing_url
+    assert json.loads(p.categories) == ["Sidewalk construction and repair service",
+                                        "Water main construction service"]
+    assert json.loads(p.raw_json)["externalRfxId"] == "Doc5672751291"  # snapshot present
+    assert p.source == "ariba_discovery"
+
+
+def test_normalize_without_detail_archives_search_only():
+    raw = {"search": _fixture("ariba_search_record.json"), "detail": None}
+    p = list(ariba.normalize_posting(raw))[0]
+    assert p.rfx_id == "1110015885"
+    assert p.document_number is None          # no externalRfxId, no Doc in this title
+    assert p.raw_json is None                 # nothing to snapshot
+    assert p.external_rfx_id is None
+    assert p.title == "Request for Tenders for Watermain and Sewer Replacement on various roads"
+    assert p.customer_name == "City of Toronto"
+    assert p.amount_max == "70542967.0799487"  # falls back to search maxAmount
+    assert p.currency is None
+    assert json.loads(p.categories) == ["Sidewalk construction and repair service",
+                                        "Sewer line construction service"]
+
+
+def test_normalize_without_detail_bridges_title_embedded_doc():
+    search = dict(_fixture("ariba_search_record.json"))
+    search["title"] = "Doc5581608073 - Request for Quotations for supplies"
+    p = list(ariba.normalize_posting({"search": search, "detail": None}))[0]
+    assert p.document_number == "5581608073"   # bridged from the title

--- a/scrapers/tests/test_ariba.py
+++ b/scrapers/tests/test_ariba.py
@@ -1,0 +1,51 @@
+import httpx
+
+from toronto_bids.http import HttpClient
+from toronto_bids.sources.ariba import AribaDiscoverySource
+
+
+def _http(handler):
+    return HttpClient(client=httpx.Client(transport=httpx.MockTransport(handler)), backoff=0.0)
+
+
+SEARCH_BODY = {
+    "totalNumberOfRecords": 3,
+    "solarRecords": [
+        {"rfxID": "1110015885", "customerName": "City of Toronto", "title": "RFT Watermain"},
+        {"rfxID": "1110099999", "customerName": "City of Toronto", "title": "RFQ Widgets"},
+        {"rfxID": "1110000001", "customerName": "TransLink", "title": "Other buyer"},
+    ],
+}
+
+
+def test_fetch_keeps_only_toronto_and_pairs_detail():
+    def handler(request):
+        if "doIndexedSearch" in str(request.url):
+            return httpx.Response(200, json=SEARCH_BODY)
+        # detail: 1110015885 succeeds, 1110099999 500s persistently
+        if request.url.path.endswith("1110015885"):
+            return httpx.Response(200, json={"id": "1110015885", "externalRfxId": "Doc5672751291"})
+        return httpx.Response(500, text="boom")
+    raws = list(AribaDiscoverySource().fetch(_http(handler)))
+    # TransLink record dropped; two Toronto records kept.
+    assert len(raws) == 2
+    by_id = {r["search"]["rfxID"]: r for r in raws}
+    assert by_id["1110015885"]["detail"]["externalRfxId"] == "Doc5672751291"
+    # The 500'd posting is still yielded, with detail=None (per-posting isolation).
+    assert by_id["1110099999"]["detail"] is None
+
+
+def test_fetch_does_not_raise_when_all_details_fail():
+    def handler(request):
+        if "doIndexedSearch" in str(request.url):
+            return httpx.Response(200, json=SEARCH_BODY)
+        return httpx.Response(500, text="boom")
+    raws = list(AribaDiscoverySource().fetch(_http(handler)))
+    assert len(raws) == 2
+    assert all(r["detail"] is None for r in raws)
+
+
+def test_source_attributes():
+    src = AribaDiscoverySource()
+    assert src.name == "ariba_discovery"
+    assert src.overwrite is True

--- a/scrapers/tests/test_db.py
+++ b/scrapers/tests/test_db.py
@@ -6,7 +6,7 @@ def test_init_creates_tables(conn):
     names = {r[0] for r in conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table'"
     )}
-    assert {"solicitation", "award", "noncompetitive", "sync_run"} <= names
+    assert {"solicitation", "award", "noncompetitive", "ariba_posting", "sync_run"} <= names
 
 
 def test_upsert_solicitation_is_idempotent(conn):

--- a/scrapers/tests/test_db.py
+++ b/scrapers/tests/test_db.py
@@ -1,4 +1,4 @@
-from toronto_bids.models import Award, NonCompetitive, Solicitation
+from toronto_bids.models import Award, NonCompetitive, Solicitation, AribaPosting
 from toronto_bids.store import db
 
 
@@ -56,3 +56,29 @@ def test_sync_run_lifecycle(conn):
     db.finish_sync_run(conn, run_id, status="ok", rows_fetched=10, rows_upserted=10)
     row = conn.execute("SELECT status, rows_fetched FROM sync_run WHERE id=?", (run_id,)).fetchone()
     assert row["status"] == "ok" and row["rows_fetched"] == 10
+
+
+def test_upsert_ariba_posting_is_idempotent(conn):
+    p = AribaPosting(rfx_id="1110015885", document_number="5672751291",
+                     title="RFT Watermain", raw_json="{}", source="ariba_discovery")
+    db.upsert_row(conn, p, overwrite=True)
+    db.upsert_row(conn, p, overwrite=True)
+    assert db.counts(conn)["ariba_posting"] == 1
+
+
+def test_ariba_posting_later_500_does_not_wipe_snapshot(conn):
+    # Run 1: detail succeeded -> raw_json + document_number captured.
+    db.upsert_row(conn, AribaPosting(rfx_id="1110015885", document_number="5672751291",
+                                     raw_json="{\"x\":1}", source="ariba_discovery"), overwrite=True)
+    # Run 2: detail 500'd -> those fields arrive as None. overwrite=True must NOT clobber them.
+    db.upsert_row(conn, AribaPosting(rfx_id="1110015885", document_number=None,
+                                     raw_json=None, source="ariba_discovery"), overwrite=True)
+    row = conn.execute(
+        "SELECT document_number, raw_json FROM ariba_posting WHERE rfx_id='1110015885'"
+    ).fetchone()
+    assert row["document_number"] == "5672751291"
+    assert row["raw_json"] == "{\"x\":1}"
+
+
+def test_counts_includes_ariba_posting(conn):
+    assert "ariba_posting" in db.counts(conn)

--- a/scrapers/tests/test_document_number.py
+++ b/scrapers/tests/test_document_number.py
@@ -1,6 +1,6 @@
 import pytest
 
-from toronto_bids.linking.document_number import normalize_document_number
+from toronto_bids.linking.document_number import normalize_document_number, bridge_document_number
 
 
 @pytest.mark.parametrize(
@@ -42,3 +42,23 @@ def test_valid_document_numbers_normalize_to_ten_digits(raw, expected):
 )
 def test_invalid_document_numbers_return_none(raw):
     assert normalize_document_number(raw) is None
+
+
+def test_bridge_uses_external_rfx_id():
+    # "Doc5672751291" -> strip -> "5672751291"
+    assert bridge_document_number("Doc5672751291", "some title") == "5672751291"
+
+
+def test_bridge_falls_back_to_title_embedded_doc():
+    title = "Doc5581608073 - Request for Quotations for the non-exclusive supply"
+    assert bridge_document_number(None, title) == "5581608073"
+
+
+def test_bridge_prefers_external_rfx_id_over_title():
+    assert bridge_document_number("Doc5672751291", "Doc9999999999 - other") == "5672751291"
+
+
+def test_bridge_returns_none_when_neither_resolves():
+    assert bridge_document_number(None, "Request for Tenders for Road Resurfacing") is None
+    assert bridge_document_number("", "") is None
+    assert bridge_document_number(None, None) is None

--- a/scrapers/tests/test_document_number.py
+++ b/scrapers/tests/test_document_number.py
@@ -62,3 +62,8 @@ def test_bridge_returns_none_when_neither_resolves():
     assert bridge_document_number(None, "Request for Tenders for Road Resurfacing") is None
     assert bridge_document_number("", "") is None
     assert bridge_document_number(None, None) is None
+
+
+def test_bridge_rejects_title_doc_with_more_than_ten_digits():
+    # An 11-digit run is ambiguous -> must NOT fabricate a truncated document number.
+    assert bridge_document_number(None, "Doc56727512911 - eleven digit run") is None

--- a/scrapers/tests/test_export_document.py
+++ b/scrapers/tests/test_export_document.py
@@ -87,4 +87,44 @@ def test_empty_store_produces_empty_collections(conn):
     assert doc["solicitations"] == []
     assert doc["noncompetitive"] == []
     assert doc["unlinked_ariba_postings"] == []
+    assert doc["unlinked_awards"] == []
     assert doc["meta"]["counts"]["solicitation"] == 0
+
+
+def test_orphan_posting_docnum_not_in_solicitation_goes_to_unlinked(seeded):
+    # A posting bridged to a doc number that matches NO solicitation must NOT vanish.
+    db.upsert_row(seeded, AribaPosting(rfx_id="1110088888", document_number="4044346425",
+                                       title="Mock RFT", source="ariba_discovery"), overwrite=True)
+    seeded.commit()
+    doc = build_export_document(seeded, generated_at="t")
+    orphan = [p for p in doc["unlinked_ariba_postings"] if p["rfx_id"] == "1110088888"]
+    assert len(orphan) == 1
+    assert orphan[0]["document_number"] == "4044346425"   # kept for diagnostics
+    # and it must NOT be nested under any solicitation
+    assert all(p["rfx_id"] != "1110088888"
+               for s in doc["solicitations"] for p in s["ariba_postings"])
+
+
+def test_orphan_award_docnum_not_in_solicitation_goes_to_unlinked_awards(seeded):
+    db.upsert_row(seeded, Award(document_number="4044346425", supplier_name_raw="Orphan Co",
+                                source="ckan_awarded"), overwrite=True)
+    seeded.commit()
+    doc = build_export_document(seeded, generated_at="t")
+    orphan = [a for a in doc["unlinked_awards"] if a["supplier_name_raw"] == "Orphan Co"]
+    assert len(orphan) == 1
+    assert orphan[0]["document_number"] == "4044346425"
+
+
+def test_no_record_is_dropped_counts_reconcile(seeded):
+    # Every posting/award is either nested or unlinked — nested + unlinked == db count.
+    db.upsert_row(seeded, AribaPosting(rfx_id="1110088888", document_number="4044346425",
+                                       source="ariba_discovery"), overwrite=True)
+    db.upsert_row(seeded, Award(document_number="4044346425", supplier_name_raw="Orphan Co",
+                                source="ckan_awarded"), overwrite=True)
+    seeded.commit()
+    doc = build_export_document(seeded, generated_at="t")
+    counts = doc["meta"]["counts"]
+    nested_postings = sum(len(s["ariba_postings"]) for s in doc["solicitations"])
+    assert nested_postings + len(doc["unlinked_ariba_postings"]) == counts["ariba_posting"]
+    nested_awards = sum(len(s["awards"]) for s in doc["solicitations"])
+    assert nested_awards + len(doc["unlinked_awards"]) == counts["award"]

--- a/scrapers/tests/test_export_document.py
+++ b/scrapers/tests/test_export_document.py
@@ -1,0 +1,90 @@
+import json
+
+import pytest
+
+from toronto_bids.export.document import build_export_document
+from toronto_bids.models import AribaPosting, Award, NonCompetitive, Solicitation
+from toronto_bids.store import db
+
+
+@pytest.fixture
+def seeded(conn):
+    # One solicitation with an award and a bridged Ariba posting.
+    db.upsert_row(conn, Solicitation(document_number="5672751291", status="Open",
+                                     title="RFT Watermain", source="odata"), overwrite=True)
+    db.upsert_row(conn, Award(document_number="5672751291", supplier_name_raw="Acme Co",
+                              award_amount="1000", source="odata"), overwrite=True)
+    db.upsert_row(conn, AribaPosting(rfx_id="1110015885", document_number="5672751291",
+                                     title="RFT Watermain", categories='["Sidewalk"]',
+                                     raw_json='{"big":"blob"}', source="ariba_discovery"), overwrite=True)
+    # An Ariba posting that never bridged (document_number is NULL).
+    db.upsert_row(conn, AribaPosting(rfx_id="1110099999", document_number=None,
+                                     title="Unbridged posting", categories='["Water"]',
+                                     source="ariba_discovery"), overwrite=True)
+    # A non-competitive contract (separate keyspace).
+    db.upsert_row(conn, NonCompetitive(workspace_number="8614", supplier_name_raw="Sole Source Inc",
+                                       reason="Emergency", source="odata"), overwrite=True)
+    conn.commit()
+    return conn
+
+
+def test_meta_has_generated_at_counts_and_sources(seeded):
+    db.finish_sync_run(seeded, db.start_sync_run(seeded, "odata_solicitations"),
+                       status="ok", rows_fetched=5, rows_upserted=5)
+    doc = build_export_document(seeded, generated_at="2026-07-15T00:00:00Z")
+    assert doc["meta"]["generated_at"] == "2026-07-15T00:00:00Z"
+    assert doc["meta"]["counts"]["solicitation"] == 1
+    assert doc["meta"]["sources"][-1]["source"] == "odata_solicitations"
+    assert doc["meta"]["sources"][-1]["status"] == "ok"
+
+
+def test_award_and_posting_nested_under_solicitation(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    sols = doc["solicitations"]
+    assert len(sols) == 1
+    sol = sols[0]
+    assert sol["document_number"] == "5672751291"
+    assert "odata_id" not in sol
+    # award nested, internal cols dropped, redundant document_number dropped
+    assert len(sol["awards"]) == 1
+    assert sol["awards"][0]["supplier_name_raw"] == "Acme Co"
+    assert "id" not in sol["awards"][0]
+    assert "document_number" not in sol["awards"][0]
+    # ariba posting nested, raw_json dropped, categories parsed to a list
+    assert len(sol["ariba_postings"]) == 1
+    assert sol["ariba_postings"][0]["rfx_id"] == "1110015885"
+    assert "raw_json" not in sol["ariba_postings"][0]
+    assert sol["ariba_postings"][0]["categories"] == ["Sidewalk"]
+    assert "document_number" not in sol["ariba_postings"][0]
+
+
+def test_unbridged_posting_goes_to_unlinked_not_dropped(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    unlinked = doc["unlinked_ariba_postings"]
+    assert len(unlinked) == 1
+    assert unlinked[0]["rfx_id"] == "1110099999"
+    assert unlinked[0]["categories"] == ["Water"]
+    assert "raw_json" not in unlinked[0]
+    # It must NOT appear under any solicitation.
+    assert all(p["rfx_id"] != "1110099999"
+               for s in doc["solicitations"] for p in s["ariba_postings"])
+
+
+def test_noncompetitive_is_separate_top_level(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    assert len(doc["noncompetitive"]) == 1
+    assert doc["noncompetitive"][0]["workspace_number"] == "8614"
+    assert "supplier_id" not in doc["noncompetitive"][0]
+
+
+def test_document_is_json_serializable(seeded):
+    doc = build_export_document(seeded, generated_at="t")
+    json.dumps(doc)  # must not raise
+
+
+def test_empty_store_produces_empty_collections(conn):
+    doc = build_export_document(conn, generated_at="t")
+    assert doc["solicitations"] == []
+    assert doc["noncompetitive"] == []
+    assert doc["unlinked_ariba_postings"] == []
+    assert doc["meta"]["counts"]["solicitation"] == 0

--- a/scrapers/tests/test_http.py
+++ b/scrapers/tests/test_http.py
@@ -57,6 +57,16 @@ def test_post_json_sends_body():
     assert client.post_json("https://example.test/x", json={"a": 1}) == {"echo": True}
 
 
+def test_get_json_sends_custom_headers():
+    seen = {}
+    def handler(request):
+        seen["accept"] = request.headers.get("Accept")
+        return httpx.Response(200, json={"ok": True})
+    client = _client(handler)
+    client.get_json("https://example.test/x", headers={"Accept": "application/json"})
+    assert seen["accept"] == "application/json"
+
+
 def test_default_client_uses_config_user_agent():
     from toronto_bids import config
     client = HttpClient()

--- a/scrapers/tests/test_json_export.py
+++ b/scrapers/tests/test_json_export.py
@@ -1,0 +1,34 @@
+import json
+
+from toronto_bids.export.base import Exporter
+from toronto_bids.export.json_export import JsonExporter
+from toronto_bids.models import Solicitation
+from toronto_bids.store import db
+
+
+def test_jsonexporter_satisfies_protocol():
+    assert isinstance(JsonExporter(), Exporter)
+    assert JsonExporter().name == "json"
+
+
+def test_export_writes_valid_json_file(conn, tmp_path):
+    db.upsert_row(conn, Solicitation(document_number="5672751291", title="RFT", source="odata"),
+                  overwrite=True)
+    conn.commit()
+    out = tmp_path / "nested" / "bids.json"
+    result = JsonExporter().export(conn, out, generated_at="2026-07-15T00:00:00Z")
+    assert result == out
+    assert out.exists()  # parent dir created
+    doc = json.loads(out.read_text())
+    assert doc["meta"]["generated_at"] == "2026-07-15T00:00:00Z"
+    assert doc["solicitations"][0]["document_number"] == "5672751291"
+
+
+def test_export_writes_utf8_content(conn, tmp_path):
+    db.upsert_row(conn, Solicitation(document_number="5672751291", title="Café Réno",
+                                     source="odata"), overwrite=True)
+    conn.commit()
+    out = tmp_path / "bids.json"
+    JsonExporter().export(conn, out, generated_at="t")
+    # ensure_ascii=False keeps accented characters literal, not \u-escaped
+    assert "Café Réno" in out.read_text(encoding="utf-8")

--- a/scrapers/tests/test_pipeline_integration.py
+++ b/scrapers/tests/test_pipeline_integration.py
@@ -39,3 +39,32 @@ def test_odata_spine_wins_and_ckan_links_on_document_number(conn):
     )}
     assert "odata" in sources
     assert "ckan_awarded" in sources
+
+
+def test_ariba_fetch_normalize_upsert_bridges_and_archives(conn):
+    from toronto_bids.sources.ariba import normalize_posting
+    from toronto_bids.store import db
+
+    search = _load("ariba_search_record.json")
+    detail = _load("ariba_detail.json")
+    # Simulate the fetch output: one detail-200 posting, one detail-500 posting.
+    raws = [
+        {"search": search, "detail": detail},
+        {"search": {**search, "rfxID": "1110099999", "title": "no doc here"}, "detail": None},
+    ]
+    for raw in raws:
+        for row in normalize_posting(raw):
+            db.upsert_row(conn, row, overwrite=True)
+    conn.commit()
+
+    assert db.counts(conn)["ariba_posting"] == 2
+    bridged = conn.execute(
+        "SELECT document_number, raw_json FROM ariba_posting WHERE rfx_id='1110015885'"
+    ).fetchone()
+    assert bridged["document_number"] == "5672751291"   # linked to the OData/CKAN spine
+    assert bridged["raw_json"] is not None               # snapshot archived
+    unbridged = conn.execute(
+        "SELECT document_number, raw_json FROM ariba_posting WHERE rfx_id='1110099999'"
+    ).fetchone()
+    assert unbridged["document_number"] is None          # archived even though un-bridged
+    assert unbridged["raw_json"] is None

--- a/scrapers/tests/test_smoke.py
+++ b/scrapers/tests/test_smoke.py
@@ -35,3 +35,24 @@ def test_sync_uses_pipeline_and_persists(tmp_path, monkeypatch):
     conn = db.connect(db_path)
     assert db.counts(conn)["solicitation"] == 1
     conn.close()
+
+
+def test_export_writes_default_path(tmp_path, monkeypatch, capsys):
+    from toronto_bids.models import Solicitation
+    monkeypatch.setattr("toronto_bids.config.DB_PATH", tmp_path / "bids.sqlite")
+    monkeypatch.setattr("toronto_bids.config.DATA_DIR", tmp_path)
+    # Seed one row via a sync-less direct write path: open the db the CLI will use.
+    from toronto_bids.store import db
+    conn = db.connect(tmp_path / "bids.sqlite")
+    db.init_db(conn)
+    db.upsert_row(conn, Solicitation(document_number="5672751291", source="odata"), overwrite=True)
+    conn.commit()
+    conn.close()
+
+    assert main(["export"]) == 0
+    import json
+    out = tmp_path / "export" / "bids.json"
+    assert out.exists()
+    doc = json.loads(out.read_text())
+    assert doc["solicitations"][0]["document_number"] == "5672751291"
+    assert "Exported" in capsys.readouterr().out

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -1,6 +1,7 @@
 import argparse
 
 from toronto_bids import __version__, config, pipeline
+from toronto_bids.export.json_export import JsonExporter
 from toronto_bids.http import HttpClient
 from toronto_bids.store import db
 
@@ -14,6 +15,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_sync.add_argument("--only", help="Comma-separated source names to run")
 
     sub.add_parser("status", help="Show row counts in the local store")
+
+    p_export = sub.add_parser("export", help="Write the store to a nested JSON artifact")
+    p_export.add_argument("--out", help="Output path (default: <DATA_DIR>/export/bids.json)")
     return parser
 
 
@@ -51,6 +55,20 @@ def _cmd_status(args) -> int:
     return 0
 
 
+def _cmd_export(args) -> int:
+    from pathlib import Path
+
+    conn = _open_db()
+    try:
+        out_path = Path(args.out) if args.out else config.DATA_DIR / "export" / "bids.json"
+        written = JsonExporter().export(conn, out_path)
+        counts = db.counts(conn)
+        print(f"Exported {counts['solicitation']} solicitations to {written}")
+    finally:
+        conn.close()
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -58,6 +76,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_sync(args)
     if args.command == "status":
         return _cmd_status(args)
+    if args.command == "export":
+        return _cmd_export(args)
     parser.print_help()
     return 0
 

--- a/scrapers/toronto_bids/config.py
+++ b/scrapers/toronto_bids/config.py
@@ -23,3 +23,16 @@ USER_AGENT = (
 )
 HTTP_TIMEOUT = 60.0
 HTTP_RETRIES = 4
+
+# SAP Ariba Discovery public JSON APIs (no auth).
+ARIBA_SEARCH_URL = "https://service.ariba.com/Network/discoveryweb/search/public/v1/doIndexedSearch"
+ARIBA_DETAIL_URL = "https://service.ariba.com/Network/discoveryweb/api/public/v1/rfx/{rfx_id}"
+ARIBA_SEARCH_PARAMS = {"siteName": "Quote"}
+ARIBA_SEARCH_BODY = {
+    "pageSize": 1000,
+    "pageNum": 0,
+    "searchType": "Quote",
+    "sortBy": "RESPONSE_DEAD_LINE",
+    "filters": [],
+}
+ARIBA_CUSTOMER_NAME = "City of Toronto"

--- a/scrapers/toronto_bids/export/base.py
+++ b/scrapers/toronto_bids/export/base.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Exporter(Protocol):
+    """The publish seam: turn the store into a published artifact at out_path.
+
+    Implementations differ by destination/format, not by document shape — they
+    all serialize build_export_document(conn). Future: Parquet, static site, API.
+    """
+
+    name: str
+
+    def export(self, conn, out_path, generated_at: str | None = None) -> Path:
+        ...

--- a/scrapers/toronto_bids/export/document.py
+++ b/scrapers/toronto_bids/export/document.py
@@ -26,23 +26,32 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
     """Assemble the solicitation-centric nested export document from the store.
 
     Pure and deterministic: no file I/O, every query ordered. Awards and Ariba
-    postings are nested under their solicitation by document_number; postings
-    with a NULL document_number go to unlinked_ariba_postings (nothing dropped).
+    postings are nested under their solicitation only when their document_number
+    matches an existing solicitation; everything else (NULL or non-matching
+    document_number) goes to unlinked_ariba_postings / unlinked_awards
+    (nothing dropped).
     """
-    generated_at = generated_at or datetime.now(timezone.utc).isoformat()
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).isoformat()
+
+    sol_docs = {r["document_number"] for r in _rows(conn, "SELECT document_number FROM solicitation")}
 
     awards_by_doc: dict[str, list] = {}
+    unlinked_awards: list = []
     for award in _rows(conn, "SELECT * FROM award ORDER BY document_number, id"):
-        awards_by_doc.setdefault(award["document_number"], []).append(
-            _drop(award, "id", "supplier_id", "document_number")
-        )
+        doc = award["document_number"]
+        cleaned = _drop(award, "id", "supplier_id")
+        if doc in sol_docs:
+            awards_by_doc.setdefault(doc, []).append(_drop(cleaned, "document_number"))
+        else:
+            unlinked_awards.append(cleaned)
 
     postings_by_doc: dict[str, list] = {}
     unlinked: list = []
     for posting in _rows(conn, "SELECT * FROM ariba_posting ORDER BY rfx_id"):
         posting = _parse_categories(_drop(posting, "raw_json"))
         doc = posting.get("document_number")
-        if doc:
+        if doc and doc in sol_docs:
             postings_by_doc.setdefault(doc, []).append(_drop(posting, "document_number"))
         else:
             unlinked.append(posting)
@@ -75,4 +84,5 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
         "solicitations": solicitations,
         "noncompetitive": noncompetitive,
         "unlinked_ariba_postings": unlinked,
+        "unlinked_awards": unlinked_awards,
     }

--- a/scrapers/toronto_bids/export/document.py
+++ b/scrapers/toronto_bids/export/document.py
@@ -1,0 +1,78 @@
+import json
+from datetime import datetime, timezone
+
+from toronto_bids.store import db
+
+
+def _rows(conn, sql):
+    return [dict(r) for r in conn.execute(sql).fetchall()]
+
+
+def _drop(record: dict, *keys) -> dict:
+    return {k: v for k, v in record.items() if k not in keys}
+
+
+def _parse_categories(posting: dict) -> dict:
+    raw = posting.get("categories")
+    if raw:
+        try:
+            posting["categories"] = json.loads(raw)
+        except (TypeError, ValueError):
+            pass  # leave the raw string if it isn't valid JSON
+    return posting
+
+
+def build_export_document(conn, generated_at: str | None = None) -> dict:
+    """Assemble the solicitation-centric nested export document from the store.
+
+    Pure and deterministic: no file I/O, every query ordered. Awards and Ariba
+    postings are nested under their solicitation by document_number; postings
+    with a NULL document_number go to unlinked_ariba_postings (nothing dropped).
+    """
+    generated_at = generated_at or datetime.now(timezone.utc).isoformat()
+
+    awards_by_doc: dict[str, list] = {}
+    for award in _rows(conn, "SELECT * FROM award ORDER BY document_number, id"):
+        awards_by_doc.setdefault(award["document_number"], []).append(
+            _drop(award, "id", "supplier_id", "document_number")
+        )
+
+    postings_by_doc: dict[str, list] = {}
+    unlinked: list = []
+    for posting in _rows(conn, "SELECT * FROM ariba_posting ORDER BY rfx_id"):
+        posting = _parse_categories(_drop(posting, "raw_json"))
+        doc = posting.get("document_number")
+        if doc:
+            postings_by_doc.setdefault(doc, []).append(_drop(posting, "document_number"))
+        else:
+            unlinked.append(posting)
+
+    solicitations = []
+    for sol in _rows(conn, "SELECT * FROM solicitation ORDER BY document_number"):
+        sol = _drop(sol, "odata_id")
+        doc = sol["document_number"]
+        sol["awards"] = awards_by_doc.get(doc, [])
+        sol["ariba_postings"] = postings_by_doc.get(doc, [])
+        solicitations.append(sol)
+
+    noncompetitive = [
+        _drop(nc, "supplier_id", "odata_id")
+        for nc in _rows(conn, "SELECT * FROM noncompetitive ORDER BY workspace_number")
+    ]
+
+    sources = _rows(
+        conn,
+        "SELECT source, status, finished_at, rows_fetched, rows_upserted "
+        "FROM sync_run ORDER BY id",
+    )
+
+    return {
+        "meta": {
+            "generated_at": generated_at,
+            "counts": db.counts(conn),
+            "sources": sources,
+        },
+        "solicitations": solicitations,
+        "noncompetitive": noncompetitive,
+        "unlinked_ariba_postings": unlinked,
+    }

--- a/scrapers/toronto_bids/export/json_export.py
+++ b/scrapers/toronto_bids/export/json_export.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from toronto_bids.export.document import build_export_document
+
+
+class JsonExporter:
+    name = "json"
+
+    def export(self, conn, out_path, generated_at: str | None = None) -> Path:
+        document = build_export_document(conn, generated_at)
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(document, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        return out_path

--- a/scrapers/toronto_bids/http.py
+++ b/scrapers/toronto_bids/http.py
@@ -16,11 +16,11 @@ class HttpClient:
         self._retries = retries
         self._backoff = backoff
 
-    def _request(self, method, url, **kwargs):
+    def _request(self, method, url, headers=None, **kwargs):
         last_exc = None
         for attempt in range(self._retries + 1):
             try:
-                resp = self._client.request(method, url, **kwargs)
+                resp = self._client.request(method, url, headers=headers, **kwargs)
                 resp.raise_for_status()
                 return resp
             except httpx.HTTPStatusError as exc:
@@ -33,11 +33,11 @@ class HttpClient:
                 time.sleep(self._backoff * (2 ** attempt))
         raise last_exc
 
-    def get_json(self, url, params=None):
-        return self._request("GET", url, params=params).json()
+    def get_json(self, url, params=None, headers=None):
+        return self._request("GET", url, params=params, headers=headers).json()
 
-    def post_json(self, url, json=None, params=None):
-        return self._request("POST", url, json=json, params=params).json()
+    def post_json(self, url, json=None, params=None, headers=None):
+        return self._request("POST", url, json=json, params=params, headers=headers).json()
 
     def close(self):
         self._client.close()

--- a/scrapers/toronto_bids/linking/document_number.py
+++ b/scrapers/toronto_bids/linking/document_number.py
@@ -22,3 +22,23 @@ def normalize_document_number(raw: str | None) -> str | None:
     if digits in _DENYLIST:
         return None
     return digits
+
+
+_TITLE_DOC = re.compile(r"Doc(\d{10})")
+
+
+def bridge_document_number(external_rfx_id: str | None, title: str | None) -> str | None:
+    """Bridge an Ariba posting to its 10-digit document_number.
+
+    Primary: the detail endpoint's externalRfxId (e.g. "Doc5672751291").
+    Fallback: a "Doc##########" token embedded in the posting title.
+    Returns None if neither yields a valid document number.
+    """
+    doc = normalize_document_number(external_rfx_id)
+    if doc is not None:
+        return doc
+    if title:
+        match = _TITLE_DOC.search(title)
+        if match:
+            return normalize_document_number(match.group(1))
+    return None

--- a/scrapers/toronto_bids/linking/document_number.py
+++ b/scrapers/toronto_bids/linking/document_number.py
@@ -24,7 +24,7 @@ def normalize_document_number(raw: str | None) -> str | None:
     return digits
 
 
-_TITLE_DOC = re.compile(r"Doc(\d{10})")
+_TITLE_DOC = re.compile(r"Doc(\d{10})(?!\d)")
 
 
 def bridge_document_number(external_rfx_id: str | None, title: str | None) -> str | None:

--- a/scrapers/toronto_bids/models.py
+++ b/scrapers/toronto_bids/models.py
@@ -43,3 +43,24 @@ class NonCompetitive:
     council_authority_link: str | None = None
     odata_id: str | None = None
     source: str = ""
+
+
+@dataclass(frozen=True)
+class AribaPosting:
+    rfx_id: str
+    document_number: str | None = None
+    title: str | None = None
+    posting_type: str | None = None      # detail 'type' field — unreliable (often "RFI")
+    status: str | None = None
+    customer_name: str | None = None
+    posted_date: str | None = None
+    close_date: str | None = None
+    categories: str | None = None        # JSON array of category names
+    amount_min: str | None = None
+    amount_max: str | None = None
+    currency: str | None = None
+    public_posting_url: str | None = None
+    sourcing_url: str | None = None      # authenticated event URL (for a later attachments phase)
+    external_rfx_id: str | None = None   # raw e.g. "Doc5672751291"
+    raw_json: str | None = None          # detail JSON snapshot, or None if the detail call failed
+    source: str = ""

--- a/scrapers/toronto_bids/pipeline.py
+++ b/scrapers/toronto_bids/pipeline.py
@@ -1,3 +1,4 @@
+from toronto_bids.sources.ariba import AribaDiscoverySource
 from toronto_bids.sources.ckan import CkanSource
 from toronto_bids.sources.odata import ODataNonCompetitiveSource, ODataSolicitationSource
 from toronto_bids.store import db
@@ -12,6 +13,7 @@ def default_sources():
         CkanSource(name="ckan_awarded", slug=config.CKAN_AWARDED_SLUG, kind="awarded"),
         CkanSource(name="ckan_open", slug=config.CKAN_OPEN_SLUG, kind="open"),
         CkanSource(name="ckan_noncomp", slug=config.CKAN_NONCOMP_SLUG, kind="noncompetitive"),
+        AribaDiscoverySource(),
     ]
 
 

--- a/scrapers/toronto_bids/sources/ariba.py
+++ b/scrapers/toronto_bids/sources/ariba.py
@@ -1,0 +1,35 @@
+from typing import Iterable
+
+from toronto_bids import config
+from toronto_bids.sources.base import Row
+
+
+class AribaDiscoverySource:
+    """Archives open City-of-Toronto SAP Ariba Discovery postings via public JSON APIs."""
+
+    name = "ariba_discovery"
+    overwrite = True  # later successful detail fills NULLs; a later 500 never wipes a snapshot.
+
+    def fetch(self, http) -> Iterable[dict]:
+        data = http.post_json(
+            config.ARIBA_SEARCH_URL,
+            json=config.ARIBA_SEARCH_BODY,
+            params=config.ARIBA_SEARCH_PARAMS,
+        )
+        for record in data.get("solarRecords", []):
+            if record.get("customerName") != config.ARIBA_CUSTOMER_NAME:
+                continue
+            detail = None
+            try:
+                detail = http.get_json(
+                    config.ARIBA_DETAIL_URL.format(rfx_id=record["rfxID"]),
+                    headers={"Accept": "application/json"},
+                )
+            except Exception:
+                # Per-posting isolation: ~40% of details 500. Archive the search
+                # metadata anyway; a later run's detail call fills the gap.
+                detail = None
+            yield {"search": record, "detail": detail}
+
+    def normalize(self, raw: dict) -> Iterable[Row]:  # implemented in Task 4
+        raise NotImplementedError

--- a/scrapers/toronto_bids/sources/ariba.py
+++ b/scrapers/toronto_bids/sources/ariba.py
@@ -1,7 +1,61 @@
+import json
 from typing import Iterable
 
 from toronto_bids import config
+from toronto_bids.linking.document_number import bridge_document_number
+from toronto_bids.models import AribaPosting
 from toronto_bids.sources.base import Row
+
+
+def _clean(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _categories(search: dict, detail: dict | None) -> str | None:
+    if detail and detail.get("categories"):
+        names = [c.get("categoryName") for c in detail["categories"] if c.get("categoryName")]
+        return json.dumps(names) if names else None
+    cats = search.get("productsAndServicesCategories")
+    return json.dumps(cats) if cats else None
+
+
+def normalize_posting(raw: dict):
+    search = raw["search"]
+    detail = raw.get("detail")
+    rfx_id = str(search["rfxID"])
+    title = _clean(search.get("title")) or (_clean(detail.get("title")) if detail else None)
+    external = _clean(detail.get("externalRfxId")) if detail else None
+
+    if detail and detail.get("opportunityAmount"):
+        amt = detail["opportunityAmount"]
+        amount_min, amount_max = _clean(amt.get("minAmount")), _clean(amt.get("maxAmount"))
+        currency = _clean(amt.get("currency"))
+    else:
+        amount_min, amount_max = _clean(search.get("minAmount")), _clean(search.get("maxAmount"))
+        currency = None
+
+    yield AribaPosting(
+        rfx_id=rfx_id,
+        document_number=bridge_document_number(external, title),
+        title=title,
+        posting_type=_clean(detail.get("type")) if detail else _clean(search.get("rfxType")),
+        status=_clean(detail.get("status")) if detail else None,
+        customer_name=_clean(search.get("customerName")),
+        posted_date=_clean(search.get("datePosted")) or (_clean(detail.get("startDate")) if detail else None),
+        close_date=_clean(search.get("endDate")) or (_clean(detail.get("endDate")) if detail else None),
+        categories=_categories(search, detail),
+        amount_min=amount_min,
+        amount_max=amount_max,
+        currency=currency,
+        public_posting_url=_clean(detail.get("publicPostingUrl")) if detail else None,
+        sourcing_url=_clean(detail.get("sourcingUrl")) if detail else None,
+        external_rfx_id=external,
+        raw_json=json.dumps(detail) if detail else None,
+        source="ariba_discovery",
+    )
 
 
 class AribaDiscoverySource:
@@ -31,5 +85,5 @@ class AribaDiscoverySource:
                 detail = None
             yield {"search": record, "detail": detail}
 
-    def normalize(self, raw: dict) -> Iterable[Row]:  # implemented in Task 4
-        raise NotImplementedError
+    def normalize(self, raw: dict) -> Iterable[Row]:
+        yield from normalize_posting(raw)

--- a/scrapers/toronto_bids/sources/base.py
+++ b/scrapers/toronto_bids/sources/base.py
@@ -1,8 +1,8 @@
 from typing import Iterable, Protocol, runtime_checkable
 
-from toronto_bids.models import Award, NonCompetitive, Solicitation
+from toronto_bids.models import AribaPosting, Award, NonCompetitive, Solicitation
 
-Row = Solicitation | Award | NonCompetitive
+Row = Solicitation | Award | NonCompetitive | AribaPosting
 
 
 @runtime_checkable

--- a/scrapers/toronto_bids/store/db.py
+++ b/scrapers/toronto_bids/store/db.py
@@ -1,7 +1,7 @@
 import sqlite3
 from importlib import resources
 
-from toronto_bids.models import Award, NonCompetitive, Solicitation
+from toronto_bids.models import Award, NonCompetitive, Solicitation, AribaPosting
 
 # Column lists per table, in the order used for INSERT. Excludes auto/default columns.
 _SOLICITATION_COLS = [
@@ -12,6 +12,11 @@ _SOLICITATION_COLS = [
 _NONCOMP_COLS = [
     "workspace_number", "supplier_name_raw", "reason", "contract_amount",
     "contract_date", "division", "council_authority_link", "odata_id", "source",
+]
+_ARIBA_POSTING_COLS = [
+    "rfx_id", "document_number", "title", "posting_type", "status", "customer_name",
+    "posted_date", "close_date", "categories", "amount_min", "amount_max", "currency",
+    "public_posting_url", "sourcing_url", "external_rfx_id", "raw_json", "source",
 ]
 
 
@@ -59,12 +64,16 @@ def upsert_row(conn, row, *, overwrite: bool) -> None:
         values = [getattr(row, c) for c in cols]
         _upsert_keyed(conn, "award", cols, values,
                       ["document_number", "supplier_name_raw", "source"], overwrite)
+    elif isinstance(row, AribaPosting):
+        values = [getattr(row, c) for c in _ARIBA_POSTING_COLS]
+        _upsert_keyed(conn, "ariba_posting", _ARIBA_POSTING_COLS, values,
+                      ["rfx_id"], overwrite)
     else:
         raise TypeError(f"Cannot upsert row of type {type(row).__name__}")
 
 
 def counts(conn) -> dict:
-    tables = ["solicitation", "award", "noncompetitive", "sync_run"]
+    tables = ["solicitation", "award", "noncompetitive", "ariba_posting", "sync_run"]
     return {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
 
 

--- a/scrapers/toronto_bids/store/schema.sql
+++ b/scrapers/toronto_bids/store/schema.sql
@@ -64,3 +64,30 @@ CREATE TABLE IF NOT EXISTS sync_run (
     rows_upserted  INTEGER DEFAULT 0,
     error          TEXT
 );
+
+-- ariba_posting archives open SAP Ariba Discovery postings (which disappear when they close).
+-- overwrite=True upserts fill NULL columns on later runs; a later 500 (all-NULL) never wipes an
+-- earlier captured snapshot. document_number is bridged best-effort and may be NULL.
+CREATE TABLE IF NOT EXISTS ariba_posting (
+    rfx_id              TEXT PRIMARY KEY,
+    document_number     TEXT,
+    title               TEXT,
+    posting_type        TEXT,
+    status              TEXT,
+    customer_name       TEXT,
+    posted_date         TEXT,
+    close_date          TEXT,
+    categories          TEXT,
+    amount_min          TEXT,
+    amount_max          TEXT,
+    currency            TEXT,
+    public_posting_url  TEXT,
+    sourcing_url        TEXT,
+    external_rfx_id     TEXT,
+    raw_json            TEXT,
+    source              TEXT,
+    first_seen          TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ariba_posting_docnum ON ariba_posting (document_number);


### PR DESCRIPTION
## P3: Export / publish seam

Stacked on #52 (P2). Base is `p2-ariba-discovery`, so this PR shows **only the P3 diff**.

Publishes the local SQLite store to a self-contained, **solicitation-centric nested JSON** document, behind a destination-agnostic `Exporter` seam.

**What's here:**
- `build_export_document(conn)` — pure, deterministic builder. Each solicitation carries its `awards` and `ariba_postings` nested by `document_number`; non-competitive contracts and **un-bridged records** (`unlinked_ariba_postings`, `unlinked_awards`) are separate top-level arrays. Column hygiene (drop internal ids and the bulky `raw_json` snapshot; parse `categories` to a list); a `meta` block with `generated_at`, `counts`, and per-source `sync_run` provenance.
- `Exporter` protocol + `JsonExporter` (UTF-8, first implementation of the seam — Parquet / static-site / API can plug in without touching the builder).
- `tb export [--out PATH]` CLI.

**Archive-always, verified:** the final whole-branch review caught a Critical bug — the first cut routed records into the nested view by *truthiness* of `document_number` rather than *membership* in the solicitation set, silently dropping postings/awards bridged to a doc number with no spine row (confirmed 2/42 postings lost on live data). Fixed to route by membership, with symmetric `unlinked_awards` and count-reconciliation regression tests. Re-verified live end-to-end: **42/42 postings and 14,423/14,423 awards fully accounted — nothing dropped.**

89 tests passing. Built via subagent-driven TDD.

> Note: base this PR on `main` after #51/#52 merge (GitHub auto-retargets on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RciieRV1itdZnm3dkbWQwN
