### PR TITLE
chore(scraper): move Playwright to optional 'council' extra

### DIFF
--- a/scrapers/README.md
+++ b/scrapers/README.md
@@ -25,8 +25,10 @@ local SQLite store. No browser, no login, no cloud.
   (`council_item` + `background_pdf` tables, with extracted text). TMMIS is Akamai-gated and
   only served to a **real, headed browser**, so this command drives a headed Chromium
   (Playwright); the PDFs themselves download over plain HTTP + `pdftotext`. It is **not** part
-  of `tb sync` — the core pipeline stays browser-free. On a headless server run
-  `tb enrich-council --virtual-display` with `Xvfb` installed (`apt-get install -y xvfb`);
+  of `tb sync` — the core pipeline stays browser-free, so Playwright lives behind the optional
+  `council` extra (the default install pulls neither Playwright nor `pyvirtualdisplay`). Enable
+  it with `uv sync --extra council && uv run playwright install chromium`. On a headless server
+  run `tb enrich-council --virtual-display` with `Xvfb` installed (`apt-get install -y xvfb`);
   `pdftotext` (poppler) is also required.
 - **Supplier dimension** (`supplier` table) — after every sync, a linking pass canonicalizes
   the free-text supplier names across awards, non-competitive contracts, and suspended firms

--- a/scrapers/pyproject.toml
+++ b/scrapers/pyproject.toml
@@ -6,6 +6,13 @@ requires-python = ">=3.12"
 dependencies = [
     "httpx",
     "lxml>=6.1.1",
+]
+
+[project.optional-dependencies]
+# Opt-in TMMIS council + background-PDF enrichment (`tb enrich-council`).
+# Needs a headed browser (Akamai blocks headless); pyvirtualdisplay runs it
+# under Xvfb on a headless server. Install with: uv sync --extra council
+council = [
     "playwright>=1.61.0",
     "pyvirtualdisplay>=3.0",
 ]

--- a/scrapers/toronto_bids/sources/council.py
+++ b/scrapers/toronto_bids/sources/council.py
@@ -78,7 +78,13 @@ def fetch_agenda_item(reference: str, virtual_display: bool = False) -> str:
     On a headless server pass virtual_display=True to run Chromium under Xvfb (needs Xvfb
     installed). Not unit-tested — exercised by the live smoke.
     """
-    from playwright.sync_api import sync_playwright
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise RuntimeError(
+            "Council enrichment needs the optional 'council' extra. "
+            "Install it with: uv sync --extra council && uv run playwright install chromium"
+        ) from exc
 
     display = None
     if virtual_display:

--- a/scrapers/uv.lock
+++ b/scrapers/uv.lock
@@ -325,6 +325,10 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "lxml" },
+]
+
+[package.optional-dependencies]
+council = [
     { name = "playwright" },
     { name = "pyvirtualdisplay" },
 ]
@@ -338,9 +342,10 @@ dev = [
 requires-dist = [
     { name = "httpx" },
     { name = "lxml", specifier = ">=6.1.1" },
-    { name = "playwright", specifier = ">=1.61.0" },
-    { name = "pyvirtualdisplay", specifier = ">=3.0" },
+    { name = "playwright", marker = "extra == 'council'", specifier = ">=1.61.0" },
+    { name = "pyvirtualdisplay", marker = "extra == 'council'", specifier = ">=3.0" },
 ]
+provides-extras = ["council"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest" }]


### PR DESCRIPTION
Follow-up cleanup after the P0–P5b stack landed.

## What

The core `tb sync` pipeline is browser-free — only the opt-in `tb enrich-council` command needs Playwright (headed Chromium for the Akamai-gated TMMIS council pages) and `pyvirtualdisplay` (Xvfb on headless servers). This moves both out of the default runtime dependencies into a `council` optional extra, so a plain `uv sync` no longer pulls a browser stack.

- **pyproject.toml** — new `[project.optional-dependencies] council = ["playwright", "pyvirtualdisplay"]`; default `dependencies` now just `httpx` + `lxml`.
- **council.py** — the lazy `playwright` import now raises a clear `RuntimeError` pointing at `uv sync --extra council` instead of a bare `ModuleNotFoundError`.
- **README.md** — documents the extra: `uv sync --extra council && uv run playwright install chromium`.

## Verification

- Full suite **144 passing** with the extra *uninstalled* (core stands alone).
- `fetch_agenda_item()` without the extra raises the friendly install message (verified).
- `uv sync --extra council` cleanly reinstalls playwright + pyvirtualdisplay (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RciieRV1itdZnm3dkbWQwN