### PR TITLE
Name 2012 solicitations from composite-report appendices (#93)

### DIFF
--- a/scrapers/tests/fixtures/bid_award_panel/2012.BD100.report.txt
+++ b/scrapers/tests/fixtures/bid_award_panel/2012.BD100.report.txt
@@ -1,0 +1,362 @@
+STAFF REPORT
+ACTION REQUIRED
+Contract Awards – November 21, 2012 - Composite Report
+Date:
+
+November 15, 2012
+
+To:
+
+Bid Committee
+
+From:
+
+Director, Purchasing and Materials Management
+
+Reference Various Calls
+
+SUMMARY
+The purpose of this report is to advise on the results of the competitive procurement calls issued
+by the Purchasing and Materials Management Division and to recommend contract awards as
+outlined in this report.
+
+RECOMMENDATIONS
+The Director of Purchasing and Materials Management recommends that the Bid Committee
+grant authority to award the following contracts in accordance with the Contract Details set out
+in the appendices of this report:
+1
+
+2
+
+Call Document
+Description
+
+Recommended
+Bidder
+Call Document
+Description
+
+Recommended
+Bidder
+
+Request for Quotation 6302-12-0219
+Quotations are invited for the non-exclusive supply and delivery
+of various shop supplies to various Purchasing and Materials
+Management (Stores) locations, from the date of award to
+November 30, 2013
+Guillevin International Co.
+Request for Quotation 3917-12-7226
+For the non exclusive provision of emergency and planned
+Concrete Cutting Services complete with Operator as required by
+Toronto Water District Operations on lands and road allowances
+in Etobicoke York, Toronto East York, North York and
+Scarborough Districts from November 1, 2012 to October 31,
+2013
+Accrue Contracting Ltd.
+
+Contract Awards – Bid Committee Composite Report – November 21, 2012
+1
+
+3
+
+4
+
+Call Document
+Description
+Recommended
+Bidder
+Call Document
+Description
+
+Recommended
+Bidder
+
+Tender Call 192-2012
+State of Good Repair Work at York Civic Centre, 2700 Eglinton Ave
+West, Toronto, Ontario.
+Steelcore Construction Ltd.
+
+Request for Quotations 3001-12-3202
+For the supply and delivery of student and instructor manuals for
+First Aid, CPR, AED and Health Care Provider CPR for the Safe
+City Program, a section of the City of Toronto’s Emergency
+Medical Services Division (EMS) for a period of one (1) year
+from the date of award to November 30, 2013
+Jones & Bartlett Learning
+
+COMMENTS
+(1)
+
+REQUIREMENTS
+
+For each of the recommended contract awards, the following requirements have been met:
+(a) The firm recommended for award is the lowest bidder meeting specifications or to the
+highest scoring proponent based on the evaluation criteria included in the call and
+meeting the requirements of the call;
+(b) the Deputy City Manager and Chief Financial Officer agrees with the Financial Impact
+information;
+(c) the appropriate Division has reviewed submissions and found the price to be reasonable,
+within available budget and concurs with the recommendation;
+(d) the call document was advertised on the City’s internet website and bids or proposals
+were opened publicly; and
+(e) the Fair Wage Office confirms the recommended firm understands the Fair Wage Policy
+and Labour Trades requirements and has agreed to comply fully.
+
+Contract Awards – Bid Committee Composite Report – November 21, 2012
+2
+
+(2)
+CONTRACT DETAILS
+APPENDIX #1
+
+Date: November 15, 2012
+
+Call No:
+Request for Quotation 6302-12-0219
+Description:
+Quotations are invited for the non-exclusive supply and delivery of various shop supplies to
+various Purchasing and Materials Management (Stores) locations, from the date of award to
+November 30, 2013 with the option to renew the contract for four (4) additional separate one (1)
+year periods at the sole discretion of the City and subject to budget approval(s). Should the
+option(s) be exercised, then the Manager, Materials Management & Stores will request the
+Director of Purchasing and Materials Management to process the renewals under the same terms
+and conditions.
+Call Dates:
+Issued October 1, 2012 Closed October 22, 2012
+Ward No:
+All
+Recommended Bidder:
+Guillevin International Co.
+Contract Award Value:
+Date of award to November 30, 2013:
+ $284,752.25 net of all applicable taxes and charges
+ $321,770.04 including all applicable taxes and charges
+ $289,763.89 net of HST Recoveries
+Option Year 1 (December 1, 2013 to November 30, 2014)
+ $298,989.86 net of all applicable taxes and charges
+ $337,858.54 including all applicable taxes and charges
+ $304,252.08 net of HST Recoveries
+Option Year 2 (December 1, 2014 to November 30, 2015)
+ $313,939.35 net of all applicable taxes and charges
+ $354,751.47 including all applicable taxes and charges
+ $319,464.68 net of HST Recoveries
+Option Year 3 (December 1, 2015 to November 30, 2016)
+ $329,636.33 net of all applicable taxes and charges
+ $372,489.05 including all applicable taxes and charges
+ $335,437.93 net of HST Recoveries
+
+Contract Awards – Bid Committee Composite Report – November 21, 2012
+4
+
+APPENDIX #1
+Option Year 4 (December 1, 2016 to November 30, 2017)
+ $346,118.14 net of all applicable taxes and charges
+ $391,113.50 including all applicable taxes and charges
+ $352,209.82 net of HST Recoveries
+
+The total potential cost to the City including all option years is $1,601,128.40 net of HST
+Recoveries, $1,777,982.60 including all applicable taxes and charges and $1,573,435.93 net of
+all applicable taxes and charges.
+Number of Bids:
+Four (4) Formal Bids, Two (2) Informal Bids, Total: Six (6) Bids
+Financial Impact:
+The total potential contract award identified in this report is $1,777,982.60 including all
+applicable taxes and charges. The total potential cost to the City is $1,601,128.40 net of HST
+Recoveries. The materials on this contract will be purchased for PMMD Stores inventory
+purposes. The material value will be held in inventory holding Balance Sheet accounts (160004,
+160026, 160049, 160067, 160068, 160082, 160083, 160085) until City Divisions require the
+material to support their work programs at which time the material value is charged to the
+appropriate Divisions’ approved operating budgets.
+Date of award
+to December
+31, 2012
+(net of HST
+Recoveries)
+
+January 1, 2013
+to November
+30, 2013
+(net of HST
+Recoveries)
+
+Option Year 1
+December 1,
+2013 to
+November 30,
+2014
+(net of HST
+Recoveries)
+
+Option Year 2
+December 1,
+2014 to
+November 30,
+2015
+(net of HST
+Recoveries)
+
+Option Year 3
+December 1,
+2015 to
+November 30,
+2016
+(net of HST
+Recoveries)
+
+Option Year 4
+December 1,
+2016 to
+November 30,
+2017
+(net of HST
+Recoveries)
+
+Total
+(net of HST
+Recoveries)
+
+$48,293.98
+
+$241,469.91
+
+$304,252.08
+
+$319,464.68
+
+$335,437.93
+
+$352,209.82
+
+$1,601,128.40
+
+Division Contacts:
+John Farrell
+Manager, Materials Management & Stores
+Purchasing & Materials Management
+Telephone: (416) 392-6764
+E-Mail: jfarrel2@toronto.ca
+
+Elena Caruso
+Manager, Goods & Services
+Purchasing & Materials Management
+Telephone: (416) 392-7316
+E-Mail: ecaruso@toronto.ca
+
+Contract Awards – Bid Committee Composite Report – November 21, 2012
+5
+
+(2)
+CONTRACT DETAILS
+Appendix # 2
+
+Date: October 31, 2012
+
+Call No:
+Request for Quotation 3917-12-7226
+Description:
+For the non exclusive provision of emergency and planned Concrete Cutting Services complete
+with Operator as required by Toronto Water District Operations on lands and road allowances in
+Etobicoke York, Toronto East York, North York and Scarborough Districts from November 1,
+2012 to October 31, 2013 with the option to renew the contract for an additional four (4) separate
+one (1) year periods, at the sole discretion of the City and subject to budget approval(s). Should
+the option(s) to renew be exercised, then the General Manager/Director of the participating
+division will request the Director of Purchasing and Materials Management Division to process
+the renewals under the same terms and conditions.
+Call Dates:
+Issued October 5, 2012, Closed October 24, 2012
+Ward No:
+All
+Recommended Bidder:
+Accrue Contracting Ltd.
+Contract Award Value:
+November 1, 2012 to October 31, 2013
+ $420,000.00 net of all applicable taxes and charges
+ $474,600.00 including all applicable taxes and charges
+ $427,392.00 net of HST recoveries
+Option Period 1 - November 1, 2013 to October 31, 2014
+ $432,600.00 net of all applicable taxes and charges
+ $488,838.00 including all applicable taxes and charges
+ $440,213.76 net of HST recoveries
+Option Period 2 - November 1, 2014 to October 31, 2015
+ $445,578.00 net of all applicable taxes and charges
+ $503,503.14 including all applicable taxes and charges
+ $453,420.17 net of HST recoveries
+
+Contract Awards – Bid Committee Composite Report – November 21, 2012
+6
+
+Appendix # 2
+Option Period 3 - November 1, 2015 to October 31, 2016
+ $458,945.34 net of all applicable taxes and charges
+ $518,608.23 including all applicable taxes and charges
+ $467,022.78 net of HST recoveries
+Option Period 4 - November 1, 2016 to October 31, 2017
+ $472,713.70 net of all applicable taxes and charges
+ $534,166.48 including all applicable taxes and charges
+ $481,033.46 net of HST recoveries
+The above costs reflect an estimated 3% increase in the Consumer Price Index for each Option
+Year.
+The total potential contract award including all option years is $2,229,837.04 net of all
+applicable taxes and charges. The total potential contract award including all option years is
+$2,519,715.85 including all applicable taxes and charges. The total potential cost to the City
+including all option years is $2,269,082.17 net of HST recoveries.
+Number of Bids:
+Two (2)
+Financial Impact:
+The total potential contract award including all option years identified in this report is
+$2,519,715.85 including all applicable taxes and charges. The total potential cost to the City is
+$2,269,082.17 net of HST recoveries. Funding for 2012 in the amount of $71,232.00 is included
+in the 2012 Approved Operating Budget for Toronto Water. Funding in the amount of
+$356,160.00 for the remaining balance of this contract in 2013 is included in the 2013
+Recommended Operating Budget for Toronto Water.
+Should the City choose to exercise its option(s) to renew for an additional four (4) separate one
+(1) year periods, then appropriate additional funding, if needed, will be requested in the 20142017 Operating Budget Submissions for Toronto Water under various cost centres. Funding
+details are provided below:
+Account
+
+Option Year 3
+Option Year 4
+Account Name November 1, Jan 1, 2013 to Option Year 1 Option Year 2
+November 1,
+November 1,
+November 1,
+2012 Award October 31, November 1,
+to Dec 31,
+2013
+2013 to October 2014 to October 2015 to October 2016 to October
+2012
+(net of HST 31, 2014 (net of 31, 2015 (net of 31, 2016 (net of 31, 2017 (net of
+HST
+HST Recoveries) HST Recoveries) HST Recoveries)
+(net of HST Recoveries)
+Recoveries)
+Recoveries)
+
+PW 3006
+PW3012
+Toronto Water
+PW2008
+PW2014
+
+71,232.00
+
+356,160.00
+
+440,213.76
+
+453,420.17
+
+467,022.78
+
+Contract Awards – Bid Committee Composite Report – November 21, 2012
+7
+
+481,033.46
+
+Total
+(net of HST
+Recoveries)
+
+2,269,082.17
+
+

--- a/scrapers/tests/test_composite_reports.py
+++ b/scrapers/tests/test_composite_reports.py
@@ -1,0 +1,167 @@
+"""#93: the 2009-2012 composite reports, where the agenda describes nothing.
+
+    BD100.1 - Contract Awards - November 21 - Composite Report
+
+One item, many awards, and a body that only says the details are "set out in the appendices
+of this report". No amount, so #77's join has nothing to stand on, and no identifier either.
+The appendices of the linked staff-report PDF carry both. The fixture is that real PDF's
+pdftotext output (2012.BD100.1, backgroundfile-52208).
+"""
+import pathlib
+
+from toronto_bids.models import Award, BackgroundPdf, Solicitation
+from toronto_bids.sources.bid_award_panel import (
+    match_composite_titles, parse_composite_appendices)
+from toronto_bids.store import db
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "bid_award_panel"
+REPORT = (FIXTURES / "2012.BD100.report.txt").read_text()
+
+
+def test_pulls_each_appendix_off_a_real_composite_report():
+    """The one item carries many awards — reading only the first would lose the rest."""
+    items = parse_composite_appendices(REPORT)
+    assert len(items) == 2
+    assert [i["winner_raw"] for i in items] == [
+        "Guillevin International Co.", "Accrue Contracting Ltd."]
+
+
+def test_takes_the_net_of_taxes_figure_not_the_other_two():
+    """Same three-figure block #77 calibrated against 980 Ariba-era items: award_amount is
+    the 'net of all applicable taxes' one. 2012.BD100 appendix 2 publishes $420,000.00 net /
+    $474,600.00 including / $427,392.00 net of HST recoveries."""
+    accrue = parse_composite_appendices(REPORT)[1]
+    assert accrue["award_value"] == 420000.00
+
+
+def test_the_title_leads_with_the_call_number():
+    """The call number is the only identifier the appendix carries and the thing a human
+    would search for. A plain re.split ate it once — the label delimits the block."""
+    accrue = parse_composite_appendices(REPORT)[1]
+    assert accrue["title"].startswith("Request for Quotation 3917-12-7226 - ")
+    assert "Concrete Cutting Services" in accrue["title"]
+
+
+def _block(value_line):
+    return ("Call No:\nTender Call 123-2012\nDescription:\nFor paving.\n\n"
+            "Recommended Bidder:\nAcme Paving Inc.\n\nContract Award Value:\n" + value_line)
+
+
+def test_reads_the_net_figure_however_the_year_words_it():
+    """Ontario had no HST until July 2010, so 2009 publishes '(Net of GST)' and nothing else.
+    Matching only 2012's 'net of all applicable taxes' silently yields zero for all of 2009
+    (243 awards) and undercounts 2011 by 47."""
+    for line, year in (
+            ("$100,000.00 (Net of GST)\n", "2009"),
+            ("$100,000.00 net of all taxes and charges\n", "2011"),
+            ("$100,000.00 net of all applicable taxes and charges\n", "2012"),
+            ("$100,000.00 net of applicable taxes and charges\n", "2012 variant"),
+    ):
+        items = parse_composite_appendices(_block(line))
+        assert [i["award_value"] for i in items] == [100000.00], year
+
+
+def test_never_takes_the_hst_recoveries_figure():
+    """The third figure in the block. #77 measured it against 980 ground-truth items: it is
+    award_amount 4 times out of 980. Taking it would match almost nothing, silently."""
+    assert parse_composite_appendices(_block("$427,392.00 net of HST recoveries\n")) == []
+
+
+def test_an_rfp_says_proponent_where_a_tender_says_bidder():
+    """'Recommended Proponent' (15 blocks) and the plural 'Recommended Bidders' (8) are the
+    same field. Accepting only the singular 'Recommended Bidder' drops 23 of 280."""
+    for label in ("Recommended Proponent", "Recommended Bidders", "Recommended Proponents"):
+        text = (f"Call No:\nTender Call 123-2012\nDescription:\nFor paving.\n\n"
+                f"{label}:\nAcme Paving Inc.\n\nContract Award Value:\n"
+                f"$100,000.00 net of all applicable taxes and charges\n")
+        items = parse_composite_appendices(text)
+        assert [i["winner_raw"] for i in items] == ["Acme Paving Inc."], label
+
+
+def test_a_block_with_no_winner_or_no_value_is_skipped_not_half_parsed():
+    """36 of 280 blocks publish no winner or no 'Contract Award Value' label at all."""
+    text = ("Call No:\nTender Call 1-2012\nDescription:\nCancelled call.\n\n"
+            "Number of Bids:\nThree (3)\n")
+    assert parse_composite_appendices(text) == []
+
+
+def _seed(conn, doc, supplier, amount, title=None):
+    db.upsert_row(conn, Solicitation(doc, title=title, source="odata"), overwrite=True)
+    db.upsert_row(conn, Award(doc, supplier_name_raw=supplier, award_amount=amount,
+                              source="odata"), overwrite=True)
+
+
+def _seed_report(conn, reference="2012.BD100.1", text=REPORT, kind="bgrd"):
+    db.upsert_row(conn, BackgroundPdf(
+        url=f"https://www.toronto.ca/legdocs/mmis/2012/bd/bgrd/backgroundfile-52208.pdf",
+        reference=reference, kind=kind, text=text), overwrite=True)
+
+
+def test_names_a_title_less_award_from_a_downloaded_report(conn):
+    _seed(conn, "1234567890", "Accrue Contracting Ltd.", "420000.00")
+    _seed_report(conn)
+    conn.commit()
+    assert match_composite_titles(conn) == 1
+    row = conn.execute("SELECT title, title_source FROM solicitation").fetchone()
+    assert row["title"].startswith("Request for Quotation 3917-12-7226 - ")
+    assert row["title_source"] == "council_composite"
+
+
+def test_reads_only_reports_already_downloaded(conn):
+    """Offline by default: the text column is the input, so a report nobody fetched
+    contributes nothing rather than triggering a download mid-match."""
+    _seed(conn, "1234567890", "Accrue Contracting Ltd.", "420000.00")
+    _seed_report(conn, text=None)
+    conn.commit()
+    assert match_composite_titles(conn) == 0
+
+
+def test_a_different_firm_at_the_same_value_is_not_named(conn):
+    """Measured, not hypothetical: council's 'Furcon Environmental Inc.' and the archive's
+    'Lea Consulting Ltd.' share an award value in 2012. The supplier check is the only thing
+    standing between that coincidence and a wrong title."""
+    _seed(conn, "1234567890", "Lea Consulting Ltd.", "420000.00")
+    _seed_report(conn)
+    conn.commit()
+    assert match_composite_titles(conn) == 0
+    assert conn.execute("SELECT title FROM solicitation").fetchone()[0] is None
+
+
+def test_an_ambiguous_match_is_dropped_not_guessed(conn):
+    for doc in ("1234567890", "9876543210"):
+        _seed(conn, doc, "Accrue Contracting Ltd.", "420000.00")
+    _seed_report(conn)
+    conn.commit()
+    assert match_composite_titles(conn) == 0
+
+
+def test_never_overrides_a_title_the_city_published(conn):
+    _seed(conn, "1234567890", "Accrue Contracting Ltd.", "420000.00",
+          title="Concrete Cutting Services")
+    _seed_report(conn)
+    conn.commit()
+    match_composite_titles(conn)
+    assert conn.execute("SELECT title FROM solicitation").fetchone()[0] == "Concrete Cutting Services"
+
+
+def test_is_idempotent(conn):
+    _seed(conn, "1234567890", "Accrue Contracting Ltd.", "420000.00")
+    _seed_report(conn)
+    conn.commit()
+    assert match_composite_titles(conn) == 1
+    assert match_composite_titles(conn) == 0
+
+
+def test_a_sync_cannot_clobber_the_recovered_provenance(conn):
+    """Same trap #79 shipped: the spine re-upserts every row with overwrite=True, so title
+    provenance stored in `source` gets reset to 'odata' on the next sync."""
+    _seed(conn, "1234567890", "Accrue Contracting Ltd.", "420000.00")
+    _seed_report(conn)
+    conn.commit()
+    assert match_composite_titles(conn) == 1
+    db.upsert_row(conn, Solicitation("1234567890", title=None, source="odata"), overwrite=True)
+    conn.commit()
+    row = conn.execute("SELECT title, source, title_source FROM solicitation").fetchone()
+    assert row["title"].startswith("Request for Quotation 3917-12-7226")
+    assert row["source"] == "odata"
+    assert row["title_source"] == "council_composite"

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -35,6 +35,11 @@ def build_parser() -> argparse.ArgumentParser:
              "cache, seconds once cached). Without it, only agendas already on disk are used")
     p_titles.add_argument("--virtual-display", action="store_true",
                           help="Run the headed browser under Xvfb (implies --scrape's needs)")
+    p_titles.add_argument(
+        "--reports", action="store_true",
+        help="Download the 2009-2012 composite staff-report PDFs first, whose appendices carry "
+             "awards the agendas of those years do not describe (#93). Plain HTTP and no "
+             "browser, unlike --scrape; needs pdftotext. ~221 files / ~80MB, resumable")
     return parser
 
 
@@ -124,8 +129,9 @@ def _cmd_enrich_titles(args) -> int:
     depend on which runs first.
     """
     from toronto_bids.sources.bid_award_panel import (
-        cached_agendas, fill_titles_from_council, scrape_agendas, store_background_pdfs,
-        match_pre_ariba_titles, store_bids, store_items)
+        cached_agendas, download_composite_reports, fill_titles_from_council,
+        match_composite_titles, match_pre_ariba_titles, scrape_agendas,
+        store_background_pdfs, store_bids, store_items)
     from toronto_bids.sources.legacy_titles import fill_titles_from_legacy
 
     conn = _open_db()
@@ -157,6 +163,17 @@ def _cmd_enrich_titles(args) -> int:
             # Pre-Ariba items name no document number, so they are matched on
             # (supplier, award value) instead (#77).
             print(f"  titles pre-Ariba    : {match_pre_ariba_titles(conn, agendas)}")
+
+        # 2009-2012 agendas describe nothing ("Composite Report"); their staff-report
+        # appendices carry the awards, and feed them to the same join (#93).
+        if args.reports:
+            http = HttpClient()
+            try:
+                n = download_composite_reports(conn, http, log=lambda m: print(m, flush=True))
+                print(f"  composite reports downloaded: {n}")
+            finally:
+                http.close()
+        print(f"  titles composite    : {match_composite_titles(conn)}")
 
         n_legacy = fill_titles_from_legacy(conn, config.LEGACY_ARIBA_DIR)
         print(f"  titles from legacy  : {n_legacy}"

--- a/scrapers/toronto_bids/sources/bid_award_panel.py
+++ b/scrapers/toronto_bids/sources/bid_award_panel.py
@@ -24,11 +24,13 @@ sources/council.py already does. Parsing is pure and testable against saved HTML
 """
 import pathlib
 import re
+import shutil
 from contextlib import contextmanager
 
 from lxml import html as _html
 from lxml.html import HtmlComment
 
+from toronto_bids import config
 from toronto_bids.linking.document_number import normalize_document_number
 from toronto_bids.linking.supplier import supplier_key
 from toronto_bids.amount import parse_amount
@@ -562,30 +564,188 @@ def match_pre_ariba_titles(conn, agendas: dict) -> int:
 
     Only a UNIQUE match is taken. A wrong title is worse than none.
     """
-    awards = []
+    items = []
+    for meeting, html in agendas.items():
+        if meeting.split(".")[0] >= "2019":
+            continue                      # 2019+ names a document number; no need to guess
+        items.extend(parse_pre_ariba_awards(html))
+    return match_on_supplier_and_value(conn, items, "council_pre_ariba")
+
+
+# --- composite reports (#93) ------------------------------------------------------------
+#
+# 2009-2012 agendas do not describe their awards. One item carries many:
+#
+#     BD100.1 - Contract Awards - November 21 - Composite Report
+#
+# and the agenda body only says the details are "set out in the appendices of this report".
+# It names no amount, so #77's (supplier, value) join has nothing to stand on, and the feed
+# offers no identifier to fall back to: probing Posting_Title and
+# Solicitation_Document_Description for all 3,628 title-less rows returned an identifier on
+# zero of them. Matching on (supplier, award date) instead was measured against 880
+# ground-truth items and rejected — at a 30-day window it is 21% wrong.
+#
+# The appendices of the linked staff-report PDF do carry all of it, in the same shape #77
+# already reads:
+#
+#     Call No:            Request for Quotation 3917-12-7226
+#     Description:        For the non exclusive provision of ... Concrete Cutting Services
+#     Recommended Bidder: Accrue Contracting Ltd.
+#     Contract Award Value:
+#         $420,000.00 net of all applicable taxes and charges     <- the figure #77 calibrated
+#         $474,600.00 including all applicable taxes and charges
+#         $427,392.00 net of HST recoveries
+#
+# So this parses the appendices and hands them to the same join. Those PDFs are plain HTTP —
+# only TMMIS itself is Akamai-gated — and they are already indexed in background_pdf by
+# store_background_pdfs, so the download is bounded and needs no browser.
+# Lookahead so the block keeps its own "Call No:" label — a plain split would eat the
+# delimiter and the call number with it.
+_APPENDIX_BLOCK = re.compile(r"(?=Call No:)", re.I)
+
+
+def _appendix_field(label: str) -> re.Pattern:
+    """A labelled appendix field, whose value may sit on the label's line or the next one.
+
+    Which one depends on the PDF, not the year, so both are accepted. The value ends at a
+    blank line or at the next 'Label:' — pdftotext emits no other structure to lean on.
+    """
+    return re.compile(label + r":[ \t]*\n?[ \t]*(.+?)(?=\n[ \t]*\n|\n[ \t]*[A-Z][A-Za-z ]{2,25}:)",
+                      re.I | re.S)
+
+
+_APX_CALL_NO = _appendix_field("Call No")
+_APX_DESCRIPTION = _appendix_field("Description")
+# RFPs say "Proponent" where tenders say "Bidder", and both are pluralized when an award is
+# split. Accepting only the singular "Recommended Bidder" drops 23 of 280 appendices (#93).
+_APX_BIDDER = _appendix_field(r"Recommended (?:Bidder|Proponent)s?")
+
+# How council words the net figure drifts with tax history, and the drift is not cosmetic:
+# Ontario had no HST until July 2010, so 2009 publishes only "$1,020,600.00 (Net of GST)"
+# and _NET_OF_TAXES matches none of it. Measured yield per year, narrow -> this:
+#
+#     2009    0 -> 243      (all of it; "net of GST")
+#     2010  230 -> 253      (the GST/HST transition year, mixed wording)
+#     2011  256 -> 303      ("net of all taxes and charges")
+#     2012  257 -> 277      ("net of all applicable taxes")
+#
+# Still refuses "net of HST recoveries" — a third figure #77 measured as the wrong one
+# (4/980 against ground truth). Deliberately separate from _NET_OF_TAXES, which #77
+# calibrated on Ariba-era agendas: widening that would reopen a settled measurement.
+_APX_AWARD_VALUE = re.compile(
+    r"\$([\d,]+(?:\.\d+)?)\s*\(?\s*net of (?:all )?(?:applicable )?(?:taxes|gst)\b", re.I)
+
+
+def parse_composite_appendices(text: str) -> list[dict]:
+    """Awards from a composite staff report's appendices, shaped for match_on_supplier_and_value.
+
+    Pure: `text` is the pdftotext output already stored in background_pdf.text. Identical
+    yield with and without pdftotext's -layout (244/280 blocks either way), so this reads
+    whatever council.py:download_pdf produced without changing that path.
+    """
+    out = []
+    for block in _APPENDIX_BLOCK.split(text)[1:]:
+        description, bidder = _APX_DESCRIPTION.search(block), _APX_BIDDER.search(block)
+        value = _APX_AWARD_VALUE.search(block)
+        if not (description and bidder and value):
+            continue                      # 36 of 280 blocks publish no winner or no value
+        amount = parse_amount(value.group(1))
+        if amount is None:
+            continue
+        call_no = _APX_CALL_NO.search(block)
+        subject = _clean(description.group(1))
+        out.append({
+            # The call number is the only identifier the appendix carries, and it is what a
+            # human would search for, so it leads the title rather than being dropped.
+            "title": f"{_clean(call_no.group(1))} - {subject}" if call_no else subject,
+            "winner_raw": _clean(bidder.group(1)),
+            "award_value": amount,
+        })
+    return out
+
+
+def match_composite_titles(conn) -> int:
+    """Name title-less solicitations from composite-report appendices already downloaded.
+
+    Offline: reads background_pdf.text, so it only sees reports fetched by
+    download_composite_reports. Idempotent.
+    """
+    items = []
+    for row in conn.execute(
+            "SELECT text FROM background_pdf WHERE text IS NOT NULL AND kind='bgrd' "
+            "AND substr(reference,1,4) BETWEEN '2009' AND '2012'"):
+        items.extend(parse_composite_appendices(row["text"]))
+    return match_on_supplier_and_value(conn, items, "council_composite")
+
+
+def download_composite_reports(conn, http, dest_dir=None, log=lambda _m: None) -> int:
+    """Download the 2009-2012 staff-report PDFs and store their text. Plain HTTP, no browser.
+
+    Bounded by what store_background_pdfs already indexed off the cached agendas (221 PDFs,
+    ~80MB). Resumable and idempotent: rows that already hold text are skipped, so an
+    interrupted run costs only what it had not yet fetched.
+    """
+    from toronto_bids.sources.council import download_pdf
+
+    if shutil.which("pdftotext") is None:
+        raise RuntimeError(
+            "pdftotext (poppler) is required to read composite reports but was not found on "
+            "PATH. Install poppler (e.g. `brew install poppler` / `apt-get install -y "
+            "poppler-utils`).")
+    dest_dir = dest_dir if dest_dir is not None else config.COUNCIL_DOCS_DIR
+    rows = conn.execute(
+        "SELECT url, reference FROM background_pdf WHERE text IS NULL AND kind='bgrd' "
+        "AND substr(reference,1,4) BETWEEN '2009' AND '2012' ORDER BY reference").fetchall()
+    log(f"  composite reports to fetch: {len(rows)}")
+    stored = 0
+    for i, row in enumerate(rows, 1):
+        try:
+            info = download_pdf(http, row["url"], dest_dir)
+            db.upsert_row(conn, BackgroundPdf(
+                url=row["url"], reference=row["reference"], kind="bgrd",
+                local_path=info["local_path"], sha256=info["sha256"], text=info["text"],
+            ), overwrite=True)
+            conn.commit()
+            stored += 1
+        except Exception as exc:
+            conn.rollback()
+            log(f"    skipped {row['reference']}: {exc}")   # one bad PDF must not end the run
+        if i % 25 == 0:
+            log(f"    {i}/{len(rows)}")
+    return stored
+
+
+def _title_less_awards_by_value(conn) -> dict:
+    """Title-less awards indexed by rounded value — the left side of the (value, supplier) join."""
+    by_value = {}
     for row in conn.execute(
             "SELECT a.document_number d, a.supplier_name_raw s, a.award_amount_numeric v "
             "FROM award a JOIN solicitation sol ON sol.document_number = a.document_number "
             "WHERE a.source='odata' AND a.award_amount_numeric IS NOT NULL "
             "AND a.supplier_name_raw IS NOT NULL AND sol.title IS NULL"):
-        awards.append((round(row["v"]), supplier_tokens(row["s"]), row["d"]))
-    by_value = {}
-    for value, toks, doc in awards:
-        by_value.setdefault(value, []).append((toks, doc))
+        by_value.setdefault(round(row["v"]), []).append((supplier_tokens(row["s"]), row["d"]))
+    return by_value
 
+
+def match_on_supplier_and_value(conn, items, title_source: str) -> int:
+    """Name title-less solicitations from items carrying (title, winner_raw, award_value).
+
+    The one join shared by the two sources that have no identifier to offer: agenda items
+    (#77) and composite-report appendices (#93). The value carries the match and the supplier
+    only confirms it; a non-unique match is dropped rather than guessed. Idempotent — the
+    UPDATE is guarded on `title IS NULL`.
+    """
+    by_value = _title_less_awards_by_value(conn)
     filled = {}
-    for meeting, html in agendas.items():
-        if meeting.split(".")[0] >= "2019":
-            continue                      # 2019+ names a document number; no need to guess
-        for item in parse_pre_ariba_awards(html):
-            want = supplier_tokens(item["winner_raw"])
-            docs = {doc for toks, doc in by_value.get(round(item["award_value"]), [])
-                    if want & toks}
-            if len(docs) == 1:
-                filled.setdefault(docs.pop(), item["title"])
+    for item in items:
+        want = supplier_tokens(item["winner_raw"])
+        docs = {doc for toks, doc in by_value.get(round(item["award_value"]), [])
+                if want & toks}
+        if len(docs) == 1:
+            filled.setdefault(docs.pop(), item["title"])
     conn.executemany(
-        "UPDATE solicitation SET title = ?, title_source = 'council_pre_ariba' "
+        "UPDATE solicitation SET title = ?, title_source = ? "
         "WHERE document_number = ? AND title IS NULL",
-        [(t, d) for d, t in filled.items()])
+        [(t, title_source, d) for d, t in filled.items()])
     conn.commit()
     return len(filled)


### PR DESCRIPTION
Closes #93.

## The problem

2009-2012 agendas describe nothing. One item carries many awards:

```
BD100.1 - Contract Awards - November 21 - Composite Report
```

and the body only says the details are "set out in the appendices of this report".

#93's first step was to read one 2012 item end to end and find out whether a dollar value appears anywhere in the sub-blocks, because that decides whether this reuses #77's matcher or needs a new join. **It doesn't.** The agenda names no amount, so #77's `(supplier, value)` join has nothing to stand on.

Two alternatives were measured and rejected before building:

- **Join on an identifier.** Probed the live feed's `Posting_Title` and `Solicitation_Document_Description` for all 3,628 title-less rows: identifier found on **zero**.
- **Join on (supplier, award date).** Measured against 880 ground-truth items: at 30 days it is **21% wrong** (precision 78.7%). 365 days is clean but recovers 5.6%.

## What does work

The linked staff-report PDF's appendices carry all of it, in the shape #77 already reads:

```
Call No:            Request for Quotation 3917-12-7226
Description:        For the non exclusive provision of ... Concrete Cutting Services
Recommended Bidder: Accrue Contracting Ltd.
Contract Award Value:
    $420,000.00 net of all applicable taxes and charges     <- the figure #77 calibrated
    $474,600.00 including all applicable taxes and charges
    $427,392.00 net of HST recoveries
```

So this downloads those PDFs, parses the appendices, and hands them to the same join — extracted here as `match_on_supplier_and_value` and shared by #77 and #93.

**Titles: 3,628 -> 3,469 title-less. `council_composite` = 158.**

| title_source | count |
|---|---:|
| odata (City feed) | 2053 |
| council_pre_ariba | 1286 |
| bid_award_panel | 342 |
| **council_composite** | **158** |
| legacy_ariba_html | 136 |

## Notes

- **`--reports`, not `--scrape`.** The PDFs are plain HTTP — only TMMIS itself is Akamai-gated. They're already indexed in `background_pdf`, so the fetch is bounded (221 files, ~80MB), needs no browser, and is resumable (rows holding text are skipped). `--scrape` needs the `council` extra and a headed Chromium; this needs neither.
- **`download_pdf` reused unchanged.** Verified identical yield with and without `pdftotext -layout` (244/280 blocks either way), so the council text path is untouched.
- **The amount wording drifts with tax history, and the drift is not cosmetic.** Ontario had no HST until July 2010, so 2009 publishes only `$1,020,600.00 (Net of GST)`. A separate `_APX_AWARD_VALUE` covers the GST- and HST-era wording while still refusing the `net of HST recoveries` figure (#77 measured it as award_amount 4 times in 980):

  | year | narrow | widened |
  |---|---:|---:|
  | 2009 | 0 | 243 |
  | 2010 | 230 | 253 |
  | 2011 | 256 | 303 |
  | 2012 | 257 | 277 |

  That lifted titles 146 -> 158. `_NET_OF_TAXES` is deliberately left alone — widening it would reopen #77's settled calibration on Ariba-era agendas.
- **The supplier check is not ceremony.** Council's `Furcon Environmental Inc.` and the archive's `Lea Consulting Ltd.` share an award value in 2012; the supplier check is the only thing between that coincidence and a wrong title. Pinned by a test.
- **2010 is not scanned.** An early 12-file sample suggested it was; across all 221, only 16 are image-only, and 2010 has 42 readable reports.

## Tests

12 new, 339 total, all offline. Fixture is the real `backgroundfile-52208.pdf` text.

## Follow-up

The bigger prize here is **not** the 158 matches — see the issue I'm filing alongside this. 2010 and 2011 hold **486 appendix awards worth ~$1.1B that the archive has 13 rows for**, and 2009 (243 more) predates our earliest award entirely. Ingesting those needs a keyspace decision, since they carry a Call Number and no 10-digit `document_number`.