### PR TITLE
Ariba capture: systemd timer + deployment runbook (#122, Part B)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -93,8 +93,11 @@ sudo .venv/bin/python -m playwright install-deps chromium   # its shared libs (n
 
 # 2. Ariba credentials, appended to the same 0600 env file as the Slack webhook.
 #    The account must NOT have MFA — an unattended login cannot answer a challenge.
+# `read -r "U?prompt"` is bash-only and fails in zsh ("no coprocess"); prompt separately so
+# this works in either shell.
 umask 077
-read -rp 'ARIBA_USERNAME: ' U; read -rsp 'ARIBA_PASSWORD: ' P; echo
+printf 'ARIBA_USERNAME: '; read -r U
+printf 'ARIBA_PASSWORD: '; read -rs P; echo
 printf 'ARIBA_USERNAME=%s\nARIBA_PASSWORD=%s\n' "$U" "$P" >> ~/.config/toronto-bids/tb.env
 unset U P; chmod 600 ~/.config/toronto-bids/tb.env
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -73,10 +73,48 @@ systemctl --user list-timers tb-nightly.timer
 
 Updating is deliberately manual.
 
+## Ariba document capture (opt-in, headed browser under Xvfb) — #122
+
+`tb enrich-ariba-attachments --capture` archives the solicitation documents behind Ariba's
+Respond gate (#117). It drives a **headed** Chromium (Ariba blocks headless login), so on this
+headless box it runs under Xvfb via `--virtual-display`. It writes to the **same** `~/tb-data`
+store, so the nightly's `tb export` includes the attachments. Its own timer, separate from
+`tb-nightly` and well clear of it (noon vs 05:30).
+
+Extra prerequisites beyond the base install:
+
+```shell
+# 1. Xvfb + Chromium's system libraries (the privileged step)
+sudo apt install -y xvfb
+cd ~/toronto-bids/scrapers
+uv sync --extra council --locked        # playwright + pyvirtualdisplay + python-dotenv
+uv run playwright install chromium      # the browser binary (~150MB, non-privileged)
+sudo .venv/bin/python -m playwright install-deps chromium   # its shared libs (needs root)
+
+# 2. Ariba credentials, appended to the same 0600 env file as the Slack webhook.
+#    The account must NOT have MFA — an unattended login cannot answer a challenge.
+umask 077
+read -rp 'ARIBA_USERNAME: ' U; read -rsp 'ARIBA_PASSWORD: ' P; echo
+printf 'ARIBA_USERNAME=%s\nARIBA_PASSWORD=%s\n' "$U" "$P" >> ~/.config/toronto-bids/tb.env
+unset U P; chmod 600 ~/.config/toronto-bids/tb.env
+
+# 3. Units + prove one run before scheduling.
+cp ~/toronto-bids/deploy/tb-ariba-attachments.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user start tb-ariba-attachments.service
+journalctl --user -u tb-ariba-attachments -n 50 --no-pager
+systemctl --user enable --now tb-ariba-attachments.timer
+```
+
+The first run is a full sweep (~1-2h, ~44 open events); later runs are fast (a bundle already
+on disk is skipped). Respond is disabled once a posting closes, so the capture only reaches
+currently-open solicitations — this is why it runs daily, not once.
+
 ## What does NOT run here
 
 `enrich-council` and `enrich-titles --scrape` need a **headed** Chromium (TMMIS is Akamai-gated
-and blocks headless). They are not on the timer and Playwright is not installed:
+and blocks headless). They are not on the timer — but Playwright IS installed now (for the Ariba
+capture above), so they can be run by hand under `--virtual-display` if ever needed:
 
 - `enrich-titles --scrape` **will never find another agenda** — the Bid Award Panel was
   abolished on 2025-10-01 by By-law 766-2025, and the 891 cached pages are the final corpus.

--- a/deploy/tb-ariba-attachments.service
+++ b/deploy/tb-ariba-attachments.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=toronto-bids — archive Ariba solicitation documents (Respond capture)
+Documentation=https://github.com/CivicTechTO/toronto-bids/blob/main/docs/superpowers/specs/2026-07-17-deployment-design.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/toronto-bids/scrapers
+# Same archive as the nightly (%h/tb-data, outside the checkout) — the capture writes
+# ariba/attachments/ and ariba_attachment rows into the shared store, so the nightly's
+# `tb export` includes them.
+Environment=TB_DATA_DIR=%h/tb-data
+# ARIBA_USERNAME / ARIBA_PASSWORD live here (mode 0600, never in git), alongside the Slack
+# webhook. The leading '-' keeps a missing file from being a systemd load error; the capture
+# raises its own clear "creds unset" message instead.
+EnvironmentFile=-%h/.config/toronto-bids/tb.env
+# Headed Chromium under Xvfb (the box is headless). --capture is idempotent and resumable:
+# bundles already on disk are skipped, so a re-run only fetches newly-opened solicitations.
+ExecStart=%h/.local/bin/uv run tb enrich-ariba-attachments --capture --virtual-display
+# The first sweep drives a real browser across ~44 events and can take 1-2h; later runs are
+# fast (mostly skips). Generous ceiling.
+TimeoutStartSec=3h

--- a/deploy/tb-ariba-attachments.timer
+++ b/deploy/tb-ariba-attachments.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run toronto-bids Ariba document capture
+Documentation=https://github.com/CivicTechTO/toronto-bids/blob/main/docs/superpowers/specs/2026-07-17-deployment-design.md
+
+[Timer]
+# Solicitations stay open for weeks, so daily is ample to catch new ones before they close.
+# Noon Toronto keeps it well clear of the 05:30 nightly, so the two never contend for the DB.
+# The box runs UTC; systemd >=252 owns the tz/DST arithmetic (verified with systemd-analyze).
+OnCalendar=*-*-* 12:00:00 America/Toronto
+RandomizedDelaySec=20m
+# A home server is not assumed to be up: run a missed job on the next boot.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Part B of #122 — the deployment config for running the Ariba document capture on plexbox. Builds on #128 (the `--virtual-display` code).

## What's here

- **`deploy/tb-ariba-attachments.service`** — a oneshot running `tb enrich-ariba-attachments --capture --virtual-display`. Writes to the shared `~/tb-data` store (so the nightly export includes the attachments), reads `ARIBA_USERNAME`/`ARIBA_PASSWORD` from the same 0600 env file as the Slack webhook, 3h ceiling for the first full sweep.
- **`deploy/tb-ariba-attachments.timer`** — daily at noon Toronto, well clear of the 05:30 nightly so the two never contend for the DB. `Persistent=true` for a home server that isn't always up.
- **`deploy/README.md`** — the extra prerequisites (Xvfb + Playwright's system libs — the privileged step; the browser download; the Ariba creds) and the enable steps.

## Why daily

Respond is disabled the moment a posting closes, so the capture only ever reaches currently-open solicitations — it must run recurrently to catch new ones before they close. Daily is ample (solicitations stay open for weeks) and cheap after the first sweep (already-captured bundles are skipped).

## Deploy status (in progress on plexbox)

- Server on main with the `--virtual-display` code; `council` extra synced; Chromium binary downloaded. ✅
- Awaiting the two privileged steps (operator): `apt install xvfb` + `playwright install-deps`, and the Ariba creds in the env file.
- Then: install units, one supervised run, enable the timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)