### PR TITLE
fix(scraper): self-heal missing columns on existing DBs in init_db

### DIFF
--- a/scrapers/tests/test_db.py
+++ b/scrapers/tests/test_db.py
@@ -170,3 +170,31 @@ def test_upsert_background_pdf_is_idempotent(conn):
 def test_counts_includes_council_tables(conn):
     c = db.counts(conn)
     assert "council_item" in c and "background_pdf" in c
+
+
+def test_init_db_adds_missing_column_to_pre_p5a_table():
+    # A database created before P5a has a suspended_firm table WITHOUT supplier_id.
+    # CREATE TABLE IF NOT EXISTS won't touch the existing table, so init_db must
+    # additively self-heal by ALTERing in the missing column.
+    c = db.connect(":memory:")
+    c.execute(
+        "CREATE TABLE suspended_firm ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " supplier_name_raw TEXT NOT NULL,"
+        " council_authority TEXT,"
+        " source TEXT,"
+        " UNIQUE (supplier_name_raw, council_authority))"
+    )
+    c.commit()
+
+    db.init_db(c)
+
+    cols = {r[1] for r in c.execute("PRAGMA table_info(suspended_firm)")}
+    assert "supplier_id" in cols
+    # The healed column must be writable — the supplier dimension backfills it.
+    c.execute("INSERT INTO suspended_firm (supplier_name_raw, council_authority, source)"
+              " VALUES ('Acme', 'A1', 'x')")
+    c.execute("UPDATE suspended_firm SET supplier_id = 7 WHERE supplier_name_raw = 'Acme'")
+    row = c.execute("SELECT supplier_id FROM suspended_firm WHERE supplier_name_raw = 'Acme'").fetchone()
+    assert row["supplier_id"] == 7
+    c.close()

--- a/scrapers/toronto_bids/store/db.py
+++ b/scrapers/toronto_bids/store/db.py
@@ -37,7 +37,49 @@ def connect(path) -> sqlite3.Connection:
 def init_db(conn) -> None:
     schema = resources.files("toronto_bids.store").joinpath("schema.sql").read_text()
     conn.executescript(schema)
+    _add_missing_columns(conn, schema)
     conn.commit()
+
+
+def _add_missing_columns(conn, schema: str) -> None:
+    """Additively self-heal an older database.
+
+    `CREATE TABLE IF NOT EXISTS` never alters a table that already exists, so a
+    database created before a column was added to schema.sql (e.g. suspended_firm.
+    supplier_id, added in P5a) silently lacks that column. Build the reference schema
+    in a scratch in-memory DB, then `ALTER TABLE ... ADD COLUMN` any column present in
+    the reference but missing from the live table. Only additive, nullable-or-defaulted
+    columns are handled — exactly what ADD COLUMN can safely apply.
+    """
+    ref = sqlite3.connect(":memory:")
+    try:
+        ref.executescript(schema)
+        ref_tables = [r[0] for r in ref.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")]
+        for table in ref_tables:
+            actual = {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+            if not actual:
+                continue  # table didn't exist — the CREATE above already made it current
+            for _cid, name, coltype, notnull, default, _pk in ref.execute(
+                    f"PRAGMA table_info({table})"):
+                if name in actual:
+                    continue
+                if notnull and default is None:
+                    continue  # ADD COLUMN can't add NOT NULL without a default
+                decl = f"{name} {coltype}".strip()
+                if notnull:
+                    decl += " NOT NULL"
+                if default is not None:
+                    decl += f" DEFAULT {default}"
+                try:
+                    conn.execute(f"ALTER TABLE {table} ADD COLUMN {decl}")
+                except sqlite3.OperationalError:
+                    # ADD COLUMN also refuses non-constant defaults (e.g. datetime('now')),
+                    # UNIQUE, and PRIMARY KEY. Such columns can't be retrofitted onto an
+                    # existing table; they predate any realistic legacy DB anyway. Skip.
+                    continue
+    finally:
+        ref.close()
 
 
 def _upsert_keyed(conn, table, cols, values, key_cols, overwrite: bool) -> None:


### PR DESCRIPTION
## The bug (found by a live end-to-end sync)

Running `tb sync` against a `bids.sqlite` created **before P5a** left `supplier=0`. The `supplier_dimension` pass failed every run:

```
supplier_dimension | failed | no such column: supplier_id
```

Root cause: `init_db` uses `CREATE TABLE IF NOT EXISTS`, which never alters an existing table. When P5a added `suspended_firm.supplier_id` to `schema.sql`, pre-existing databases never got the column. The failure is isolated (recorded as `failed`, sync doesn't crash), so it degraded silently — the exact "hasn't worked in a while" failure mode the rewrite set out to kill. A **fresh** DB was always fine; only upgraded DBs broke.

## The fix

`init_db` now additively self-heals after the `CREATE`s: it builds the reference schema in a scratch in-memory DB, then `ALTER TABLE ADD COLUMN`s any column present in the reference but missing from the live table. Only additive, nullable-or-constant-default columns are applied — non-constant-default columns (`first_seen`/`last_seen`, `DEFAULT (datetime('now'))`) are skipped, since `ADD COLUMN` forbids them and they predate any realistic legacy DB. **`schema.sql` stays the single source of truth**, so any future additive column heals automatically.

## Verification

- New TDD test `test_init_db_adds_missing_column_to_pre_p5a_table` (RED→GREEN): builds a pre-P5a `suspended_firm` without `supplier_id`, runs `init_db`, asserts the column appears and is writable.
- Full suite **145 passing**.
- **Live:** the previously-broken `bids.sqlite` now heals on next sync — `supplier_dimension` `ok`, **supplier=4189**; fresh syncs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RciieRV1itdZnm3dkbWQwN