### PR TITLE
fix: surface source failures at the CLI (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ installs a `tb` command. No browser, no login, no cloud, no API keys.
 ```shell
 cd scrapers
 uv sync
-uv run tb sync      # fetch every source into files/bids.sqlite
-uv run tb status    # row counts
+uv run tb sync      # fetch every source into files/bids.sqlite (non-zero exit if any source failed)
+uv run tb status    # row counts + last run per source
 uv run tb export    # write the whole store to one JSON artifact
 uv run pytest       # tests (offline; uses fixtures)
 ```

--- a/scrapers/README.md
+++ b/scrapers/README.md
@@ -47,10 +47,16 @@ cd scrapers
 uv sync
 uv run tb sync            # fetch all sources into files/bids.sqlite
 uv run tb sync --only odata_solicitations,ckan_awarded
-uv run tb status          # row counts
+uv run tb status          # row counts + last run per source
 uv run tb export [--out PATH]  # write the whole store to a single JSON artifact
 uv run pytest             # tests (offline; uses fixtures)
 ```
+
+Each source runs in isolation: one source failing never stops the others, and whatever
+the others fetched is still committed. Failures are not silent, though — `tb sync` prints
+each one to stderr and **exits non-zero** if any source failed, so cron and CI notice.
+`tb status` shows the last run per source with its status and error, which is where you
+look first when a number seems wrong.
 
 - `uv run tb export [--out PATH]` — write the whole store to a single
   solicitation-centric nested JSON artifact (default `<DATA_DIR>/export/bids.json`):

--- a/scrapers/tests/test_cli.py
+++ b/scrapers/tests/test_cli.py
@@ -1,0 +1,49 @@
+"""CLI-level tests for failure visibility (#18).
+
+The bug these lock down: a sync where every source blew up still printed
+"Sync complete" and exited 0, so nothing — human or cron — could tell.
+"""
+from toronto_bids import cli, config, pipeline
+from toronto_bids.models import Solicitation
+from toronto_bids.store import db
+
+from tests.test_pipeline import FakeSource
+
+
+def _isolate_db(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "test.sqlite")
+
+
+def test_sync_exits_zero_and_says_complete_when_sources_succeed(monkeypatch, tmp_path, capsys):
+    _isolate_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(pipeline, "default_sources", lambda: [
+        FakeSource("odata_solicitations", [Solicitation("3303123110", source="odata")]),
+    ])
+    assert cli.main(["sync"]) == 0
+    assert "Sync complete" in capsys.readouterr().out
+
+
+def test_sync_exits_nonzero_and_names_the_failure(monkeypatch, tmp_path, capsys):
+    _isolate_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(pipeline, "default_sources", lambda: [
+        FakeSource("odata_solicitations", [Solicitation("3303123110", source="odata")]),
+        FakeSource("ckan_open", [], boom=True),
+    ])
+    assert cli.main(["sync"]) == 1
+    out = capsys.readouterr()
+    assert "Sync complete" not in out.out
+    assert "1 failed source(s)" in out.out
+    assert "ckan_open" in out.err and "network exploded" in out.err
+
+
+def test_status_shows_last_run_per_source(monkeypatch, tmp_path, capsys):
+    _isolate_db(monkeypatch, tmp_path)
+    conn = db.connect(config.DB_PATH)
+    db.init_db(conn)
+    db.finish_sync_run(conn, db.start_sync_run(conn, "ckan_open"),
+                       status="failed", error="network exploded")
+    conn.close()
+    assert cli.main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "ckan_open" in out and "failed" in out and "network exploded" in out

--- a/scrapers/tests/test_pipeline.py
+++ b/scrapers/tests/test_pipeline.py
@@ -24,8 +24,8 @@ def test_run_source_upserts_and_records_ok(conn):
         Solicitation("3303123110", status="Awarded", source="odata"),
         Award("3303123110", supplier_name_raw="Computer Media Group", source="odata"),
     ])
-    fetched, upserted = pipeline.run_source(conn, http=None, source=src)
-    assert (fetched, upserted) == (2, 2)
+    fetched, upserted, error = pipeline.run_source(conn, http=None, source=src)
+    assert (fetched, upserted, error) == (2, 2, None)
     assert db.counts(conn)["solicitation"] == 1
     assert db.counts(conn)["award"] == 1
     run = conn.execute("SELECT status FROM sync_run WHERE source='odata_solicitations'").fetchone()
@@ -34,8 +34,9 @@ def test_run_source_upserts_and_records_ok(conn):
 
 def test_run_source_isolates_failure(conn):
     src = FakeSource("odata_solicitations", [], boom=True)
-    fetched, upserted = pipeline.run_source(conn, http=None, source=src)
+    fetched, upserted, error = pipeline.run_source(conn, http=None, source=src)
     assert (fetched, upserted) == (0, 0)
+    assert "network exploded" in error  # returned to the caller, not just buried in sync_run
     run = conn.execute("SELECT status, error FROM sync_run WHERE source='odata_solicitations'").fetchone()
     assert run["status"] == "failed"
     assert "network exploded" in run["error"]
@@ -45,10 +46,25 @@ def test_sync_runs_all_and_one_failure_does_not_stop_others(conn):
     good = FakeSource("odata_solicitations", [Solicitation("3303123110", source="odata")])
     bad = FakeSource("ckan_open", [], boom=True)
     also_good = FakeSource("ckan_awarded", [Solicitation("5749398870", source="ckan_awarded")], overwrite=False)
-    pipeline.sync(conn, http=None, sources=[good, bad, also_good])
+    failures = pipeline.sync(conn, http=None, sources=[good, bad, also_good])
     assert db.counts(conn)["solicitation"] == 2
     # 3 sources + 1 supplier_dimension sync_run = 4
     assert db.counts(conn)["sync_run"] == 4
+    # the failure is isolated but NOT swallowed: sync hands it back
+    assert [name for name, _ in failures] == ["ckan_open"]
+    assert "network exploded" in failures[0][1]
+
+
+def test_sync_returns_no_failures_when_all_sources_succeed(conn):
+    good = FakeSource("odata_solicitations", [Solicitation("3303123110", source="odata")])
+    assert pipeline.sync(conn, http=None, sources=[good]) == []
+
+
+def test_sync_reports_every_failed_source(conn):
+    bad = FakeSource("ckan_open", [], boom=True)
+    worse = FakeSource("ariba_discovery", [], boom=True)
+    failures = pipeline.sync(conn, http=None, sources=[bad, worse])
+    assert sorted(name for name, _ in failures) == ["ariba_discovery", "ckan_open"]
 
 
 def test_sync_only_filters_sources(conn):
@@ -78,7 +94,8 @@ def test_sync_supplier_dimension_failure_is_isolated(conn, monkeypatch):
     def boom(_conn):
         raise RuntimeError("link exploded")
     monkeypatch.setattr(pipeline, "build_supplier_dimension", boom)
-    pipeline.sync(conn, http=None, sources=[])  # no sources; linking still runs and fails safely
+    failures = pipeline.sync(conn, http=None, sources=[])  # no sources; linking still fails safely
     row = conn.execute("SELECT status, error FROM sync_run WHERE source='supplier_dimension'").fetchone()
     assert row["status"] == "failed"
     assert "link exploded" in row["error"]
+    assert failures == [("supplier_dimension", "link exploded")]

--- a/scrapers/tests/test_smoke.py
+++ b/scrapers/tests/test_smoke.py
@@ -24,6 +24,7 @@ def test_sync_uses_pipeline_and_persists(tmp_path, monkeypatch):
     def fake_sync(conn, http, sources=None, only=None):
         db.upsert_row(conn, Solicitation("3303123110", source="odata"), overwrite=True)
         conn.commit()
+        return []  # no failures
     monkeypatch.setattr(pipeline_mod, "sync", fake_sync)
 
     assert main(["sync"]) == 0

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from toronto_bids import __version__, config, pipeline
 from toronto_bids.export.json_export import export_json
@@ -43,19 +44,30 @@ def _cmd_sync(args) -> int:
         if unknown:
             print(f"Warning: unknown source name(s): {', '.join(unknown)}")
     try:
-        pipeline.sync(conn, http, only=only)
+        failures = pipeline.sync(conn, http, only=only)
         counts = db.counts(conn)
-        print("Sync complete:", ", ".join(f"{k}={v}" for k, v in counts.items()))
+        print("Row counts:", ", ".join(f"{k}={v}" for k, v in counts.items()))
+        for name, error in failures:
+            print(f"FAILED  {name}: {error}", file=sys.stderr)
+        print("Sync complete" if not failures
+              else f"Sync finished with {len(failures)} failed source(s)")
     finally:
         http.close()
         conn.close()
-    return 0
+    # Non-zero so a human or a cron job notices; a silent zero-row run is the bug (#18).
+    return 1 if failures else 0
 
 
 def _cmd_status(args) -> int:
     conn = _open_db()
     for table, n in db.counts(conn).items():
         print(f"{table:16s} {n}")
+    runs = db.last_runs(conn)
+    if runs:
+        print("\nLast run per source:")
+        for r in runs:
+            line = f"  {r['source']:22s} {r['status']:8s} {r['started_at']}  rows={r['rows_upserted']}"
+            print(line + (f"\n    error: {r['error']}" if r["error"] else ""))
     conn.close()
     return 0
 

--- a/scrapers/toronto_bids/pipeline.py
+++ b/scrapers/toronto_bids/pipeline.py
@@ -21,7 +21,11 @@ def default_sources():
 
 
 def run_source(conn, http, source):
-    """Run one source; record a sync_run. Never raises — returns (fetched, upserted)."""
+    """Run one source; record a sync_run. Never raises — returns (fetched, upserted, error).
+
+    error is None on success. Callers are responsible for surfacing it: this is the only
+    place a source's exception is seen, so silence here means silence everywhere.
+    """
     run_id = db.start_sync_run(conn, source.name)
     fetched = upserted = 0
     try:
@@ -33,29 +37,39 @@ def run_source(conn, http, source):
         conn.commit()
         db.finish_sync_run(conn, run_id, status="ok",
                            rows_fetched=fetched, rows_upserted=upserted)
+        return fetched, upserted, None
     except Exception as exc:  # per-source isolation
         conn.commit()
         db.finish_sync_run(conn, run_id, status="failed",
                            rows_fetched=fetched, rows_upserted=upserted, error=str(exc))
-    return fetched, upserted
+        return fetched, upserted, str(exc)
 
 
-def sync(conn, http, sources=None, only=None) -> None:
+def sync(conn, http, sources=None, only=None) -> list[tuple[str, str]]:
+    """Run every source in isolation. Returns [(source_name, error)] for those that failed."""
     sources = sources if sources is not None else default_sources()
     if only is not None:
         wanted = set(only)
         sources = [s for s in sources if s.name in wanted]
+    failures = []
     for source in sources:
-        run_source(conn, http, source)
-    _run_supplier_dimension(conn)
+        *_, error = run_source(conn, http, source)
+        if error:
+            failures.append((source.name, error))
+    error = _run_supplier_dimension(conn)
+    if error:
+        failures.append(("supplier_dimension", error))
+    return failures
 
 
-def _run_supplier_dimension(conn) -> None:
+def _run_supplier_dimension(conn) -> str | None:
     """Rebuild the supplier dimension after sources. Isolated: never raises out of sync."""
     run_id = db.start_sync_run(conn, "supplier_dimension")
     try:
         n = build_supplier_dimension(conn)
         db.finish_sync_run(conn, run_id, status="ok", rows_fetched=n, rows_upserted=n)
+        return None
     except Exception as exc:
         conn.rollback()
         db.finish_sync_run(conn, run_id, status="failed", error=str(exc))
+        return str(exc)

--- a/scrapers/toronto_bids/store/db.py
+++ b/scrapers/toronto_bids/store/db.py
@@ -112,6 +112,14 @@ def counts(conn) -> dict:
     return {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
 
 
+def last_runs(conn) -> list:
+    """The most recent sync_run per source, newest source-run first."""
+    return conn.execute(
+        "SELECT source, status, started_at, rows_upserted, error FROM sync_run "
+        "WHERE id IN (SELECT MAX(id) FROM sync_run GROUP BY source) ORDER BY source"
+    ).fetchall()
+
+
 def start_sync_run(conn, source: str) -> int:
     cur = conn.execute(
         "INSERT INTO sync_run (source, started_at, status) VALUES (?, datetime('now'), 'running')",


### PR DESCRIPTION
Closes #18.

## The bug

`tb sync` printed `Sync complete` and exited **0** even when every source failed:

```
$ tb sync            # (with a source that raises)
Sync complete: solicitation=0, award=0, ...
$ echo $?
0
```

`run_source` wraps each source in a blanket `except Exception` so one bad source cannot take down the others. That isolation is correct and stays. The bug is that `run_source` was the *only* place the error was ever seen — it recorded `status='failed' in `sync_run` and returned counts, `sync` discarded the outcome, and `_cmd_sync` returned 0 unconditionally. `tb status` never read `sync_run` either, so the sole trace of a total failure was a table nothing surfaced.

## The fix

- `run_source` returns `(fetched, upserted, error)` — `error` is `None` on success.
- `sync` returns `[(source_name, error)]` for sources that failed (including the supplier-dimension pass).
- `tb sync` prints each failure to **stderr** and **exits 1** if any source failed. The success path is unchanged.
- `tb status` gains a "last run per source" section (status, timestamp, rows, error).

Same scenario now:

```
$ tb sync
FAILED  odata_solicitations: City feed returned 503     # stderr
Row counts: solicitation=0, ...
Sync finished with 1 failed source(s)
$ echo $?
1
```

## Verification

- **147 tests pass** (was 142; +5).
- **Adds `tests/test_cli.py`** — there were no CLI-level tests at all, which is precisely why the exit code went unnoticed for so long.
- **Mutation-tested**: reverting `return 1 if failures else 0` back to `return 0` fails the suite. The test fails for the right reason.
- **Live sync** against the real City OData feed: 7,444 solicitations, `Sync complete`, exit 0 — no false alarm on the happy path.

## Scope note

The issue title says "implement logging", but the actual defect was invisible failure, and `sync_run` already records per-source history. A stdlib `logging` module with `-v/--verbose` is deliberately **not** included — it can come when someone needs it. This is the part that has value today, and it becomes load-bearing the moment a scheduler runs `tb sync`: a cron job that cannot distinguish success from silent failure is worse than no cron job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RciieRV1itdZnm3dkbWQwN