### PR TITLE
fix(scraper): bridge Ariba postings from the spine link (#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,10 @@ Normalizers read feed fields with `raw.get(...)`, so a field the City renames si
 ### Linking
 
 - Everything competitive is keyed on the normalized 10-digit `document_number` (`linking/document_number.py`: strip non-digits, require exactly 10, reject a placeholder denylist). Non-competitive contracts live in a separate keyspace (`workspace_number`) — there is no join between them.
-- After every sync, `linking/supplier.py:build_supplier_dimension` rebuilds the supplier dimension from scratch: a normalized string key groups raw names across `award`/`noncompetitive`/`suspended_firm`; `supplier_id` FKs are cleared and re-backfilled each run. Legal suffixes (Inc, Ltd) are deliberately kept in the key.
-- Ariba postings bridge to a document number via the detail `externalRfxId`, falling back to a `Doc(\d{10})` token in the title; unbridged postings keep a NULL `document_number`.
+- Two linking passes run after the sources on every sync, isolated the same way sources are (`pipeline._run_linking_pass` — a failure is recorded in `sync_run` and returned, never raised). They run regardless of `--only`, since they read whatever is in the store.
+- `linking/supplier.py:build_supplier_dimension` rebuilds the supplier dimension from scratch: a normalized string key groups raw names across `award`/`noncompetitive`/`suspended_firm`; `supplier_id` FKs are cleared and re-backfilled each run. Legal suffixes (Inc, Ltd) are deliberately kept in the key.
+- `linking/ariba.py:bridge_postings_to_spine` is the primary Ariba bridge: `solicitation.ariba_posting_link` embeds the rfx id (`/RfxEvent/preview/<id>`), so the spine names the join outright. `sources/ariba.py` also bridges inline from the detail `externalRfxId`, falling back to a `Doc(\d{10})` title token, but that path depends on the detail call — which 500s ~48% of the time — so it bridges roughly half. The linking pass fills the rest and only fills NULLs (the two agree wherever both fire). Older spine rows carry dead link formats (`discovery.ariba.com/rfx/`, merx, Lotus Notes, `n/a`) that are deliberately unparsed: those postings are long closed and absent from `ariba_posting`.
+- A posting with no `document_number`, or one whose `document_number` has no `solicitation` row, stays unlinked and surfaces in the export's `unlinked_ariba_postings`.
 
 ### Council enrichment (`sources/council.py`) — not a Source
 

--- a/scrapers/tests/test_ariba_bridge.py
+++ b/scrapers/tests/test_ariba_bridge.py
@@ -1,0 +1,64 @@
+from toronto_bids.linking.ariba import bridge_postings_to_spine, rfx_id_from_link
+from toronto_bids.models import AribaPosting, Solicitation
+from toronto_bids.store import db
+
+_LINK = ("https://portal.us.bn.cloud.ariba.com/dashboard/public/appext/comsapsbncdiscoveryui"
+         "#/RfxEvent/preview/1110017742?anId=ANONYMOUS")
+
+
+def _seed(conn, *, link=_LINK, doc="5732578927", rfx="1110017742", bridged=None):
+    db.upsert_row(conn, Solicitation(document_number=doc, status="Open",
+                                     ariba_posting_link=link, source="odata"), overwrite=True)
+    db.upsert_row(conn, AribaPosting(rfx_id=rfx, document_number=bridged,
+                                     source="ariba_discovery"), overwrite=True)
+    conn.commit()
+
+
+def test_rfx_id_from_link():
+    assert rfx_id_from_link(_LINK) == "1110017742"
+    # dead formats the spine still carries for long-closed postings
+    assert rfx_id_from_link("https://discovery.ariba.com/rfx/22538756") is None
+    assert rfx_id_from_link("https://www.merx.com/solicitations/open-bids/Jack-Layton") is None
+    assert rfx_id_from_link("n/a") is None
+    assert rfx_id_from_link(None) is None
+
+
+def test_bridges_unbridged_posting_via_spine_link(conn):
+    _seed(conn)
+    assert bridge_postings_to_spine(conn) == 1
+    assert conn.execute(
+        "SELECT document_number FROM ariba_posting WHERE rfx_id='1110017742'"
+    ).fetchone()[0] == "5732578927"
+
+
+def test_leaves_already_bridged_posting_alone(conn):
+    # sources/ariba.py already bridged this one; the spine agrees, so nothing to do.
+    _seed(conn, bridged="5732578927")
+    assert bridge_postings_to_spine(conn) == 0
+    assert conn.execute(
+        "SELECT document_number FROM ariba_posting WHERE rfx_id='1110017742'"
+    ).fetchone()[0] == "5732578927"
+
+
+def test_dead_link_format_bridges_nothing(conn):
+    _seed(conn, link="https://discovery.ariba.com/rfx/22538756", rfx="22538756")
+    assert bridge_postings_to_spine(conn) == 0
+    assert conn.execute(
+        "SELECT document_number FROM ariba_posting WHERE rfx_id='22538756'"
+    ).fetchone()[0] is None
+
+
+def test_posting_with_no_matching_spine_row_stays_unbridged(conn):
+    db.upsert_row(conn, AribaPosting(rfx_id="9999999999", source="ariba_discovery"),
+                  overwrite=True)
+    conn.commit()
+    assert bridge_postings_to_spine(conn) == 0
+    assert conn.execute(
+        "SELECT document_number FROM ariba_posting WHERE rfx_id='9999999999'"
+    ).fetchone()[0] is None
+
+
+def test_is_idempotent(conn):
+    _seed(conn)
+    assert bridge_postings_to_spine(conn) == 1
+    assert bridge_postings_to_spine(conn) == 0  # second run has nothing left to fill

--- a/scrapers/tests/test_pipeline.py
+++ b/scrapers/tests/test_pipeline.py
@@ -48,8 +48,8 @@ def test_sync_runs_all_and_one_failure_does_not_stop_others(conn):
     also_good = FakeSource("ckan_awarded", [Solicitation("5749398870", source="ckan_awarded")], overwrite=False)
     failures = pipeline.sync(conn, http=None, sources=[good, bad, also_good])
     assert db.counts(conn)["solicitation"] == 2
-    # 3 sources + 1 supplier_dimension sync_run = 4
-    assert db.counts(conn)["sync_run"] == 4
+    # 3 sources + 2 linking passes (ariba_bridge, supplier_dimension) = 5
+    assert db.counts(conn)["sync_run"] == 5
     # the failure is isolated but NOT swallowed: sync hands it back
     assert [name for name, _ in failures] == ["ckan_open"]
     assert "network exploded" in failures[0][1]
@@ -72,8 +72,8 @@ def test_sync_only_filters_sources(conn):
     other = FakeSource("ckan_open", [Solicitation("5749398870", source="ckan_open")])
     pipeline.sync(conn, http=None, sources=[good, other], only=["odata_solicitations"])
     assert db.counts(conn)["solicitation"] == 1
-    # 1 source + 1 supplier_dimension sync_run = 2
-    assert db.counts(conn)["sync_run"] == 2
+    # 1 source + 2 linking passes (which run regardless of --only) = 3
+    assert db.counts(conn)["sync_run"] == 3
 
 
 def test_sync_runs_supplier_dimension_after_sources(conn):
@@ -87,6 +87,22 @@ def test_sync_runs_supplier_dimension_after_sources(conn):
     assert db.counts(conn)["supplier"] == 1
     row = conn.execute("SELECT status FROM sync_run WHERE source='supplier_dimension'").fetchone()
     assert row is not None and row["status"] == "ok"
+
+
+def test_sync_ariba_bridge_failure_is_isolated(conn, monkeypatch):
+    from toronto_bids import pipeline
+    def boom(_conn):
+        raise RuntimeError("bridge exploded")
+    monkeypatch.setattr(pipeline, "bridge_postings_to_spine", boom)
+    failures = pipeline.sync(conn, http=None, sources=[])
+    row = conn.execute("SELECT status, error FROM sync_run WHERE source='ariba_bridge'").fetchone()
+    assert row["status"] == "failed"
+    assert "bridge exploded" in row["error"]
+    assert failures == [("ariba_bridge", "bridge exploded")]
+    # the pass behind it still ran: one failure never stops the next
+    assert conn.execute(
+        "SELECT status FROM sync_run WHERE source='supplier_dimension'"
+    ).fetchone()["status"] == "ok"
 
 
 def test_sync_supplier_dimension_failure_is_isolated(conn, monkeypatch):

--- a/scrapers/toronto_bids/linking/ariba.py
+++ b/scrapers/toronto_bids/linking/ariba.py
@@ -1,0 +1,55 @@
+"""Bridge Ariba postings to the spine using the link the City already gives us (#67).
+
+`sources/ariba.py` bridges a posting by reading `externalRfxId` off the detail call and
+falling back to a `Doc##########` token in the title — reconstructing a join the spine hands
+us directly, and dropping roughly half of it on the way (22 of 44 open solicitations linked).
+`solicitation.ariba_posting_link` carries the rfx id, so this pass just reads it.
+
+Runs after the sources, like `build_supplier_dimension`: postings and spine rows both exist
+by then, and the ~48% of detail calls that 500 (see the Ariba gotcha) cost us nothing here —
+the bridge no longer depends on the detail call succeeding.
+"""
+import re
+
+# The modern Discovery link: .../RfxEvent/preview/1110017742?anId=ANONYMOUS
+# Older spine rows carry dead formats (discovery.ariba.com/rfx/, merx.com, the retired Lotus
+# Notes callawards.nsf, and literal "n/a"). Those postings closed long ago and are absent from
+# ariba_posting — the public detail API serves open postings only — so parsing them buys
+# nothing. Deliberately unhandled rather than overlooked.
+_RFX_ID = re.compile(r"/RfxEvent/preview/(\d+)")
+
+
+def rfx_id_from_link(link: str | None) -> str | None:
+    """The Ariba rfx id in a spine posting link, or None if it is not the modern format."""
+    if not link:
+        return None
+    match = _RFX_ID.search(str(link))
+    return match.group(1) if match else None
+
+
+def bridge_postings_to_spine(conn) -> int:
+    """Fill `ariba_posting.document_number` from the spine's link. Idempotent.
+
+    Returns the number of postings newly bridged.
+
+    Only fills NULLs. Where `sources/ariba.py` already bridged a posting the two agree —
+    verified against every currently-bridged posting — so there are no conflicts to resolve,
+    only gaps to fill. If they ever diverge, the spine is authoritative and this should
+    become an overwrite; it is a fill today because that is all the data asks for.
+    """
+    pairs = [
+        (row["document_number"], rfx)
+        for row in conn.execute(
+            "SELECT document_number, ariba_posting_link FROM solicitation "
+            "WHERE ariba_posting_link IS NOT NULL AND document_number IS NOT NULL"
+        )
+        if (rfx := rfx_id_from_link(row["ariba_posting_link"]))
+    ]
+    before = conn.total_changes
+    conn.executemany(
+        "UPDATE ariba_posting SET document_number = ? "
+        "WHERE rfx_id = ? AND document_number IS NULL",
+        pairs,
+    )
+    conn.commit()
+    return conn.total_changes - before

--- a/scrapers/toronto_bids/pipeline.py
+++ b/scrapers/toronto_bids/pipeline.py
@@ -5,6 +5,7 @@ from toronto_bids.sources.schema_check import SchemaCheckSource
 from toronto_bids.sources.suspended_firms import SuspendedFirmsSource
 from toronto_bids.store import db
 from toronto_bids import config
+from toronto_bids.linking.ariba import bridge_postings_to_spine
 from toronto_bids.linking.supplier import build_supplier_dimension
 
 
@@ -62,17 +63,21 @@ def sync(conn, http, sources=None, only=None) -> list[tuple[str, str]]:
         *_, error = run_source(conn, http, source)
         if error:
             failures.append((source.name, error))
-    error = _run_supplier_dimension(conn)
-    if error:
-        failures.append(("supplier_dimension", error))
+    # Linking passes run after every source, and regardless of --only: they read whatever is
+    # in the store, so a partial sync still leaves the links consistent with it.
+    for name, link in (("ariba_bridge", bridge_postings_to_spine),
+                       ("supplier_dimension", build_supplier_dimension)):
+        error = _run_linking_pass(conn, name, link)
+        if error:
+            failures.append((name, error))
     return failures
 
 
-def _run_supplier_dimension(conn) -> str | None:
-    """Rebuild the supplier dimension after sources. Isolated: never raises out of sync."""
-    run_id = db.start_sync_run(conn, "supplier_dimension")
+def _run_linking_pass(conn, name, link) -> str | None:
+    """Run one post-source linking pass. Isolated like a source: never raises out of sync."""
+    run_id = db.start_sync_run(conn, name)
     try:
-        n = build_supplier_dimension(conn)
+        n = link(conn)
         db.finish_sync_run(conn, run_id, status="ok", rows_fetched=n, rows_upserted=n)
         return None
     except Exception as exc:


### PR DESCRIPTION
Closes #67.

## The problem

`sources/ariba.py` bridges a posting to a document number by reading `externalRfxId` off the Ariba detail call, falling back to a `Doc(\d{10})` token in the title. Detail calls 500 about 48% of the time (a documented, expected gotcha), so the bridge landed on roughly half the postings — 25 of 42 — and the rest kept a NULL `document_number`.

That whole chain reconstructs a join the City hands us directly. `solicitation.ariba_posting_link` embeds the rfx id:

```
https://portal.us.bn.cloud.ariba.com/dashboard/public/appext/comsapsbncdiscoveryui#/RfxEvent/preview/1110017742?anId=ANONYMOUS
                                                                                                    ^^^^^^^^^^ = ariba_posting.rfx_id
```

All 44 genuinely-open solicitations carry one. So the spine names the pairing outright, with no network call and no dependence on the flaky detail endpoint.

## The change

`linking/ariba.py:bridge_postings_to_spine` — a post-source linking pass alongside `build_supplier_dimension`, parsing the rfx id out of the spine link and filling `ariba_posting.document_number`.

Measured against the live store:

| | before | after |
|---|---|---|
| postings bridged | 25/42 | **42/42** |
| open solicitations joined to a posting | 22/44 | **39/44** |
| export `unlinked_ariba_postings` | 19 | **2** |

The 5 open solicitations still without a posting link to Ariba events that Discovery's search doesn't return — upstream, not something code reaches. The 2 remaining unlinked postings are historical rows whose document numbers predate the spine.

## Notes for review

- **Fills NULLs only.** Wherever both bridges fire they agree — verified across every currently-bridged posting — so there are no conflicts to resolve, only gaps. The docstring records that the spine is authoritative if they ever diverge.
- **The inline bridge stays.** It still works for postings that aren't on the spine, and removing it isn't needed to fix this.
- **Dead link formats are deliberately unparsed.** Older spine rows carry `discovery.ariba.com/rfx/`, merx.com, retired Lotus Notes URLs, and literal `n/a`. Those postings closed long ago and are absent from `ariba_posting` (the public detail API serves open postings only), so parsing them buys nothing. Called out in the module comment so it reads as a decision, not an oversight.
- **`_run_supplier_dimension` generalized to `_run_linking_pass`** so both passes share the per-source isolation wrapper instead of duplicating it. Linking passes run regardless of `--only`, which matches the existing behaviour.

## Testing

`tests/test_ariba_bridge.py` — 6 new tests covering the happy path, already-bridged rows left alone, dead link formats, postings with no spine row, and idempotency. Plus `test_sync_ariba_bridge_failure_is_isolated` proving the new pass fails like a source does and doesn't stop the pass behind it.

166 passed. Two `test_pipeline.py` sync_run counts updated for the extra pass.

## Context

Found while investigating #67, which I had originally framed as a coverage gap ("42 of 849 open solicitations"). That premise was wrong — only 44 solicitations are genuinely open; the other 805 are stale `Open` rows the City never transitioned. Ariba's coverage was already ~95%. The real defect was bridging, which is what this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)