### PR TITLE
feat(scraper): pull the capital project pipeline; decline pcard and consulting (#69)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Data flow: sources fetch/normalize → SQLite upsert (`store/db.py`) → supplie
 
 ### Ordering and overwrite semantics
 
-Order in `default_sources()` matters: `schema_check` first (drift detection), then the OData spine (`overwrite=True`, authoritative), then CKAN backfill (`overwrite=False`), then Ariba and suspended firms. Both upsert modes COALESCE (`db._upsert_keyed`): with `overwrite=True` a new non-NULL value wins but NULL never wipes an existing value; with `overwrite=False` only currently-NULL columns get filled. Rows are never deleted — archive semantics with `first_seen`/`last_seen` on every data table.
+Order in `default_sources()` matters: `schema_check` first (drift detection), then the OData spine (`overwrite=True`, authoritative), then CKAN backfill (`overwrite=False`), then Ariba and suspended firms. `ckan_pipeline` is the one CKAN source with `overwrite=True`: no spine covers the forward-looking `capital_project` table, so CKAN is authoritative there (#69). Both upsert modes COALESCE (`db._upsert_keyed`): with `overwrite=True` a new non-NULL value wins but NULL never wipes an existing value; with `overwrite=False` only currently-NULL columns get filled. Rows are never deleted — archive semantics with `first_seen`/`last_seen` on every data table.
 
 ### Per-source isolation and failure surfacing
 

--- a/docs/superpowers/specs/2026-07-14-toronto-bids-scraper-rewrite-design.md
+++ b/docs/superpowers/specs/2026-07-14-toronto-bids-scraper-rewrite-design.md
@@ -65,11 +65,33 @@ archiving currently-open posting detail.
 | **CKAN `tobids-awarded-contracts`** | Competitive awards, one row per successful supplier (~7,574 rows). `Document Number`, RFx type, `Successful Supplier`, `Award` ($), date, division, buyer. | `datastore_search?resource_id=<uuid>` or `/datastore/dump/<uuid>` (one request) | Live; newest award = today |
 | **CKAN `tobids-all-open-solicitations`** | Solicitation notices (~903 rows; archive back to 2008 — only ~44 truly open). `Document Number`, RFx/NOIP type, division, buyer, wards. | `datastore_search` / dump | Live |
 | **CKAN `tobids-non-competitive-contracts`** | Sole-source awards (~2,920 rows). `Workspace Number`, `Reason`, `Supplier Name`, `Contract Amount`, `Contract Date`. | `datastore_search` / dump | Live |
-| **CKAN `capital-project-pipeline`** | 46 forward-looking upcoming solicitations (no doc/award ids yet). | `datastore_search?resource_id=<uuid>` | ~6 wks |
-| **CKAN `pcard-expenditures`** | Purchasing-card spend (~820k rows), free-text merchant + division. **Adjacent — not joinable.** | `datastore_search` / dump | ~5-mo lag |
-| **CKAN `consulting-services-expenditures`** | Annual consulting spend (XLSX only, no datastore API). **Adjacent — not joinable.** | `package_show` → download XLSX | Annual |
+| **CKAN `capital-project-pipeline`** | 46 forward-looking upcoming solicitations (no doc/award ids yet). Built 2026-07-16 (#69) — see §2.1.1. | `datastore_search?resource_id=<uuid>` | ~6 wks |
 | **Ariba Discovery leads search** (`doIndexedSearch`) | Enumerate currently-open Toronto postings + their `rfxID` (Ariba internal posting id). | `POST https://service.ariba.com/Network/discoveryweb/search/public/v1/doIndexedSearch?siteName=Quote` body `{"pageSize":1000,"pageNum":0,"searchType":"Quote","sortBy":"RESPONSE_DEAD_LINE","filters":[]}`; filter `customerName=="City of Toronto"` client-side | Live |
 | **Ariba Discovery detail** (`/rfx/{rfxId}`) | Per-posting detail incl. `externalRfxId` (= `Doc##########`) needed to join to the spine, UNSPSC categories, dates. | `GET https://service.ariba.com/Network/discoveryweb/api/public/v1/rfx/{rfxId}` with `Accept: application/json` | Live, **open postings only** (closed → 401); **~48% return HTTP 500 → retry/skip** |
+
+#### 2.1.1 Considered and declined (resolved 2026-07-16, #69)
+
+Two datasets were listed in this table as Tier 1 "sources we pull" and never implemented.
+That was not an oversight: **they were listed because they are easy to fetch, not because they
+belong in this archive**, and §2.5.6 already says so — "no join key; orthogonal spend data".
+The table contradicted itself. Recording the decision rather than leaving every future reader
+to re-litigate whether the implementation is incomplete.
+
+| Declined | Why |
+|---|---|
+| **`pcard-expenditures`** | **819,993 rows** (measured 2026-07-16) of free-text merchant names, ~5-month lag, no join key. It would dominate the export artifact while linking to nothing, and feeding 820k more free-text merchant strings to the fuzzy supplier dimension (§2.5.4) would manufacture false links, not insight. The City publishes it directly; we would add nothing. |
+| **`consulting-services-expenditures`** | XLSX only — **no datastore API** (confirmed 2026-07-16: 4 resources, 0 datastore-active) — annual, not joinable. Lowest value-to-effort of the three. |
+
+`capital-project-pipeline` **was** built, because it is a different case despite sitting in the
+same row of the table. It does not join the spine either — a project has no document number
+until it is actually solicited — but it is the only forward-looking source in the entire
+landscape, it is 46 rows and one request, and **the City refreshes it, so entries drop off as
+they are sourced**. What the City *planned* to buy is preserved nowhere else once it stops
+planning. That vanishing act is precisely what this archive exists for, whereas pcard spend
+sits permanently on the City's own portal.
+
+It is the one CKAN source with `overwrite=True`: no spine covers it, so CKAN is authoritative
+there and a project whose target year slips must land rather than be COALESCEd away.
 
 **CKAN API base:** `https://ckan0.cf.opendata.inter.prod-toronto.ca/api/3/action/`
 Resolve CKAN resource UUIDs **at runtime** via `package_show?id=<slug>` — they rotate on
@@ -285,8 +307,9 @@ Keyed on the normalized `document_number` except where noted. Rows are **never d
   `committee`; `term_id`.
 - **`background_pdf`** (Tier 3) — `id` PK; `year`; `committee`; `url`; `local_path`;
   `extracted_text`; `linked_reference` FK.
-- **`pcard`**, **`consulting`**, **`capital_pipeline`** — adjacent tables, **explicitly
-  marked unlinked** (no shared key with the spine).
+- **`capital_project`** — forward-looking, **explicitly unlinked** (no shared key with the
+  spine; a project has no document number until it is solicited). Built 2026-07-16 (#69).
+  `pcard` and `consulting` were declined — see §2.1.1.
 - **`sync_run`** (provenance/observability) — `id` PK; `source`; `started_at`; `finished_at`;
   `status` (ok/failed); `rows_fetched`; `rows_upserted`; `error`.
 
@@ -351,8 +374,8 @@ Each phase ships something that works standalone and gets its own implementation
   `feis_non_competitive`) + CKAN adapters (awarded / open / non-competitive) + the linking
   pass on `document_number` → SQLite. **Reproduces and exceeds the old scraper's mission with
   zero browser.**
-- **P1.5 — adjacent datasets (optional)**: `capital-project-pipeline`, `pcard`, `consulting`
-  as clearly-unlinked tables.
+- **P1.5 — adjacent datasets (optional)**: `capital-project-pipeline` as a clearly-unlinked
+  table. Done 2026-07-16 (#69); `pcard` and `consulting` declined, see §2.1.1.
 - **P2 — Ariba Discovery JSON**: `doIndexedSearch` + `/rfx/{id}` detail adapters, the
   rfxId↔document_number bridge, open-posting archival. Still no auth/browser.
 - **P3 — publish seam**: `Exporter` interface + `json_export.py`; `tb export`.

--- a/scrapers/tests/test_capital_pipeline.py
+++ b/scrapers/tests/test_capital_pipeline.py
@@ -1,0 +1,97 @@
+"""#69: the forward-looking capital project pipeline.
+
+Solicitations the City *intends* to issue. No document_number — a project only gets one once
+it is actually solicited — so this joins nothing and lives in its own table.
+"""
+import pytest
+
+from toronto_bids.sources.ckan import CkanSource, normalize_capital_project
+from toronto_bids.store import db
+
+RAW = {
+    "_id": "1",
+    "No.": "2",
+    "Name and Construction Contract Number":
+        "Dufferin Transfer Station - Compactors Replacement  - 25ECS-MI-02SW",
+    "Type of Work": "Construction",
+    "Scope of Work: Detailed Description": "Replace the compactors at Dufferin.",
+    "Delivery Division": "Solid Waste Management Services",
+    "Project Owner (Division)": "Solid Waste Management Services",
+    "Target Sourcing Year": "2026",
+    "Target Award Year": "2026",
+    "Sourcing Type": "RFT",
+    "Estimated Range": "Up to $5M",
+    "Estimated Contract Term (Months)": "24",
+}
+
+
+def test_normalizes_a_pipeline_row():
+    project, = normalize_capital_project(RAW)
+    assert project.name == RAW["Name and Construction Contract Number"]
+    assert project.type_of_work == "Construction"
+    assert project.target_sourcing_year == "2026"
+    assert project.sourcing_type == "RFT"
+    assert project.estimated_range == "Up to $5M"
+    assert project.source == "ckan_pipeline"
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("Dufferin Transfer Station - Compactors Replacement  - 25ECS-MI-02SW", "25ECS-MI-02SW"),
+    ("Dufferin Transfer Station - Paving - 25SWM-IRM-042CDU", "25SWM-IRM-042CDU"),
+    ("Basement Flooding Protection Program - 23ECS-LU-02FP", "23ECS-LU-02FP"),
+    # Many projects are named without one; that is not an error.
+    ("Sewage Pumping Station Planning and Environmental Assessment Study", None),
+])
+def test_teases_the_construction_contract_number_out_of_the_name(name, expected):
+    """Nothing joins on it today, but it is the only identifier a future join could use."""
+    project, = normalize_capital_project({"Name and Construction Contract Number": name})
+    assert project.contract_number == expected
+
+
+def test_a_row_with_no_name_is_skipped():
+    assert list(normalize_capital_project({"Type of Work": "Construction"})) == []
+
+
+def test_stores_and_is_idempotent(conn):
+    project, = normalize_capital_project(RAW)
+    db.upsert_row(conn, project, overwrite=True)
+    db.upsert_row(conn, project, overwrite=True)
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM capital_project").fetchone()[0] == 1
+    assert db.counts(conn)["capital_project"] == 1
+
+
+def test_a_refreshed_project_updates_rather_than_being_coalesced_away(conn):
+    """CKAN is authoritative here — no spine covers the pipeline — so the source overwrites.
+
+    A project whose target year slips must land; with overwrite=False the old year would win.
+    """
+    first, = normalize_capital_project(RAW)
+    db.upsert_row(conn, first, overwrite=True)
+    moved, = normalize_capital_project(dict(RAW, **{"Target Sourcing Year": "2027"}))
+    db.upsert_row(conn, moved, overwrite=True)
+    conn.commit()
+    assert conn.execute("SELECT target_sourcing_year FROM capital_project").fetchone()[0] == "2027"
+
+
+def test_the_pipeline_source_overwrites_unlike_the_other_ckan_sources():
+    from toronto_bids import config, pipeline
+
+    by_name = {s.name: s for s in pipeline.default_sources()}
+    assert by_name["ckan_pipeline"].overwrite is True
+    assert by_name["ckan_awarded"].overwrite is False   # CKAN backfills the OData spine
+    assert by_name["ckan_open"].overwrite is False
+    assert CkanSource(name="x", slug=config.CKAN_PIPELINE_SLUG,
+                      kind="capital_pipeline").overwrite is False   # default stays False
+
+
+def test_capital_projects_reach_the_export(conn):
+    from toronto_bids.export.document import build_export_document
+
+    project, = normalize_capital_project(RAW)
+    db.upsert_row(conn, project, overwrite=True)
+    conn.commit()
+    doc = build_export_document(conn, generated_at="2026-07-16T00:00:00Z")
+    assert len(doc["capital_projects"]) == 1
+    assert doc["capital_projects"][0]["contract_number"] == "25ECS-MI-02SW"
+    assert doc["meta"]["counts"]["capital_project"] == 1

--- a/scrapers/tests/test_schema_check.py
+++ b/scrapers/tests/test_schema_check.py
@@ -50,6 +50,13 @@ CKAN_NONCOMP = {
     "Workspace Number": "WS-1", "Supplier Name": "Acme", "Reason": "Sole source",
     "Contract Amount": "5", "Contract Date": "2025-02-02", "Division": "Fleet", "_id": 1,
 }
+CKAN_PIPELINE = {
+    "Name and Construction Contract Number": "Dufferin Compactors - 25ECS-MI-02SW",
+    "Type of Work": "Construction", "Scope of Work: Detailed Description": "Replace them",
+    "Delivery Division": "Solid Waste", "Project Owner (Division)": "Solid Waste",
+    "Target Sourcing Year": "2026", "Target Award Year": "2026", "Sourcing Type": "RFT",
+    "Estimated Range": "Up to $5M", "Estimated Contract Term (Months)": "24", "_id": 1,
+}
 
 
 class FakeHttp:
@@ -60,7 +67,8 @@ class FakeHttp:
     $skip loop and fetch_datastore's offset loop actually terminate.
     """
 
-    def __init__(self, solicitation=None, noncomp=None, awarded=None, open_=None, ckan_noncomp=None):
+    def __init__(self, solicitation=None, noncomp=None, awarded=None, open_=None,
+                 ckan_noncomp=None, pipeline_=None):
         def page(value, default):
             value = default if value is None else value
             return [value] if isinstance(value, dict) and value else list(value or [])
@@ -71,6 +79,7 @@ class FakeHttp:
             "awarded": page(awarded, CKAN_AWARDED),
             "open": page(open_, CKAN_OPEN),
             "ckan_noncomp": page(ckan_noncomp, CKAN_NONCOMP),
+            "pipeline": page(pipeline_, CKAN_PIPELINE),
         }
 
     def get_json(self, url, params=None):
@@ -80,7 +89,8 @@ class FakeHttp:
         if "datastore_search" in url:
             key = {config.CKAN_AWARDED_SLUG: "awarded",
                    config.CKAN_OPEN_SLUG: "open",
-                   config.CKAN_NONCOMP_SLUG: "ckan_noncomp"}[params["resource_id"]]
+                   config.CKAN_NONCOMP_SLUG: "ckan_noncomp",
+                   config.CKAN_PIPELINE_SLUG: "pipeline"}[params["resource_id"]]
             offset, limit = params["offset"], params["limit"]
             return {"result": {"records": self.records[key][offset:offset + limit]}}
         key = "noncomp" if config.ODATA_NONCOMPETITIVE in url else "solicitation"
@@ -209,3 +219,20 @@ def test_drift_is_isolated_and_surfaced_not_swallowed(conn):
     assert [name for name, _ in failures] == ["schema_check"]  # surfaced to the CLI
     assert "Status" in failures[0][1]
     assert db.counts(conn)["solicitation"] == 1  # ingestion continued anyway
+
+
+def test_detects_a_renamed_pipeline_column():
+    """The forward-looking feed is guarded like every other (#69)."""
+    drifted = {**CKAN_PIPELINE}
+    drifted["Project Name"] = drifted.pop("Name and Construction Contract Number")
+    with pytest.raises(ValueError, match="Name and Construction Contract Number"):
+        SchemaCheckSource().fetch(FakeHttp(pipeline_=drifted))
+
+
+def test_every_declared_ckan_feed_has_a_source_that_reads_it():
+    """A declared feed with no source, or a source with no declaration, is a bug either way."""
+    from toronto_bids.sources.schema_check import _CKAN
+
+    slugs_declared = {slug for slug, _fields in _CKAN.values()}
+    slugs_pulled = {s.slug for s in pipeline.default_sources() if hasattr(s, "slug")}
+    assert slugs_declared == slugs_pulled

--- a/scrapers/toronto_bids/config.py
+++ b/scrapers/toronto_bids/config.py
@@ -12,6 +12,8 @@ ODATA_BASE = "https://secure.toronto.ca/c3api_data/v2/DataAccess.svc/pmmd_solici
 CKAN_AWARDED_SLUG = "tobids-awarded-contracts"
 CKAN_OPEN_SLUG = "tobids-all-open-solicitations"
 CKAN_NONCOMP_SLUG = "tobids-non-competitive-contracts"
+# Forward-looking: solicitations the City intends to issue (#69). No document_number yet.
+CKAN_PIPELINE_SLUG = "capital-project-pipeline"
 
 # OData entity sets.
 ODATA_SOLICITATIONS = "feis_solicitation_published"

--- a/scrapers/toronto_bids/export/document.py
+++ b/scrapers/toronto_bids/export/document.py
@@ -69,6 +69,10 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
         for nc in _rows(conn, "SELECT * FROM noncompetitive ORDER BY workspace_number")
     ]
 
+    # Forward-looking and joinable to nothing — a project has no document_number until it
+    # is actually solicited. Top-level rather than nested for that reason (#69).
+    capital_projects = _rows(conn, "SELECT * FROM capital_project ORDER BY name")
+
     suspended_firms = [
         _drop(firm, "id")
         for firm in _rows(conn, "SELECT * FROM suspended_firm ORDER BY supplier_name_raw, council_authority")
@@ -104,6 +108,7 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
         "noncompetitive": noncompetitive,
         "suspended_firms": suspended_firms,
         "suppliers": suppliers,
+        "capital_projects": capital_projects,
         "council_items": council_items,
         "unlinked_ariba_postings": unlinked,
         "unlinked_awards": unlinked_awards,

--- a/scrapers/toronto_bids/models.py
+++ b/scrapers/toronto_bids/models.py
@@ -100,6 +100,28 @@ class Supplier:
 
 
 @dataclass(frozen=True)
+class CapitalProject:
+    """A solicitation the City intends to issue but has not yet (#69).
+
+    Forward-looking, so it has no document_number and never joins the spine — a project
+    only gets one when it is actually solicited. Keyed on the City's combined name+contract
+    string because 'No.' is a row index that churns on every refresh.
+    """
+    name: str
+    contract_number: str | None = None    # e.g. '25ECS-MI-02SW', teased out of `name`
+    type_of_work: str | None = None
+    scope: str | None = None
+    delivery_division: str | None = None
+    owner_division: str | None = None
+    target_sourcing_year: str | None = None
+    target_award_year: str | None = None
+    sourcing_type: str | None = None
+    estimated_range: str | None = None
+    estimated_term_months: str | None = None
+    source: str = ""
+
+
+@dataclass(frozen=True)
 class CouncilItem:
     reference: str
     title: str | None = None

--- a/scrapers/toronto_bids/pipeline.py
+++ b/scrapers/toronto_bids/pipeline.py
@@ -23,6 +23,10 @@ def default_sources():
         CkanSource(name="ckan_awarded", slug=config.CKAN_AWARDED_SLUG, kind="awarded"),
         CkanSource(name="ckan_open", slug=config.CKAN_OPEN_SLUG, kind="open"),
         CkanSource(name="ckan_noncomp", slug=config.CKAN_NONCOMP_SLUG, kind="noncompetitive"),
+        # No spine covers the forward-looking pipeline, so CKAN is authoritative for it
+        # and it overwrites (#69).
+        CkanSource(name="ckan_pipeline", slug=config.CKAN_PIPELINE_SLUG,
+                   kind="capital_pipeline", overwrite=True),
         AribaDiscoverySource(),
         SuspendedFirmsSource(),
     ]

--- a/scrapers/toronto_bids/sources/base.py
+++ b/scrapers/toronto_bids/sources/base.py
@@ -1,8 +1,9 @@
 from typing import Iterable, Protocol, runtime_checkable
 
-from toronto_bids.models import AribaPosting, Award, NonCompetitive, Solicitation, SuspendedFirm
+from toronto_bids.models import (AribaPosting, Award, CapitalProject, NonCompetitive,
+                                  Solicitation, SuspendedFirm)
 
-Row = Solicitation | Award | NonCompetitive | AribaPosting | SuspendedFirm
+Row = Solicitation | Award | NonCompetitive | AribaPosting | SuspendedFirm | CapitalProject
 
 
 @runtime_checkable

--- a/scrapers/toronto_bids/sources/ckan.py
+++ b/scrapers/toronto_bids/sources/ckan.py
@@ -1,8 +1,9 @@
+import re
 from typing import Iterable, Iterator
 
 from toronto_bids import config
 from toronto_bids.linking.document_number import normalize_document_number
-from toronto_bids.models import Award, NonCompetitive, Solicitation
+from toronto_bids.models import Award, CapitalProject, NonCompetitive, Solicitation
 from toronto_bids.sources.base import Row
 
 
@@ -112,24 +113,57 @@ def normalize_noncompetitive(raw: dict):
     )
 
 
+# The City packs a construction contract number into the project name:
+#   'Dufferin Transfer Station - Compactors Replacement  - 25ECS-MI-02SW'
+# Same shape as the contract numbers seen on Bid Award Panel agendas ('22TR-OM-104-SC-TM')
+# and in the legacy archive's folder names ('22ECS-TI-22SP'). Nothing joins on it today —
+# these projects have no document number yet — but teasing it out costs one regex and is the
+# only identifier a future join could use.
+_CONTRACT_NO = re.compile(r"\b(\d{2}[A-Z]{2,4}(?:-[A-Z0-9]+){1,3})\b")
+
+
+def normalize_capital_project(raw: dict):
+    name = _clean(raw.get("Name and Construction Contract Number"))
+    if name is None:
+        return
+    match = _CONTRACT_NO.search(name)
+    yield CapitalProject(
+        name=name,
+        contract_number=match.group(1) if match else None,
+        type_of_work=_clean(raw.get("Type of Work")),
+        scope=_clean(raw.get("Scope of Work: Detailed Description")),
+        delivery_division=_clean(raw.get("Delivery Division")),
+        owner_division=_clean(raw.get("Project Owner (Division)")),
+        target_sourcing_year=_clean(raw.get("Target Sourcing Year")),
+        target_award_year=_clean(raw.get("Target Award Year")),
+        sourcing_type=_clean(raw.get("Sourcing Type")),
+        estimated_range=_clean(raw.get("Estimated Range")),
+        estimated_term_months=_clean(raw.get("Estimated Contract Term (Months)")),
+        source="ckan_pipeline",
+    )
+
+
 _NORMALIZERS = {
     "awarded": normalize_awarded,
     "open": normalize_open,
     "noncompetitive": normalize_noncompetitive,
+    "capital_pipeline": normalize_capital_project,
 }
 
 
 class CkanSource:
     """A CKAN dataset adapter."""
 
-    overwrite = False  # CKAN backfills; OData is the spine.
-
-    def __init__(self, name: str, slug: str, kind: str):
+    def __init__(self, name: str, slug: str, kind: str, overwrite: bool = False):
         if kind not in _NORMALIZERS:
             raise ValueError(f"Unknown CKAN kind: {kind}")
         self.name = name
         self.slug = slug
         self.kind = kind
+        # False by default: CKAN backfills, OData is the spine. capital_pipeline is the
+        # exception — no spine covers it, so CKAN *is* authoritative there, and a project
+        # whose target year or scope shifts must land rather than be COALESCEd away.
+        self.overwrite = overwrite
 
     def fetch(self, http) -> Iterable[dict]:
         resource_id = resolve_resource_id(http, self.slug)

--- a/scrapers/toronto_bids/sources/schema_check.py
+++ b/scrapers/toronto_bids/sources/schema_check.py
@@ -62,6 +62,12 @@ _CKAN = {
         "Workspace Number", "Supplier Name", "Reason", "Contract Amount",
         "Contract Date", "Division",
     }),
+    "ckan_pipeline": (config.CKAN_PIPELINE_SLUG, {
+        "Name and Construction Contract Number", "Type of Work",
+        "Scope of Work: Detailed Description", "Delivery Division",
+        "Project Owner (Division)", "Target Sourcing Year", "Target Award Year",
+        "Sourcing Type", "Estimated Range", "Estimated Contract Term (Months)",
+    }),
 }
 
 

--- a/scrapers/toronto_bids/store/db.py
+++ b/scrapers/toronto_bids/store/db.py
@@ -2,7 +2,7 @@ import sqlite3
 from dataclasses import fields
 from importlib import resources
 
-from toronto_bids.models import Award, NonCompetitive, Solicitation, AribaPosting, SuspendedFirm, Supplier, CouncilItem, BackgroundPdf
+from toronto_bids.models import Award, CapitalProject, NonCompetitive, Solicitation, AribaPosting, SuspendedFirm, Supplier, CouncilItem, BackgroundPdf
 
 # model -> (table, conflict-key columns). A model's fields ARE the table's writable
 # columns, in INSERT order; auto/default columns (id, first_seen, last_seen, supplier_id)
@@ -17,6 +17,7 @@ _TABLES = {
     Supplier: ("supplier", ["supplier_key"]),
     CouncilItem: ("council_item", ["reference"]),
     BackgroundPdf: ("background_pdf", ["url"]),
+    CapitalProject: ("capital_project", ["name"]),
 }
 
 # Tables whose uniqueness is enforced by an expression index rather than a column list, so
@@ -159,7 +160,8 @@ def upsert_row(conn, row, *, overwrite: bool) -> None:
 
 def counts(conn) -> dict:
     tables = ["solicitation", "award", "noncompetitive", "ariba_posting",
-              "suspended_firm", "supplier", "council_item", "background_pdf", "sync_run"]
+              "suspended_firm", "supplier", "capital_project", "council_item",
+              "background_pdf", "sync_run"]
     return {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
 
 

--- a/scrapers/toronto_bids/store/schema.sql
+++ b/scrapers/toronto_bids/store/schema.sql
@@ -171,3 +171,29 @@ CREATE TABLE IF NOT EXISTS background_pdf (
 );
 
 CREATE INDEX IF NOT EXISTS idx_background_pdf_reference ON background_pdf (reference);
+
+-- Solicitations the City intends to issue but has not yet (#69, rewrite spec §2.1
+-- "capital-project-pipeline"). Forward-looking, so there is no document_number and no join to
+-- the spine — a project only gets one once it is actually solicited. Worth archiving anyway:
+-- the City refreshes this list and entries drop off as they are sourced, so what was planned
+-- is preserved nowhere else. That disappearing act is what this archive exists for.
+--
+-- Keyed on the City's combined name+contract string: 'No.' is a row index that churns on every
+-- refresh. A renamed project therefore lands as a new row rather than updating the old one;
+-- at 46 rows that is visible and tolerable, and archive semantics keep both.
+CREATE TABLE IF NOT EXISTS capital_project (
+    name                     TEXT PRIMARY KEY,
+    contract_number          TEXT,
+    type_of_work             TEXT,
+    scope                    TEXT,
+    delivery_division        TEXT,
+    owner_division           TEXT,
+    target_sourcing_year     TEXT,
+    target_award_year        TEXT,
+    sourcing_type            TEXT,
+    estimated_range          TEXT,
+    estimated_term_months    TEXT,
+    source                   TEXT,
+    first_seen               TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen                TEXT NOT NULL DEFAULT (datetime('now'))
+);


### PR DESCRIPTION
Closes #69. Targets `main` — independent of #79/#80.

Three CKAN datasets sat in rewrite spec §2.1's Tier 1 *"sources we pull"* table and were never implemented. This resolves all three — in opposite directions.

## Built: `capital-project-pipeline`

46 rows, one request, live-verified. `capital_project` 0 → 46, **36 carrying a construction contract number**.

```
25SWM-IRM-042CDU   RFT   2026  Up to $5M     Dufferin Transfer Station - Paving...
25ECS-MI-02SW      RFT   2026  $5M to $50M   Dufferin Transfer Station - Compactors...
26ECS-MI-03SW      nRFP  2026  Over $50M     Dufferin Transfer Station office building...
```

**Why this one and not the others:** it's the only forward-looking source in the landscape, and **the City refreshes it, so entries drop off as they're sourced**. What the City *planned* to buy is preserved nowhere else once it stops planning. That vanishing act is exactly what this archive exists for — whereas pcard spend sits permanently on the City's own portal.

Building it honours a decision the spec already made (Tier 1, "sources we pull") rather than making a new one.

## Declined: `pcard-expenditures`, `consulting-services-expenditures`

Both **measured, not assumed**:

| | finding |
|---|---|
| `pcard-expenditures` | **819,993 rows** of free-text merchant, ~5-month lag, no join key |
| `consulting-services-expenditures` | XLSX only — **0 datastore-active resources** |

§2.5.6 already said *"no join key; orthogonal spend data"*, so **the table contradicted itself**: these were listed because they're easy to fetch, not because they belong here. New spec **§2.1.1** records the decision so nobody re-litigates whether the implementation is incomplete.

Feeding 820k more free-text merchant strings to the fuzzy supplier dimension (§2.5.4) would manufacture false links, not insight.

## Things worth reviewing

**`capital_project` joins nothing, by nature.** A project has no document number until it's actually solicited. So it gets its own table and its own top-level export key — never nested under a solicitation.

**`CkanSource` gains an `overwrite` flag, defaulting `False`.** The class hardcoded `False` because *"CKAN backfills; OData is the spine"* — true for every existing CKAN source, but **no spine covers the pipeline**, so CKAN is authoritative there and a project whose target year slips must land rather than be COALESCEd away. A test pins that asymmetry (`ckan_pipeline` True, `ckan_awarded`/`ckan_open` False, default False).

**Keyed on the name, not `No.`** — `No.` is a row index that churns on every refresh. A renamed project therefore lands as a new row rather than updating; at 46 rows that's visible and archive semantics keep both. Documented in the schema.

**The contract number is teased out for one regex.** `25ECS-MI-02SW`. Nothing joins on it today, but it's the same shape seen on Bid Award Panel agendas (`22TR-OM-104-SC-TM`) and in the legacy archive's folder names (`22ECS-TI-22SP`) — the only identifier a future join could use.

**Declared in `schema_check` in the same change**, per the source contract, with a drift test. Plus a new test that every declared CKAN feed has a source reading it *and vice versa* — a declared feed with no source is a bug either way, and nothing was checking.

## Testing

`test_capital_pipeline.py` (7) — normalization, contract-number extraction incl. the many projects without one, nameless rows skipped, idempotency, the refresh-updates case, the overwrite asymmetry, and the export key.
`test_schema_check.py` (+2) — pipeline drift detection, declared-feeds↔sources parity.

251 passed. Live `tb sync --only ckan_pipeline` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)