### PR TITLE
Ariba capture --virtual-display for headless-server runs (#122, Part A)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-ariba-capture-virtual-display-design.md
+++ b/docs/superpowers/specs/2026-07-17-ariba-capture-virtual-display-design.md
@@ -1,0 +1,45 @@
+# Ariba capture `--virtual-display` (#122, Part A)
+
+## Problem
+
+`capture_attachments` launches a **headed** Chromium — SAP Ariba blocks headless login, and the
+whole flow was validated headed. On a headless server (plexbox, the nightly host) there is no X
+display, so headed Chromium cannot start. To run the capture on the schedule the browser needs a
+virtual framebuffer (Xvfb), driven via `pyvirtualdisplay` — exactly what the council /
+Bid Award Panel scrapers already do behind `--virtual-display`.
+
+## Design
+
+Mirror the existing, in-repo pattern verbatim (`sources/bid_award_panel.py:agenda_fetcher`, wired
+through `enrich-council --virtual-display` and `enrich-titles --virtual-display`):
+
+- Add `virtual_display: bool = False` to `capture_attachments`. When true, start a
+  `pyvirtualdisplay.Display(visible=False, size=(1440, 900))` before the `sync_playwright` block
+  and `stop()` it in a `finally`, so the headed browser renders into the framebuffer. When false,
+  behaviour is unchanged (a real display, as on a dev laptop).
+- `pyvirtualdisplay` already ships with the `council` extra (added in #117) — no dependency
+  change.
+- Add a `--virtual-display` flag to `tb enrich-ariba-attachments`, threaded to
+  `capture_attachments`. It is only meaningful with `--capture` (the only browser-driving mode);
+  `--ingest`/`--reindex` are offline and ignore it.
+
+## Testing
+
+The browser half of this module is exercised live, not unit-tested (the module's own contract —
+`login`/`capture_event`/`capture_attachments` need a real Ariba session). The `Display` wrapper is
+part of that half. The one cheap, meaningful unit test is the **CLI wiring**: `tb
+enrich-ariba-attachments --capture --virtual-display` calls `capture_attachments` with
+`virtual_display=True` (patch `capture_attachments`, assert the kwarg) — the part a typo would
+silently break. Offline, no browser.
+
+## Out of scope (Part B — server deployment)
+
+`sudo apt install xvfb` + Playwright system libs, `playwright install chromium`, the Ariba creds
+in the server env, and the `tb-ariba-attachments` systemd timer. Those are the deployment steps
+in #122, done on plexbox after this lands.
+
+## References
+
+- `sources/bid_award_panel.py:agenda_fetcher` — the `virtual_display` pattern being mirrored.
+- `cli.py` — `enrich-council`/`enrich-titles` `--virtual-display` flags (the CLI precedent).
+- #122 — the deployment this unblocks.

--- a/scrapers/tests/test_ariba_attachments.py
+++ b/scrapers/tests/test_ariba_attachments.py
@@ -181,3 +181,21 @@ def test_cli_reindex_rebuilds_from_the_store(tmp_path, monkeypatch, capsys):
     assert cli.main(["enrich-ariba-attachments", "--reindex"]) == 0
     out = capsys.readouterr().out
     assert "Doc1234567891.zip" in out
+
+
+def test_cli_capture_threads_virtual_display(tmp_path, monkeypatch):
+    # --virtual-display must reach capture_attachments (the flag a headless server needs).
+    from toronto_bids import config, cli
+    from toronto_bids.sources import ariba_attachments as aa
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "bids.sqlite")
+
+    seen = {}
+
+    def fake_capture(conn, log=lambda _m: None, headless=False, virtual_display=False):
+        seen["virtual_display"] = virtual_display
+        return 0
+
+    monkeypatch.setattr(aa, "capture_attachments", fake_capture)
+    assert cli.main(["enrich-ariba-attachments", "--capture", "--virtual-display"]) == 0
+    assert seen["virtual_display"] is True

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -70,6 +70,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--reindex", action="store_true",
         help="Rebuild the index from the bundles already on disk under <DATA_DIR>/ariba/"
              "attachments/ (offline, no browser). Needed once after the recursion change (#123).")
+    p_ariba.add_argument(
+        "--virtual-display", action="store_true",
+        help="Run --capture's headed Chromium under Xvfb (headless servers; needs Xvfb "
+             "installed). Ignored by the offline --ingest/--reindex modes.")
 
     p_titles.add_argument(
         "--reports", action="store_true",
@@ -305,8 +309,9 @@ def _cmd_enrich_ariba_attachments(args) -> int:
             print(f"  bundles ingested: {aa.ingest_downloads(conn, args.ingest, log=out)}")
         elif args.capture:
             print("Capturing open-solicitation attachment bundles (headed browser):")
-            print(f"  bundles captured: "
-                  f"{aa.capture_attachments(conn, log=out, headless=args.headless)}")
+            n = aa.capture_attachments(conn, log=out, headless=args.headless,
+                                       virtual_display=args.virtual_display)
+            print(f"  bundles captured: {n}")
         else:
             open_n = len(aa.open_solicitation_events(conn))
             docs = conn.execute(

--- a/scrapers/toronto_bids/sources/ariba_attachments.py
+++ b/scrapers/toronto_bids/sources/ariba_attachments.py
@@ -485,7 +485,8 @@ def _selected_total_mb(page) -> float | None:
     )
 
 
-def capture_attachments(conn, dest_dir=None, log=lambda _m: None, headless=False) -> int:
+def capture_attachments(conn, dest_dir=None, log=lambda _m: None, headless=False,
+                        virtual_display=False) -> int:
     """Log in, walk every open solicitation, capture and index each bundle. Resumable.
 
     A bundle already on disk is not re-downloaded — the expensive half is the download, and
@@ -514,21 +515,32 @@ def capture_attachments(conn, dest_dir=None, log=lambda _m: None, headless=False
         return 0
 
     captured = 0
-    with sync_playwright() as pw:
-        browser = pw.chromium.launch(
-            headless=headless, args=["--disable-blink-features=AutomationControlled"])
-        try:
-            page = browser.new_context(accept_downloads=True).new_page()
-            login(page, config.ARIBA_USERNAME, config.ARIBA_PASSWORD, log=log)
-            for i, event in enumerate(pending, 1):
-                try:
-                    saved = capture_event(page, event, dest_dir, log=log)
-                    if saved is not None:
-                        store_bundle(conn, saved, event["document_number"], dest_dir)
-                        captured += 1
-                except Exception as exc:
-                    log(f"  Doc{event['document_number']}: FAILED — {exc}")
-                log(f"    {i}/{len(pending)}")
-        finally:
-            browser.close()
+    # A headed browser is required (Ariba blocks headless login), so a headless server needs a
+    # virtual framebuffer — same Xvfb wrapper as sources/bid_award_panel.py:agenda_fetcher.
+    display = None
+    if virtual_display:
+        from pyvirtualdisplay import Display
+        display = Display(visible=False, size=(1440, 900))
+        display.start()
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(
+                headless=headless, args=["--disable-blink-features=AutomationControlled"])
+            try:
+                page = browser.new_context(accept_downloads=True).new_page()
+                login(page, config.ARIBA_USERNAME, config.ARIBA_PASSWORD, log=log)
+                for i, event in enumerate(pending, 1):
+                    try:
+                        saved = capture_event(page, event, dest_dir, log=log)
+                        if saved is not None:
+                            store_bundle(conn, saved, event["document_number"], dest_dir)
+                            captured += 1
+                    except Exception as exc:
+                        log(f"  Doc{event['document_number']}: FAILED — {exc}")
+                    log(f"    {i}/{len(pending)}")
+            finally:
+                browser.close()
+    finally:
+        if display is not None:
+            display.stop()
     return captured


### PR DESCRIPTION
Part A of #122 — the code prerequisite for running the Ariba capture on the nightly (plexbox is headless, and the capture drives a **headed** Chromium because SAP Ariba blocks headless login).

## What changed

Mirrors the existing in-repo Xvfb pattern (`sources/bid_award_panel.py:agenda_fetcher`, wired through `enrich-council`/`enrich-titles --virtual-display`):

- `capture_attachments` gains `virtual_display=False`. When true, it starts a `pyvirtualdisplay.Display(visible=False, size=(1440, 900))` around the browser and `stop()`s it in a `finally`, so the headed Chromium renders into a virtual framebuffer. When false, behaviour is unchanged.
- New `tb enrich-ariba-attachments --virtual-display` flag, threaded to `capture_attachments`. Only meaningful with `--capture`; the offline `--ingest`/`--reindex` modes ignore it.
- No dependency change — `pyvirtualdisplay` already ships with the `council` extra (#117).

## Tests

490 passing. The browser half is exercised live (its own contract), so the added unit test covers the **CLI wiring** — `--capture --virtual-display` reaches `capture_attachments(virtual_display=True)` — the part a typo would silently break.

## Part B (server deployment, not in this PR)

`sudo apt install xvfb` + Playwright system libs, `playwright install chromium`, the Ariba creds in the server env, and a `tb-ariba-attachments` systemd timer on plexbox — done after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)