### PR TITLE
feat: detect City feed drift against a declared schema (#10)

### DIFF
--- a/scrapers/README.md
+++ b/scrapers/README.md
@@ -58,6 +58,18 @@ each one to stderr and **exits non-zero** if any source failed, so cron and CI n
 `tb status` shows the last run per source with its status and error, which is where you
 look first when a number seems wrong.
 
+### Feed drift
+
+`sources/schema_check.py` declares the fields each normalizer reads out of the City's
+OData and CKAN feeds, and a `schema_check` source samples one record per feed on every
+sync to confirm they're still there. If the City renames or drops a field, the run fails
+loudly instead of quietly NULLing that column across every row.
+
+It's an ordinary source, so per-source isolation applies deliberately: **drift is reported
+without stopping ingestion**. A renamed buyer-phone field should never cost us the archive
+of a posting that disappears when it closes. When it fires, fix the normalizer and the
+declared field set together — they're two halves of one change.
+
 - `uv run tb export [--out PATH]` — write the whole store to a single
   solicitation-centric nested JSON artifact (default `<DATA_DIR>/export/bids.json`):
   each solicitation with its `awards` and `ariba_postings` nested by `document_number`,

--- a/scrapers/tests/test_schema_check.py
+++ b/scrapers/tests/test_schema_check.py
@@ -1,0 +1,211 @@
+"""Drift detection for the City's feeds (#10).
+
+The failure being caught: a renamed City field makes every normalizer's .get() return
+None, so the column NULLs out across all rows and the run still reports success.
+"""
+import pytest
+
+from toronto_bids import config, pipeline
+from toronto_bids.sources.schema_check import SchemaCheckSource, missing_fields
+
+# One record per feed, shaped like the real thing (verified live 2026-07-16). Only the
+# fields the normalizers read plus a little noise — the real feeds carry ~63.
+ODATA_SOLICITATION = {
+    "Solicitation_Document_Number": "3303123110", "Status": "Awarded",
+    "Solicitation_Document_Type": "RFQ", "Solicitation_Form_Type": "Goods",
+    "Posting_Title": "Widgets", "Solicitation_Document_Description": "Some widgets",
+    "Issue_Date": "2025-01-01", "Closing_Date": "2025-02-01",
+    "High_Level_Category": "Goods", "Client_Division": "Fleet Services",
+    "Buyer_Name": "A Buyer", "Buyer_Email": "b@toronto.ca", "Buyer_Phone_Number": "416",
+    "Wards": "All", "Ariba_Discovery_Posting_Link": "https://example.test", "id": "1",
+    "Awarded_Suppliers": [{
+        "Successful_Bidder": "Acme", "Award_Amount": "100", "Date_Awarded": "2025-02-02",
+        "AwardedDate": "2025-02-02", "street": "1 Main St",
+    }],
+    "Staff_Notes": "unused field the feed happens to carry",
+}
+ODATA_NONCOMP = {
+    "Non_Competitive_Reference_Number": "WS-1", "Non_Competitive_Reason": "Sole source",
+    "Client_Division": "Fleet", "Council_Authority_Link_to_Staff_Report": "2025.GG26.3",
+    "id": "2",
+    "Awarded_Suppliers": [{"Successful_Bidder": "Acme", "Award_Amount": "5",
+                          "Date_Awarded": "2025-02-02"}],
+}
+CKAN_AWARDED = {
+    "Document Number": "3303123110", "RFx (Solicitation) Type": "RFQ",
+    "High Level Category": "Goods", "Solicitation Document Description": "Widgets",
+    "Division": "Fleet", "Buyer Name": "A Buyer", "Buyer Email": "b@toronto.ca",
+    "Buyer Phone Number": "416", "Successful Supplier": "Acme", "Award": "100",
+    "Award Authority Obtained Date": "2025-02-02", "_id": 1,
+}
+CKAN_OPEN = {
+    "Document Number": "5749398870", "RFx (Solicitation) Type": "RFQ",
+    "NOIP (Notice of Intended Procurement) Type": "", "Issue Date": "2025-01-01",
+    "Submission Deadline": "2025-02-01", "High Level Category": "Goods",
+    "Solicitation Document Description": "Widgets", "Division": "Fleet",
+    "Buyer Name": "A Buyer", "Buyer Email": "b@toronto.ca",
+    "Buyer Phone Number": "416", "Wards": "All", "_id": 1,
+}
+CKAN_NONCOMP = {
+    "Workspace Number": "WS-1", "Supplier Name": "Acme", "Reason": "Sole source",
+    "Contract Amount": "5", "Contract Date": "2025-02-02", "Division": "Fleet", "_id": 1,
+}
+
+
+class FakeHttp:
+    """Serves each feed, matching the real request/response shapes in odata.py and ckan.py.
+
+    Each feed takes a dict (one record), a list (several — the OData feeds are sampled),
+    or {} / [] for a feed that returns nothing. Pages honestly, so fetch_entityset's
+    $skip loop and fetch_datastore's offset loop actually terminate.
+    """
+
+    def __init__(self, solicitation=None, noncomp=None, awarded=None, open_=None, ckan_noncomp=None):
+        def page(value, default):
+            value = default if value is None else value
+            return [value] if isinstance(value, dict) and value else list(value or [])
+
+        self.records = {
+            "solicitation": page(solicitation, ODATA_SOLICITATION),
+            "noncomp": page(noncomp, ODATA_NONCOMP),
+            "awarded": page(awarded, CKAN_AWARDED),
+            "open": page(open_, CKAN_OPEN),
+            "ckan_noncomp": page(ckan_noncomp, CKAN_NONCOMP),
+        }
+
+    def get_json(self, url, params=None):
+        params = params or {}
+        if "package_show" in url:  # CKAN slug -> resource id; slug round-trips as the id
+            return {"result": {"resources": [{"datastore_active": True, "id": params["id"]}]}}
+        if "datastore_search" in url:
+            key = {config.CKAN_AWARDED_SLUG: "awarded",
+                   config.CKAN_OPEN_SLUG: "open",
+                   config.CKAN_NONCOMP_SLUG: "ckan_noncomp"}[params["resource_id"]]
+            offset, limit = params["offset"], params["limit"]
+            return {"result": {"records": self.records[key][offset:offset + limit]}}
+        key = "noncomp" if config.ODATA_NONCOMPETITIVE in url else "solicitation"
+        skip, top = params["$skip"], params["$top"]
+        return {"value": self.records[key][skip:skip + top]}
+
+
+def _run():
+    return SchemaCheckSource().fetch(FakeHttp())
+
+
+def test_passes_when_every_feed_still_has_the_fields_we_read():
+    assert list(_run()) == []  # no drift, no rows
+
+
+def test_detects_a_renamed_odata_field():
+    drifted = {**ODATA_SOLICITATION}
+    drifted["Posting_Title_v2"] = drifted.pop("Posting_Title")  # the City renames a field
+    with pytest.raises(ValueError, match="Posting_Title"):
+        SchemaCheckSource().fetch(FakeHttp(solicitation=drifted))
+
+
+def test_detects_a_renamed_ckan_column():
+    drifted = {**CKAN_AWARDED}
+    drifted["Winning Supplier"] = drifted.pop("Successful Supplier")
+    with pytest.raises(ValueError, match="Successful Supplier"):
+        SchemaCheckSource().fetch(FakeHttp(awarded=drifted))
+
+
+def test_detects_drift_in_the_nested_supplier_dict():
+    drifted = {**ODATA_SOLICITATION, "Awarded_Suppliers": [{"Bidder": "Acme"}]}
+    # match the nested field, not "Awarded_Suppliers" — that also matches the top-level message
+    with pytest.raises(ValueError, match="Successful_Bidder"):
+        SchemaCheckSource().fetch(FakeHttp(solicitation=drifted))
+
+
+def test_nested_check_looks_past_records_that_have_no_supplier_yet():
+    """The live feed's record #1 has no Awarded_Suppliers (it isn't awarded yet), so a
+    check that only sampled record #1 would silently verify none of the nested fields."""
+    not_awarded = {**ODATA_SOLICITATION, "Awarded_Suppliers": []}
+    drifted_award = {**ODATA_SOLICITATION, "Awarded_Suppliers": [{"Bidder": "Acme"}]}
+    with pytest.raises(ValueError, match="Successful_Bidder"):
+        SchemaCheckSource().fetch(FakeHttp(solicitation=[not_awarded, drifted_award]))
+
+
+def test_reports_when_no_sampled_record_has_a_supplier_to_check():
+    # Can't verify != verified. Silence here would hide the nested fields forever.
+    not_awarded = {**ODATA_SOLICITATION, "Awarded_Suppliers": []}
+    with pytest.raises(ValueError, match="went unchecked"):
+        SchemaCheckSource().fetch(FakeHttp(solicitation=[not_awarded]))
+
+
+def test_reports_every_drifted_feed_not_just_the_first():
+    bad_odata = {k: v for k, v in ODATA_SOLICITATION.items() if k != "Status"}
+    bad_ckan = {k: v for k, v in CKAN_NONCOMP.items() if k != "Reason"}
+    with pytest.raises(ValueError) as exc:
+        SchemaCheckSource().fetch(FakeHttp(solicitation=bad_odata, ckan_noncomp=bad_ckan))
+    assert "Status" in str(exc.value) and "Reason" in str(exc.value)
+
+
+def test_detects_a_feed_that_returns_nothing():
+    with pytest.raises(ValueError, match="no records"):
+        SchemaCheckSource().fetch(FakeHttp(open_={}))
+
+
+def test_declared_schema_matches_what_the_normalizers_actually_read():
+    """The declared fields mirror the normalizers' .get("...") calls by hand. This fails
+    when the two diverge — otherwise someone adds raw.get("New_Field"), forgets to declare
+    it, and drift in that field silently stops being detected: #10's bug, quietly restored.
+    """
+    import ast
+    import pathlib
+
+    from toronto_bids.sources import schema_check
+
+    # (module, normalizer) -> the feed whose declared fields that normalizer reads.
+    reads = {
+        ("odata.py", "normalize_solicitation"): "odata_solicitations",
+        ("odata.py", "normalize_noncompetitive"): "odata_noncompetitive",
+        ("ckan.py", "normalize_awarded"): "ckan_awarded",
+        ("ckan.py", "normalize_open"): "ckan_open",
+        ("ckan.py", "normalize_noncompetitive"): "ckan_noncomp",
+    }
+    src_dir = pathlib.Path(schema_check.__file__).parent
+    for (module, func_name), feed in reads.items():
+        tree = ast.parse((src_dir / module).read_text())
+        func = next(n for n in ast.walk(tree)
+                    if isinstance(n, ast.FunctionDef) and n.name == func_name)
+        # every string literal passed to a .get(...) inside the normalizer
+        actually_read = {
+            n.args[0].value for n in ast.walk(func)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "get" and n.args and isinstance(n.args[0], ast.Constant)
+        }
+        if feed in schema_check._ODATA:
+            _, top, supplier = schema_check._ODATA[feed]
+            declared = top | supplier
+        else:
+            _, declared = schema_check._CKAN[feed]
+        assert actually_read == declared, (
+            f"{module}:{func_name} and the declared schema for {feed} have diverged.\n"
+            f"  read but not declared (drift here goes undetected): {sorted(actually_read - declared)}\n"
+            f"  declared but not read (stale entry): {sorted(declared - actually_read)}"
+        )
+
+
+def test_unused_extra_fields_are_not_drift():
+    # The City adding a field is not a problem; only losing one we read is.
+    assert missing_fields("f", {"a": 1, "b": 2, "new": 3}, {"a", "b"}) == []
+
+
+def test_schema_check_runs_in_the_default_pipeline():
+    assert "schema_check" in [s.name for s in pipeline.default_sources()]
+
+
+def test_drift_is_isolated_and_surfaced_not_swallowed(conn):
+    """Drift must fail loudly (#18) yet never stop the other sources ingesting (#10)."""
+    from tests.test_pipeline import FakeSource
+    from toronto_bids.models import Solicitation
+    from toronto_bids.store import db
+
+    drifted = {k: v for k, v in ODATA_SOLICITATION.items() if k != "Status"}
+    real_data = FakeSource("odata_solicitations", [Solicitation("3303123110", source="odata")])
+    failures = pipeline.sync(conn, http=FakeHttp(solicitation=drifted),
+                             sources=[SchemaCheckSource(), real_data])
+    assert [name for name, _ in failures] == ["schema_check"]  # surfaced to the CLI
+    assert "Status" in failures[0][1]
+    assert db.counts(conn)["solicitation"] == 1  # ingestion continued anyway

--- a/scrapers/toronto_bids/pipeline.py
+++ b/scrapers/toronto_bids/pipeline.py
@@ -1,6 +1,7 @@
 from toronto_bids.sources.ariba import AribaDiscoverySource
 from toronto_bids.sources.ckan import CkanSource
 from toronto_bids.sources.odata import ODataNonCompetitiveSource, ODataSolicitationSource
+from toronto_bids.sources.schema_check import SchemaCheckSource
 from toronto_bids.sources.suspended_firms import SuspendedFirmsSource
 from toronto_bids.store import db
 from toronto_bids import config
@@ -8,8 +9,13 @@ from toronto_bids.linking.supplier import build_supplier_dimension
 
 
 def default_sources():
-    """OData spine first (overwrite=True), then CKAN backfill (overwrite=False)."""
+    """OData spine first (overwrite=True), then CKAN backfill (overwrite=False).
+
+    schema_check leads: it reports feed drift without blocking the sources behind it
+    (per-source isolation), so drift is loud but never costs us a run's data.
+    """
     return [
+        SchemaCheckSource(),
         ODataSolicitationSource(),
         ODataNonCompetitiveSource(),
         CkanSource(name="ckan_awarded", slug=config.CKAN_AWARDED_SLUG, kind="awarded"),

--- a/scrapers/toronto_bids/sources/schema_check.py
+++ b/scrapers/toronto_bids/sources/schema_check.py
@@ -1,0 +1,125 @@
+"""The schema the City's feeds must provide, and a check that they still do (#10).
+
+Every normalizer reads its fields by name (`raw.get("Posting_Title")`). If the City
+renames or drops one, `.get` returns None, that column NULLs out on every row written from
+then on, and nothing anywhere complains. This module is the declared schema for the two
+machine-readable sources and the check that catches that.
+
+It runs as an ordinary source, which buys two things for free:
+
+  * per-source isolation — drift is reported WITHOUT stopping ingestion, so a renamed
+    field never costs us the archive of postings that vanish when they close;
+  * visibility — the failure lands in sync_run, on stderr, and in tb sync's exit code (#18).
+
+That trade is deliberate, and the upsert semantics are why it's the right one: every write
+COALESCEs, so a NULL never overwrites a value already in the store (see db._upsert_keyed).
+Undetected drift therefore costs new rows a column until someone fixes the normalizer, and
+the next sync backfills them — recoverable. Aborting the source instead would cost us the
+postings themselves, which is not.
+
+Only fields a normalizer actually reads are listed. The feeds carry ~63 fields; the day we
+start reading one, it belongs here. Verified live 2026-07-16: all five feeds return one
+stable key-set across 500 records each, so a missing key means real drift, not an empty cell.
+"""
+from itertools import islice
+
+from toronto_bids import config
+from toronto_bids.sources.ckan import fetch_datastore, resolve_resource_id
+from toronto_bids.sources.odata import fetch_entityset
+
+# entityset -> (top-level fields, fields of each nested Awarded_Suppliers dict).
+# AwardedDate is solicitation-only; that asymmetry is why normalize_solicitation falls
+# back Date_Awarded -> AwardedDate and normalize_noncompetitive does not.
+_ODATA = {
+    "odata_solicitations": (config.ODATA_SOLICITATIONS, {
+        "Solicitation_Document_Number", "Status", "Solicitation_Document_Type",
+        "Solicitation_Form_Type", "Posting_Title", "Solicitation_Document_Description",
+        "Issue_Date", "Closing_Date", "High_Level_Category", "Client_Division",
+        "Buyer_Name", "Buyer_Email", "Buyer_Phone_Number", "Wards",
+        "Ariba_Discovery_Posting_Link", "id", "Awarded_Suppliers",
+    }, {"Successful_Bidder", "Award_Amount", "Date_Awarded", "AwardedDate"}),
+    "odata_noncompetitive": (config.ODATA_NONCOMPETITIVE, {
+        "Non_Competitive_Reference_Number", "Non_Competitive_Reason", "Client_Division",
+        "Council_Authority_Link_to_Staff_Report", "id", "Awarded_Suppliers",
+    }, {"Successful_Bidder", "Award_Amount", "Date_Awarded"}),
+}
+
+# CKAN dataset slug -> the datastore columns the normalizer reads.
+_CKAN = {
+    "ckan_awarded": (config.CKAN_AWARDED_SLUG, {
+        "Document Number", "RFx (Solicitation) Type", "High Level Category",
+        "Solicitation Document Description", "Division", "Buyer Name", "Buyer Email",
+        "Buyer Phone Number", "Successful Supplier", "Award",
+        "Award Authority Obtained Date",
+    }),
+    "ckan_open": (config.CKAN_OPEN_SLUG, {
+        "Document Number", "RFx (Solicitation) Type",
+        "NOIP (Notice of Intended Procurement) Type", "Issue Date", "Submission Deadline",
+        "High Level Category", "Solicitation Document Description", "Division",
+        "Buyer Name", "Buyer Email", "Buyer Phone Number", "Wards",
+    }),
+    "ckan_noncomp": (config.CKAN_NONCOMP_SLUG, {
+        "Workspace Number", "Supplier Name", "Reason", "Contract Amount",
+        "Contract Date", "Division",
+    }),
+}
+
+
+# Records to sample per OData feed. One is not enough: the feed carries not-yet-awarded
+# solicitations whose Awarded_Suppliers is empty, and record #1 is one of them today, so
+# sampling a single record would leave the nested fields silently unchecked. 15 of the
+# first 50 carry a supplier (measured 2026-07-16).
+_SAMPLE = 50
+
+
+def missing_fields(feed: str, record: dict | None, expected: set) -> list[str]:
+    """Drift complaints for one sampled record. Empty list == the feed still matches."""
+    if record is None:
+        return [f"{feed}: feed returned no records at all"]
+    gone = sorted(expected - record.keys())
+    if not gone:
+        return []
+    return [f"{feed}: missing {gone} — renamed or dropped; fix the normalizer and the "
+            f"declared fields in sources/schema_check.py together"]
+
+
+def check_odata(http, feed: str, entityset: str, expected: set, supplier_expected: set) -> list[str]:
+    records = list(islice(fetch_entityset(http, entityset, page_size=_SAMPLE), _SAMPLE))
+    problems = missing_fields(feed, records[0] if records else None, expected)
+    if problems:
+        return problems
+    # Awarded_Suppliers is a nested list whose fields drift independently of the record
+    # around it, and it's empty for anything not yet awarded. Scan the sample for a record
+    # that actually has one; finding none means we could not check, which is worth saying
+    # out loud rather than passing green.
+    supplier = next((s for r in records for s in (r.get("Awarded_Suppliers") or [])), None)
+    if supplier is None:
+        return [f"{feed}: no awarded supplier in the first {_SAMPLE} records, so "
+                f"{sorted(supplier_expected)} went unchecked"]
+    return missing_fields(f"{feed}.Awarded_Suppliers", supplier, supplier_expected)
+
+
+def check_ckan(http, feed: str, slug: str, expected: set) -> list[str]:
+    resource_id = resolve_resource_id(http, slug)
+    record = next(iter(fetch_datastore(http, resource_id, page_size=1)), None)
+    return missing_fields(feed, record, expected)
+
+
+class SchemaCheckSource:
+    """Samples one record per feed and fails the run if a field we read has gone missing."""
+
+    name = "schema_check"
+    overwrite = True
+
+    def fetch(self, http):
+        problems = []
+        for feed, (entityset, expected, supplier_expected) in _ODATA.items():
+            problems += check_odata(http, feed, entityset, expected, supplier_expected)
+        for feed, (slug, expected) in _CKAN.items():
+            problems += check_ckan(http, feed, slug, expected)
+        if problems:
+            raise ValueError("City feed check failed: " + "; ".join(problems))
+        return []  # a check, not a data source: it contributes no rows
+
+    def normalize(self, raw):
+        return []


### PR DESCRIPTION
Closes #10. Builds on #18 (already merged) — the dependency is real, not just ordering: drift detection is worthless unless failures are visible.

## The bug

Every normalizer reads fields by name:

```python
title=_clean(raw.get("Posting_Title")),
```

If the City renames or drops that field, `.get()` returns `None`, `title` NULLs out on every row written from then on, and **nothing anywhere complains**. Exactly one source validated its own shape (the suspended-firms HTML parser). The OData and CKAN normalizers had no equivalent.

The issue asked for "a schema from the 2 data sources". This declares it and enforces it.

## The design

`sources/schema_check.py` declares the fields each normalizer actually reads, and `SchemaCheckSource` samples the live feeds each sync to confirm they are still there. **It runs as an ordinary source**, which reuses machinery already in the pipeline rather than adding any:

- **per-source isolation** ⇒ drift is reported *without* stopping ingestion;
- **#18** ⇒ the report is loud (`sync_run` + stderr + non-zero exit).

Report-don't-abort is the deliberate part, and `db._upsert_keyed` is why it's right: every write `COALESCE`s, so **a NULL never overwrites a value already in the store**. Undetected drift costs *new* rows one column, and the next sync backfills them once the normalizer is fixed — recoverable. Aborting the source instead would cost us the postings themselves, which is not. For a project whose purpose is archiving records before they disappear, that asymmetry decides it.

This is also why the obvious one-line alternative — `raw["X"]` instead of `raw.get("X")`, letting KeyError signal drift — is the wrong trade: a rename of *any* field, however cosmetic, would abort the spine and ingest zero rows that day.

## Grounded in the real feeds, not guessed

Probed live before writing anything: all 5 feeds return **exactly one distinct key-set across 500 sampled records**, so a missing key means real drift, not an omitted null. The `AwardedDate`/`Date_Awarded` asymmetry the normalizer works around turns out to be real too — `AwardedDate` exists only on solicitations, not non-competitives — and the declared schema reflects that.

## Review caught two real ones

An adversarial review found both; both are fixed here:

1. **The nested `Awarded_Suppliers` check was verifying nothing in production.** It sampled record #1 only — and record #1 of the live feed is a *not-yet-awarded* solicitation with no suppliers, so all 4 nested fields were silently skipped. Only 15 of the first 50 records carry a supplier. It now scans the sample for an awarded record, and reports when it can't find one — "couldn't check" is not "checked".
2. **Nothing stopped the declared schema going stale** — the weak point of the whole design. `test_declared_schema_matches_what_the_normalizers_actually_read` diffs the declarations against the actual `.get()` calls using stdlib `ast`, so adding `raw.get("New_Field")` without declaring it now fails CI instead of quietly restoring the bug.

## Verification

- **159 tests pass** (was 156).
- **Live**: the check passes against all 5 real feeds today.
- **Live negative**: simulated a renamed field → `exit 1` with the error on stderr, **while 7,444 solicitations still ingested**. That is the whole design in one run.
- **Both new guards mutation-tested**: undeclaring a field fails the AST test naming it; a bogus nested field fails against real data, proving the nested path actually executes now.

## Left for later (deliberately)

The issue's other two items are untouched and still open questions: an automated cross-source count check ("CKAN has 40 awards OData doesn't"), and the per-source award double-count, which needs fuzzy supplier de-dup and is a phase of its own. Both are documented in `scrapers/README.md`. Say the word if you want either now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RciieRV1itdZnm3dkbWQwN