### PR TITLE
Portal listing capture (#135): armed bids&tenders fetch, provisional parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,8 @@ The bids&tenders **portal listings** (`sources/bids_tenders.py`, #135) are captu
 HTTP — the grid loads from `POST /Module/Tenders/en/Tender/Search/<NodeId>` (session cookie +
 the FIRST antiforgery token; **never send `sort=` — it errors**), no browser. `fetch_listings`
 is gated (`PermissionError` until a body's grant is recorded in `docs/permissions/`); TRCA and
-the Zoo granted 2026-07-18. Rows land in `agency_solicitation` (`overwrite=True`, COALESCE-
-enriching any board-report row with the same `native_ref`). Runs in `tb nightly` (isolated) and
+the Zoo granted 2026-07-18. Rows land in `agency_solicitation` (`overwrite=False`, backfill — fills only NULL fields,
+so it never clobbers a board-report title, only fills a board row's empty dates). Runs in `tb nightly` (isolated) and
 `tb enrich-agencies --portal`. **Both portals are currently empty (total=0), so parse_listing is
 PROVISIONAL** — mapped to the grid JS's field names, validated only against a synthetic fixture;
 `--record` dumps raw JSON to seed a real fixture when a bid first appears, at which point the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,17 @@ and attribution conditions in its permission file. Bid documents stay out of sco
 regardless — they sit behind the Vendor clickwrap. Bill 97 amalgamates TRCA away on
 2027-02-01; its capture is deadline-bound.
 
+The bids&tenders **portal listings** (`sources/bids_tenders.py`, #135) are captured over plain
+HTTP — the grid loads from `POST /Module/Tenders/en/Tender/Search/<NodeId>` (session cookie +
+the FIRST antiforgery token; **never send `sort=` — it errors**), no browser. `fetch_listings`
+is gated (`PermissionError` until a body's grant is recorded in `docs/permissions/`); TRCA and
+the Zoo granted 2026-07-18. Rows land in `agency_solicitation` (`overwrite=True`, COALESCE-
+enriching any board-report row with the same `native_ref`). Runs in `tb nightly` (isolated) and
+`tb enrich-agencies --portal`. **Both portals are currently empty (total=0), so parse_listing is
+PROVISIONAL** — mapped to the grid JS's field names, validated only against a synthetic fixture;
+`--record` dumps raw JSON to seed a real fixture when a bid first appears, at which point the
+parser (and a possible portal `agency_award` path) is completed. No bid documents — Vendor clickwrap.
+
 ### Export seam (`export/`)
 
 `build_export_document(conn)` in `export/document.py` is deterministic given a `generated_at` (result-shaping queries ORDER BY, no file I/O); `export_json` is a thin serializer over it. A new publishing destination is another function over the same builder — keep all shaping logic in `document.py`.

--- a/docs/superpowers/plans/2026-07-18-bidsandtenders-portal-listings.md
+++ b/docs/superpowers/plans/2026-07-18-bidsandtenders-portal-listings.md
@@ -1,0 +1,616 @@
+# bids&tenders Portal Listing Capture (#135) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Arm a verified plain-HTTP capture of TRCA/Zoo bids&tenders listing metadata into `agency_solicitation`, running nightly and safely no-opping while the portals are empty; parser is provisional until a real record can validate it.
+
+**Architecture:** `sources/bids_tenders.py` replaces its gate-only stub with a real source: `fetch_listings` (own `httpx.Client` doing the antiforgery session dance, paged, rate-limited), `parse_listing` (pure, PROVISIONAL — mapped to the JS-documented schema), `store_listings` (COALESCE upsert), `record_listings` (dump raw JSON for future fixtures). Wired into `tb enrich-agencies --portal [--record]` and an isolated `tb nightly` step.
+
+**Tech Stack:** Python 3.12, `uv`, httpx (already a dep), sqlite3, pytest (offline).
+
+## Global Constraints
+
+- **Never send the `sort` query param** to `/Tender/Search` — its space/comma triggers a server error (verified live 2026-07-18). Query params are `status,limit,start,dir,from,to` only.
+- Use the **first** `__RequestVerificationToken` on the landing page (the `#bidDetailAntiForgery`-scoped one 302s).
+- The session needs one `httpx.Client` across the landing GET and the search POSTs so the antiforgery cookie persists; extract `NodeId` + token from the landing HTML.
+- **Rate-limit**: a deliberate `time.sleep` (default 1.5 s) before every search POST — the explicit "low-impact / off-peak" condition in both permission files.
+- **No bid documents, ever** — listings only (Vendor clickwrap). No login, no writes, read-only.
+- `parse_listing` is **PROVISIONAL** (module docstring says so): validated only against a synthetic fixture until a real record is captured. The `agency_award`-from-awarded path is **not built** in this plan.
+- Portals are empty today (`total=0`); every path must no-op cleanly on empty. Per-body isolation: TRCA failing never stops Zoo.
+- Tests offline, no network: `cd scrapers && uv run pytest`. Commit messages end with the project's Co-Authored-By + Claude-Session trailer. Branch: `feat-135-portal-listings` (already checked out; the spec is committed there).
+
+---
+
+### Task 1: `fetch_listings` — the verified session + paging (impure) and its gate
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/bids_tenders.py` (replace the stub)
+- Modify: `scrapers/tests/test_agencies.py` (update the two gate tests, which reference the old stub behaviour)
+
+**Interfaces:**
+- Consumes: `config.BIDS_TENDERS_PORTALS`, `config.USER_AGENT`, `config.HTTP_TIMEOUT`.
+- Produces: `fetch_listings(portal, *, delay=1.5, log=...) -> Iterator[dict]` yielding each raw record augmented with `buyer_slug` and `status_code`; `_search_params(status, start, limit) -> dict` (pure, testable); `_STATUS_CODES`. Later tasks consume these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `test_gate_blocks_a_portal_without_permission` and `test_enabled_portal_has_no_capture_yet` in `scrapers/tests/test_agencies.py` (their premises change: `fetch_listings` now takes `portal` alone, and an enabled portal no longer raises `NotImplementedError`). Keep `test_no_portal_is_enabled_without_a_recorded_permission` untouched. New tests:
+
+```python
+def test_gate_blocks_a_portal_without_permission():
+    import pytest as _pytest
+    from toronto_bids.sources.bids_tenders import fetch_listings
+    ungranted = {"slug": "example", "portal_url": "https://example.bidsandtenders.ca/",
+                 "enabled": False, "permission": None}
+    with _pytest.raises(PermissionError):
+        next(fetch_listings(ungranted))          # generator: gate fires on first pull
+
+
+def test_search_params_never_include_sort():
+    from toronto_bids.sources.bids_tenders import _search_params
+    p = _search_params(status=1, start=0, limit=50)
+    assert "sort" not in p                        # sort= triggers a server error (verified)
+    assert p == {"status": 1, "limit": 50, "start": 0, "dir": "desc", "from": "", "to": ""}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_agencies.py -k "gate_blocks or search_params" -v`
+Expected: FAIL — `_search_params` undefined; `fetch_listings` still has the old two-arg signature.
+
+- [ ] **Step 3: Replace the stub with the real source**
+
+Write `scrapers/toronto_bids/sources/bids_tenders.py`:
+
+```python
+"""The bids&tenders portal source (#135) — listing metadata, PROVISIONAL parser.
+
+Reads public bid listings from a body's bids&tenders portal via its plain-HTTP JSON grid
+endpoint (no browser). GATED: fetch_listings raises PermissionError unless the portal's
+config entry is enabled, which happens only when the body's written grant is recorded in
+docs/permissions/ (the PMMD/Ariba precedent). Listings only — bid documents sit behind the
+Vendor clickwrap and are never fetched.
+
+PROVISIONAL: as of 2026-07-18 both permitted portals (TRCA, Zoo) are empty, so parse_listing
+is mapped against the field names documented in the portal's own grid JS but has NOT been
+validated against a real record. When a bid first appears, `tb enrich-agencies --portal
+--record` captures real JSON to fixtures and the parser is completed and re-validated.
+"""
+import re
+import time
+
+import httpx
+
+from toronto_bids import config
+from toronto_bids.models import AgencySolicitation
+from toronto_bids.store import db
+
+_LANDING = "Module/Tenders/en"
+_SEARCH = "Module/Tenders/en/Tender/Search/"
+_NODE_RE = re.compile(r'id="NodeId"[^>]*value="([^"]+)"')
+_TOKEN_RE = re.compile(r'name="__RequestVerificationToken"[^>]*value="([^"]+)"')
+# The status codes the endpoint accepts (Open / Awarded / Cancelled / ...). The exact
+# code->label mapping is recorded when data first appears; the sweep covers them all.
+_STATUS_CODES = range(0, 6)
+_PAGE = 50
+_DELAY = 1.5
+
+
+def _search_params(status: int, start: int, limit: int = _PAGE) -> dict:
+    # NEVER include 'sort' — 'sort=ClosingDate desc,Id' (space/comma) triggers a server error
+    # that redirects to Error?aspxerrorpath (verified live 2026-07-18). Default order is fine.
+    return {"status": status, "limit": limit, "start": start, "dir": "desc", "from": "", "to": ""}
+
+
+def fetch_listings(portal: dict, *, delay: float = _DELAY, log=lambda _m: None):
+    """Yield every listing record for a portal, across all statuses, paged and rate-limited.
+
+    Manages its own httpx.Client (the antiforgery cookie set on the landing GET must persist
+    to the search POSTs — a session concern specific to this source, not the shared HttpClient).
+    Yields each raw JSON record with `buyer_slug` and `status_code` attached. On an empty portal
+    (total=0, the current reality) this yields nothing — a clean no-op.
+    """
+    if not portal.get("enabled"):
+        raise PermissionError(
+            f"bids&tenders portal '{portal['slug']}' is not enabled: fetching requires the "
+            f"body's written permission recorded in docs/permissions/ (see #135 / #103). "
+            f"Current permission record: {portal.get('permission')!r}")
+    base = portal["portal_url"].rstrip("/") + "/"
+    client = httpx.Client(
+        headers={"User-Agent": config.USER_AGENT, "X-Requested-With": "XMLHttpRequest"},
+        timeout=config.HTTP_TIMEOUT, follow_redirects=True)
+    try:
+        land = client.get(base + _LANDING).text
+        node_m, tok_m = _NODE_RE.search(land), _TOKEN_RE.search(land)
+        if not (node_m and tok_m):
+            raise RuntimeError(f"bids&tenders {portal['slug']}: no NodeId/token on landing page")
+        node, token = node_m.group(1), tok_m.group(1)   # FIRST token (bidDetail-scoped one 302s)
+        for status in _STATUS_CODES:
+            start = 0
+            while True:
+                time.sleep(delay)                        # rate-limit (permission condition)
+                resp = client.post(base + _SEARCH + node,
+                                   params=_search_params(status, start),
+                                   data={"keywords": "", "__RequestVerificationToken": token})
+                try:
+                    payload = resp.json()
+                except ValueError:
+                    log(f"  {portal['slug']} status={status} start={start}: non-JSON, skipping")
+                    break
+                rows = payload.get("data") or []
+                total = payload.get("total") or 0
+                for rec in rows:
+                    yield {**rec, "buyer_slug": portal["slug"], "status_code": status}
+                start += len(rows)
+                if not rows or start >= total:
+                    break
+    finally:
+        client.close()
+```
+
+(The rest — `parse_listing`, `store_listings`, `record_listings` — is added in Tasks 2-4.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd scrapers && uv run pytest tests/test_agencies.py -v`
+Expected: PASS (gate + `_search_params` + the untouched `test_no_portal_is_enabled_without_a_recorded_permission`). Then `uv run pytest` — full suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/bids_tenders.py scrapers/tests/test_agencies.py
+git commit -m "feat(portal): bids&tenders fetch_listings — verified session + paging, gated (#135)"
+```
+
+---
+
+### Task 2: `parse_listing` (PROVISIONAL) + synthetic fixture
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/bids_tenders.py` (append)
+- Create: `scrapers/tests/fixtures/agencies/bids_tenders_record_sample.json`
+- Modify: `scrapers/tests/fixtures/agencies/SOURCES.md` (note the synthetic fixture)
+- Create: `scrapers/tests/test_bids_tenders.py`
+
+**Interfaces:**
+- Consumes: Task 1's module; `AgencySolicitation` model.
+- Produces: `parse_listing(record: dict, buyer_id: int) -> AgencySolicitation`. Task 3 consumes it.
+
+- [ ] **Step 1: Create the synthetic fixture**
+
+`scrapers/tests/fixtures/agencies/bids_tenders_record_sample.json` — a hand-built record matching the JS-documented schema (`Id`, `Title`, closing date, counts) plus the `buyer_slug`/`status_code` that `fetch_listings` attaches. **Synthetic — the exact field names/formats are unverified until a real record is captured (#135).**
+
+```json
+{
+  "Id": "0f9a1b2c-3d4e-5f60-7182-93a4b5c6d7e8",
+  "ReferenceNumber": "RFT-2026-014",
+  "Title": "Trail Bridge Replacement - Example Creek",
+  "ClosingDate": "2026-08-15T14:00:00",
+  "DatePosted": "2026-07-20T09:00:00",
+  "StatusText": "Open",
+  "Documents": 3,
+  "Addendums": 0,
+  "PlanTakers": 5,
+  "buyer_slug": "trca",
+  "status_code": 1
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`scrapers/tests/test_bids_tenders.py`:
+
+```python
+import json
+import pathlib
+
+from toronto_bids.sources.bids_tenders import parse_listing
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "agencies"
+
+
+def _sample():
+    return json.loads((FIXTURES / "bids_tenders_record_sample.json").read_text())
+
+
+def test_parse_listing_maps_documented_fields():
+    row = parse_listing(_sample(), buyer_id=7)
+    assert row.buyer_id == 7
+    assert row.native_ref == "RFT-2026-014"          # ReferenceNumber, normalized
+    assert row.title == "Trail Bridge Replacement - Example Creek"
+    assert row.status == "Open"
+    assert row.closing_date == "2026-08-15T14:00:00"
+    assert row.posted_date == "2026-07-20T09:00:00"
+    assert row.portal_url.endswith("/Tender/Detail/0f9a1b2c-3d4e-5f60-7182-93a4b5c6d7e8")
+    assert row.source == "bids_tenders"
+
+
+def test_parse_listing_falls_back_to_id_when_no_reference():
+    rec = _sample(); del rec["ReferenceNumber"]
+    row = parse_listing(rec, buyer_id=7)
+    assert row.native_ref == "0F9A1B2C-3D4E-5F60-7182-93A4B5C6D7E8"   # Id, uppercased
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_bids_tenders.py -v`
+Expected: FAIL — `cannot import name 'parse_listing'`.
+
+- [ ] **Step 4: Implement `parse_listing`**
+
+Append to `bids_tenders.py`:
+
+```python
+# Portal base per slug, for building a record's detail URL. Derived from config so the two
+# stay in sync.
+_PORTAL_BASE = {p["slug"]: p["portal_url"].rstrip("/") for p in config.BIDS_TENDERS_PORTALS}
+
+_WS = re.compile(r"\s+")
+
+
+def _native_ref(record: dict) -> str:
+    """The body's own bid identifier, normalized like the board-report path (trim/upper/
+    collapse-ws) so a portal row and a board-report row for one procurement share a key."""
+    raw = record.get("ReferenceNumber") or record.get("BidNumber") or record.get("Id") or ""
+    return _WS.sub(" ", str(raw)).strip().upper()
+
+
+def parse_listing(record: dict, buyer_id: int) -> AgencySolicitation:
+    """Map one raw portal record to an AgencySolicitation. PROVISIONAL (see module docstring):
+    field names/formats are from the grid JS, unverified until a real record is captured."""
+    base = _PORTAL_BASE.get(record.get("buyer_slug"), "")
+    rid = record.get("Id")
+    portal_url = f"{base}/Module/Tenders/en/Tender/Detail/{rid}" if (base and rid) else None
+    return AgencySolicitation(
+        buyer_id=buyer_id,
+        native_ref=_native_ref(record),
+        title=record.get("Title"),
+        status=record.get("StatusText") or record.get("Status"),
+        posted_date=record.get("DatePosted") or record.get("PostDate"),
+        closing_date=record.get("ClosingDate") or record.get("BidClosingDate"),
+        portal_url=portal_url,
+        source="bids_tenders",
+    )
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd scrapers && uv run pytest tests/test_bids_tenders.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Note the synthetic fixture in SOURCES.md**
+
+Append to `scrapers/tests/fixtures/agencies/SOURCES.md`:
+
+```markdown
+## bids_tenders_record_sample.json — SYNTHETIC (#135)
+
+Hand-built, NOT a real capture. As of 2026-07-18 both permitted bids&tenders portals (TRCA,
+Zoo) are empty (total=0, all statuses), so no real listing record exists to record. This
+fixture matches the field names documented in the portal's grid JS
+(Module/Tenders/Resources/scriptsV2/home/index.js: Id, Title, ClosingDate, Documents,
+Addendums, PlanTakers) and exercises parse_listing's mapping mechanics only. `parse_listing`
+is PROVISIONAL until `tb enrich-agencies --portal --record` captures a real record and replaces
+this fixture (#135 deferred item).
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/bids_tenders.py scrapers/tests/test_bids_tenders.py \
+        scrapers/tests/fixtures/agencies/bids_tenders_record_sample.json \
+        scrapers/tests/fixtures/agencies/SOURCES.md
+git commit -m "feat(portal): provisional parse_listing + synthetic fixture (#135)"
+```
+
+---
+
+### Task 3: `store_listings` — COALESCE upsert into agency_solicitation
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/bids_tenders.py` (append)
+- Modify: `scrapers/tests/test_bids_tenders.py` (append)
+
+**Interfaces:**
+- Consumes: `parse_listing` (Task 2), `db.upsert_row`, `AgencySolicitation`, `buyers.seed_buyers`.
+- Produces: `store_listings(conn, records, buyer_ids) -> int` where `buyer_ids` is the `{slug: id}` map from `seed_buyers`. Returns the number of rows upserted.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scrapers/tests/test_bids_tenders.py`:
+
+```python
+import sqlite3
+
+import pytest
+
+from toronto_bids.buyers import seed_buyers
+from toronto_bids.models import AgencySolicitation
+from toronto_bids.sources.bids_tenders import store_listings
+from toronto_bids.store import db
+
+
+@pytest.fixture
+def conn():
+    c = db.connect(":memory:")
+    db.init_db(c)
+    yield c
+    c.close()
+
+
+def test_store_listings_inserts_portal_row(conn):
+    ids = seed_buyers(conn)
+    n = store_listings(conn, [_sample()], ids)
+    assert n == 1
+    row = conn.execute("SELECT native_ref, title, status, source FROM agency_solicitation").fetchone()
+    assert row["native_ref"] == "RFT-2026-014"
+    assert row["source"] == "bids_tenders"
+
+
+def test_store_listings_enriches_a_board_report_row(conn):
+    ids = seed_buyers(conn)
+    # A board-report row already exists for the same ref, with a title but no dates/status.
+    db.upsert_row(conn, AgencySolicitation(
+        buyer_id=ids["trca"], native_ref="RFT-2026-014", title="Board title",
+        status="awarded", source="trca_board"), overwrite=False)
+    store_listings(conn, [_sample()], ids)
+    rows = conn.execute("SELECT title, status, closing_date FROM agency_solicitation "
+                        "WHERE native_ref='RFT-2026-014'").fetchall()
+    assert len(rows) == 1                              # COALESCE-enriched, not duplicated
+    assert rows[0]["title"] == "Board title"           # board title preserved (overwrite guard)
+    assert rows[0]["closing_date"] == "2026-08-15T14:00:00"  # portal filled the empty date
+
+
+def test_store_listings_empty_is_noop(conn):
+    ids = seed_buyers(conn)
+    assert store_listings(conn, [], ids) == 0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_bids_tenders.py -k store -v`
+Expected: FAIL — `cannot import name 'store_listings'`.
+
+- [ ] **Step 3: Implement `store_listings`**
+
+Append to `bids_tenders.py`:
+
+```python
+def store_listings(conn, records, buyer_ids: dict) -> int:
+    """Upsert each parsed listing into agency_solicitation. overwrite=True: the portal owns the
+    listing fields (status/dates), so a nightly re-fetch keeps an open bid current, while
+    COALESCE still protects a board-report-supplied title from being nulled. Skips a record
+    whose buyer_slug is not a seeded buyer. Returns rows upserted."""
+    n = 0
+    for record in records:
+        buyer_id = buyer_ids.get(record.get("buyer_slug"))
+        if buyer_id is None:
+            continue
+        db.upsert_row(conn, parse_listing(record, buyer_id), overwrite=True)
+        n += 1
+    conn.commit()
+    return n
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd scrapers && uv run pytest tests/test_bids_tenders.py -v` then `uv run pytest`
+Expected: all PASS. (Note the `overwrite=True` + COALESCE: `db._upsert_keyed` fills the NULL `closing_date` but keeps the non-NULL board title — verify the enrich test proves both.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/bids_tenders.py scrapers/tests/test_bids_tenders.py
+git commit -m "feat(portal): store_listings — COALESCE upsert into agency_solicitation (#135)"
+```
+
+---
+
+### Task 4: `record_listings` + `tb enrich-agencies --portal [--record]`
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/bids_tenders.py` (append `record_listings` + `run_portal_capture`)
+- Modify: `scrapers/toronto_bids/config.py` (append `PORTAL_RECORDINGS_DIR`)
+- Modify: `scrapers/toronto_bids/cli.py` (`--portal`/`--record` flags + wiring in `_cmd_enrich_agencies`)
+- Modify: `scrapers/tests/test_bids_tenders.py` (append)
+
+**Interfaces:**
+- Consumes: `fetch_listings`, `store_listings`, `seed_buyers`, `config.BIDS_TENDERS_PORTALS`.
+- Produces: `record_listings(records, out_dir) -> int`; `run_portal_capture(conn, *, record=False, only=None, log=...) -> dict` (per-body isolated orchestrator returning `{slug: count}` and never raising for one body's failure). `run_portal_capture` is what nightly (Task 5) calls.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scrapers/tests/test_bids_tenders.py`:
+
+```python
+def test_record_listings_writes_one_file_per_record(tmp_path):
+    from toronto_bids.sources.bids_tenders import record_listings
+    recs = [dict(_sample(), status_code=1), dict(_sample(), status_code=3)]
+    n = record_listings(recs, tmp_path)
+    assert n == 2
+    written = sorted(p.name for p in tmp_path.glob("*.json"))
+    assert all(name.startswith("trca-") for name in written)
+
+
+def test_run_portal_capture_isolates_a_failing_body(conn, monkeypatch):
+    from toronto_bids.sources import bids_tenders as bt
+    ids = seed_buyers(conn)
+
+    def fake_fetch(portal, **_kw):
+        if portal["slug"] == "trca":
+            raise RuntimeError("boom")            # one body fails
+        yield dict(_sample(), buyer_slug="toronto-zoo")
+
+    monkeypatch.setattr(bt, "fetch_listings", fake_fetch)
+    result = bt.run_portal_capture(conn, log=lambda _m: None)
+    assert result["toronto-zoo"] == 1             # zoo still captured
+    assert "trca" in result and result["trca"] == "FAILED: boom"   # trca isolated, recorded
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_bids_tenders.py -k "record_listings or portal_capture" -v`
+Expected: FAIL — names undefined.
+
+- [ ] **Step 3: Implement**
+
+Append to `config.py`:
+
+```python
+# Raw bids&tenders listing JSON captured by `--record`, one file per record — the seed for
+# real parser fixtures once a portal has data (#135).
+PORTAL_RECORDINGS_DIR = DATA_DIR / "agencies" / "portal_recordings"
+```
+
+Append to `bids_tenders.py`:
+
+```python
+import json
+
+from toronto_bids.buyers import seed_buyers
+
+
+def record_listings(records, out_dir) -> int:
+    """Write each raw record to out_dir/<slug>-<status>-<n>.json — the seed for real fixtures
+    once a portal has data. Returns the count written."""
+    import pathlib
+    out = pathlib.Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    n = 0
+    for record in records:
+        slug = record.get("buyer_slug", "unknown")
+        status = record.get("status_code", "x")
+        (out / f"{slug}-{status}-{n}.json").write_text(json.dumps(record, indent=1, default=str))
+        n += 1
+    return n
+
+
+def run_portal_capture(conn, *, record: bool = False, only=None, log=lambda _m: None) -> dict:
+    """Fetch + store (and optionally record) every enabled portal, per-body isolated: one
+    body's failure is caught and reported, never stops the others. Returns {slug: count | 'FAILED: ...'}."""
+    buyer_ids = seed_buyers(conn)
+    result = {}
+    for portal in config.BIDS_TENDERS_PORTALS:
+        if not portal["enabled"]:
+            continue
+        if only and portal["slug"] not in only:
+            continue
+        try:
+            records = list(fetch_listings(portal, log=log))
+            if record:
+                written = record_listings(records, config.PORTAL_RECORDINGS_DIR)
+                log(f"  {portal['slug']}: recorded {written} raw record(s)")
+            result[portal["slug"]] = store_listings(conn, records, buyer_ids)
+            log(f"  {portal['slug']}: {result[portal['slug']]} listing(s) stored")
+        except Exception as exc:                       # per-body isolation (empty portal is fine; a real error is caught)
+            result[portal["slug"]] = f"FAILED: {exc}"
+            log(f"  FAILED {portal['slug']}: {exc}")
+    return result
+```
+
+Wire the CLI. In `cli.py`'s `build_parser`, add to the `enrich-agencies` subparser (`p_ag`):
+
+```python
+    p_ag.add_argument("--portal", action="store_true",
+                      help="Capture bids&tenders portal listings for enabled+permitted bodies "
+                           "(plain HTTP, rate-limited). Currently a no-op while portals are empty.")
+    p_ag.add_argument("--record", action="store_true",
+                      help="With --portal: also dump each raw JSON record under "
+                           "<DATA_DIR>/agencies/portal_recordings/ to seed parser fixtures.")
+```
+
+In `_cmd_enrich_agencies`, after the existing trca/zoo blocks and before `build_supplier_dimension`, add:
+
+```python
+        if args.portal:
+            try:
+                from toronto_bids.sources.bids_tenders import run_portal_capture
+                only = None if not args.only else {"trca": "trca", "zoo": "toronto-zoo"}[args.only]
+                res = run_portal_capture(conn, record=args.record,
+                                         only={only} if only else None, log=out)
+                print(f"  portal listings      : {res}")
+                for slug, v in res.items():
+                    if isinstance(v, str) and v.startswith("FAILED"):
+                        failures.append((f"portal:{slug}", v))
+            except Exception as exc:
+                failures.append(("portal", str(exc)))
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd scrapers && uv run pytest tests/test_bids_tenders.py -v` then `uv run pytest`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/bids_tenders.py scrapers/toronto_bids/config.py \
+        scrapers/toronto_bids/cli.py scrapers/tests/test_bids_tenders.py
+git commit -m "feat(portal): --record mode + run_portal_capture orchestrator + CLI wiring (#135)"
+```
+
+---
+
+### Task 5: nightly integration + CLAUDE.md
+
+**Files:**
+- Modify: `scrapers/toronto_bids/cli.py` (`_cmd_nightly` — add an isolated portal step)
+- Modify: `CLAUDE.md` (extend the agency-capture subsection)
+- Modify: `scrapers/tests/test_bids_tenders.py` (append a nightly-isolation assertion via `run_portal_capture`, already covered — add a doc-smoke instead)
+
+**Interfaces:**
+- Consumes: `run_portal_capture` (Task 4).
+
+- [ ] **Step 1: Add the nightly step**
+
+In `cli.py`'s `_cmd_nightly`, inside the `if conn is not None:` block, after the `award_summary` step and before `export`, add an isolated portal step mirroring the existing pattern:
+
+```python
+        try:
+            from toronto_bids.sources.bids_tenders import run_portal_capture
+            res = run_portal_capture(conn, log=out)
+            for slug, v in res.items():
+                if isinstance(v, str) and v.startswith("FAILED"):
+                    failures.append((f"portal:{slug}", v))
+        except Exception as exc:
+            failures.append(("portal", str(exc)))
+```
+
+(Isolated exactly like `sync` and `award_summary`: a portal failure records to `failures` and never stops export. On empty portals it stores 0 and adds nothing.)
+
+- [ ] **Step 2: Verify nightly still composes**
+
+Run: `cd scrapers && uv run pytest tests/test_nightly.py -v` (if present) then `uv run pytest`
+Expected: PASS — the new step is caught like the others; existing nightly tests unaffected. If `test_nightly.py` monkeypatches steps, confirm the portal step's import doesn't break the patched path; if it does, guard the import as the other in-function imports are.
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+In the "Agency capture" subsection, append:
+
+```markdown
+The bids&tenders **portal listings** (`sources/bids_tenders.py`, #135) are captured over plain
+HTTP — the grid loads from `POST /Module/Tenders/en/Tender/Search/<NodeId>` (session cookie +
+the FIRST antiforgery token; **never send `sort=` — it errors**), no browser. `fetch_listings`
+is gated (`PermissionError` until a body's grant is recorded in `docs/permissions/`); TRCA and
+the Zoo granted 2026-07-18. Rows land in `agency_solicitation` (`overwrite=True`, COALESCE-
+enriching any board-report row with the same `native_ref`). Runs in `tb nightly` (isolated) and
+`tb enrich-agencies --portal`. **Both portals are currently empty (total=0), so parse_listing is
+PROVISIONAL** — mapped to the grid JS's field names, validated only against a synthetic fixture;
+`--record` dumps raw JSON to seed a real fixture when a bid first appears, at which point the
+parser (and a possible portal `agency_award` path) is completed. No bid documents — Vendor clickwrap.
+```
+
+- [ ] **Step 4: Full suite + commit**
+
+Run: `cd scrapers && uv run pytest`
+Expected: all PASS.
+
+```bash
+git add scrapers/toronto_bids/cli.py CLAUDE.md scrapers/tests/test_bids_tenders.py
+git commit -m "feat(portal): isolated nightly portal step; document the capture (#135)"
+```
+
+---
+
+## After the last task
+
+Run the full suite once more. Then the real-world verification: `cd scrapers && uv run tb enrich-agencies --portal --record` — expected today to fetch, store **0 rows**, record **0 files**, exit 0 (the honest verification while portals are empty). Use superpowers:finishing-a-development-branch. **#135 stays open** for the deferred parser-validation task (triggered when a portal first has data); note that on the issue. #109/#132 already addressed by the board-report capture.

--- a/docs/superpowers/specs/2026-07-18-bidsandtenders-portal-listings-design.md
+++ b/docs/superpowers/specs/2026-07-18-bidsandtenders-portal-listings-design.md
@@ -10,19 +10,42 @@ bodies, and keeps it current as open bids come and go.
 ## The finding that shapes it
 
 The portal is a JS single-page app, but its grid loads from a plain-HTTP JSON endpoint — **no
-browser required** (unlike the council/Ariba scrapers). Probed live 2026-07-18:
+browser required** (unlike the council/Ariba scrapers). Probed live 2026-07-18 and fully solved:
 
-- `GET /Module/Tenders/en` returns the landing HTML carrying a `NodeId` (a per-portal GUID) and
-  an ASP.NET `__RequestVerificationToken` (hidden field + a paired cookie set on the response).
-- `POST /Module/Tenders/en/Tender/Search/<NodeId>?status=<n>&limit=<n>&start=<n>&dir=desc&from=&to=&sort=ClosingDate desc,Id`
+- `GET /Module/Tenders/en` returns the landing HTML carrying a `NodeId` (a per-portal GUID) and,
+  in `#bidDetailAntiForgery` / hidden fields, `__RequestVerificationToken` values plus a paired
+  antiforgery **cookie** set on the response.
+- `POST /Module/Tenders/en/Tender/Search/<NodeId>?status=<n>&limit=<n>&start=<n>&dir=desc&from=&to=`
   with body `{keywords: "", __RequestVerificationToken: <token>}` and the session cookie returns
   `{"success": true, "data": [ …records… ], "total": <n>}`.
-- Without the session cookie + token the endpoint 302s to an error page. The pairing is standard
-  ASP.NET antiforgery: the cookie set on the landing GET must accompany the hidden-field token.
+- **Two live gotchas, both load-bearing:** (1) use the **FIRST** `__RequestVerificationToken` on
+  the page — the `#bidDetailAntiForgery`-scoped one 302s. (2) **Never send the `sort` query param**
+  (`sort=ClosingDate desc,Id`) — its space/comma triggers an unhandled server error that
+  redirects to `Error?aspxerrorpath=…`. Omit `sort` entirely; the default order is fine.
+- The record schema is documented in the grid JS (`Module/Tenders/Resources/scriptsV2/home/index.js`):
+  `Id` (→ detail URL `/Module/Tenders/en/Tender/Detail/<Id>`), `Title`, a closing-date field, and
+  `Documents` / `Addendums` / `PlanTakers` counts, with a separate Awarded section.
 - Both portals expose the same endpoint, differing only by host and `NodeId`
   (TRCA `950af760-…`, Zoo `d572c998-…`).
 
 Because it is plain HTTP, it can join the unattended nightly path.
+
+## The empty-portal reality (drives the phasing)
+
+**As of 2026-07-18 both permitted portals are completely empty** — `total=0` for every status
+(Open, Awarded, Cancelled, …) across a 2010–2027 date range; TRCA's homepage reads "no open bids."
+This is consistent with the board-report finding that TRCA's real history lives on eSCRIBE (already
+captured, #136) and both bodies adopted bids&tenders only recently. Consequences that shape the
+build (decided with the maintainer — "option A: arm the infrastructure now"):
+
+- There is **no live record to record a fixture from today**, so the parser cannot be validated
+  against real data yet. Building a parser validated only against a hand-built fixture is the exact
+  anti-pattern that produced three wrong parsers earlier in #135 — so **`parse_listing` is written
+  against the JS-documented schema but treated as PROVISIONAL** until a real record validates it.
+- The fetch is verified working (it correctly returns `total=0`), so we **arm the infrastructure
+  now**: fetch + a raw-JSON **recording mode** + isolated nightly hook that safely no-ops on empty.
+  The moment a bid appears, its raw JSON is captured to a fixture and `parse_listing` is completed
+  and validated against it. Nothing is lost when bids appear.
 
 ## Decisions (settled in brainstorming)
 
@@ -44,34 +67,50 @@ Because it is plain HTTP, it can join the unattended nightly path.
 Pure/impure split in `sources/bids_tenders.py` (replacing the current gate-only stub, whose
 `PermissionError`-on-disabled behaviour is retained):
 
-### Impure half — `fetch_listings(http, portal) -> Iterable[dict]`
+### Impure half — `fetch_listings(http, portal) -> Iterator[dict]`
 
 1. Re-raise `PermissionError` if `not portal["enabled"]` (unchanged from the stub — a future
    portal added without a recorded grant stays blocked).
-2. **Establish a session**: `GET {portal_url}Module/Tenders/en`, following redirects and
-   accumulating cookies on the client; extract `NodeId` and `__RequestVerificationToken` from the
-   returned HTML.
-3. **Fetch each status** in `_STATUS_CODES` (the set the endpoint accepts — confirmed at fixture
-   time; provisionally the codes behind Open/Closing/Closed/Awarded). For each, page with
-   `limit`/`start` until `start >= total`, yielding every record. A `size` cap per page (e.g. 50)
+2. **Establish a session** on a fresh `httpx.Client` (cookies must persist across the landing GET
+   and the search POSTs): `GET {portal_url}Module/Tenders/en` following redirects; extract `NodeId`
+   and the **first** `__RequestVerificationToken` from the returned HTML.
+3. **Fetch each status** in `_STATUS_CODES` (provisionally `range(0, 6)` — the exact status→label
+   mapping is recorded when data first appears). Query params `status,limit,start,dir,from,to`
+   (**no `sort`**); body `{keywords: "", __RequestVerificationToken: <token>}`. Page with
+   `limit`/`start` until `start >= total`, yielding every record. A `limit` cap per page (e.g. 50)
    keeps requests modest.
 4. **Rate-limit**: a deliberate `time.sleep` between every HTTP request (a small constant, e.g.
    1–2 s), so a full sweep stays low-impact — the explicit condition both bodies set.
 5. Attach `buyer_slug` and `status_code` to each yielded record so the pure half needs no
-   external context.
+   external context. On an empty portal this yields nothing and is a clean no-op.
 
-`HttpClient` gains a small `post_form(url, params, data)` helper if it lacks one (it has
-`post_json`; the portal needs form-encoded body + query params + persisted cookies — httpx.Client
-already persists cookies, so this is a thin addition, not a new client).
+The session dance lives in `fetch_listings` on its own `httpx.Client`, not `HttpClient` — the
+antiforgery cookie+token pairing is specific to this source and does not belong in the shared
+client. Retry/backoff on transient errors is still valuable but the token/cookie extraction is
+bespoke.
 
-### Pure half — `parse_listing(record, buyer_id) -> AgencySolicitation` (and optional `AgencyAward`)
+### Recording mode — `record_listings(portal, out_dir) -> int`
 
-Maps one JSON record to a model. `native_ref` is the portal's bid number, normalized by the same
-trim/uppercase/whitespace-collapse the board-report path uses, so a portal row and a board-report
-row for the same procurement share a key and COALESCE into one enriched row. Fields:
-`title`, `status` (mapped from the status code / the record's own status text), `posted_date`,
-`closing_date`, `portal_url` (the record's own detail URL), `source="bids_tenders"`. Tested
-against recorded JSON fixtures — no network, no browser.
+Writes each raw JSON record fetched to `out_dir/<slug>-<status>-<n>.json`. Run manually
+(`tb enrich-agencies --portal --record`) so that the FIRST time a portal has data, we capture real
+records to turn into parser fixtures — the step that unblocks completing `parse_listing`. Returns
+the count written (0 while portals are empty).
+
+### Pure half — `parse_listing(record, buyer_id, buyer_slug) -> AgencySolicitation` (PROVISIONAL)
+
+Maps one JSON record to a model. Written against the JS-documented field names (`Id`, `Title`,
+closing-date field, detail URL `/Module/Tenders/en/Tender/Detail/<Id>`); `native_ref` is the
+portal's bid identifier, normalized by the same trim/uppercase/whitespace-collapse the
+board-report path uses, so a portal row and a board-report row for the same procurement share a
+key and COALESCE into one enriched row. Fields: `title`, `status` (mapped from `status_code`),
+`posted_date`, `closing_date`, `portal_url` (built from `Id`), `source="bids_tenders"`.
+
+**Marked PROVISIONAL in a module docstring**: it is tested against a hand-built record matching
+the documented schema (enough to lock the mapping mechanics), but the exact JSON field names,
+date formats, and status representation are unverified until a real record is captured via the
+recording mode. Completing/validating it against the first real fixture is an explicit deferred
+task, not part of this build. The `agency_award`-from-awarded path is **not built now** — deferred
+until a real awarded record shows whether a supplier/value field exists.
 
 ### Store — `store_listings(conn, buyer_id, records) -> dict`
 
@@ -106,26 +145,32 @@ surfaces `agency_solicitation`/`agency_award`, so listings appear with no export
 
 ## Testing
 
-- Pure `parse_listing` tests against recorded JSON fixtures under
-  `tests/fixtures/agencies/` (real responses captured under the granted permission — the
-  fixture-recording step the gate always anticipated). Cover: an open row, a closed row, an
-  awarded row (with and, if it occurs, without a supplier field), and a row missing optional
-  fields.
+- Pure `parse_listing` tested against a **hand-built record** matching the JS-documented schema
+  (`tests/fixtures/agencies/bids_tenders_record_sample.json`) — enough to lock the field-mapping
+  mechanics (native_ref normalization, detail-URL construction, status mapping, model shape). This
+  fixture is explicitly synthetic and labelled so in `SOURCES.md`; the parser stays PROVISIONAL
+  until a real record replaces it.
 - `store_listings` tested against an in-memory DB: a portal row COALESCE-enriching an existing
-  board-report row (same `native_ref`), and a portal-only row.
+  board-report row (same `native_ref`), and a portal-only row. Storage logic is deterministic, so
+  these tests are valid regardless of the empty-portal reality.
 - The session/fetch path stays untested by unit tests (nothing to record without a live call),
-  exactly as the Ariba/council fetch halves are; a live `tb enrich-agencies --portal` run is the
-  real-world verification, and — per the hard lesson of #136 — its recall is *measured* against
-  the live `total` the endpoint reports, not assumed.
+  exactly as the Ariba/council fetch halves are. A live `tb enrich-agencies --portal` run is the
+  real-world verification; **today it correctly returns 0 rows**, which is the honest verification
+  available now. When a portal has data, `--record` captures a real fixture and — per the hard
+  lesson of #136 — the parser is re-validated with recall *measured* against the endpoint's `total`,
+  not assumed.
 
-## Open items resolved at fixture-record time (not blockers)
+## Deferred to first-real-data (an explicit follow-up task, NOT this build)
 
-- The exact `status` code → Open/Closing/Closed/Awarded mapping (probe each code's `total`).
+When a TRCA or Zoo bid first appears, `tb enrich-agencies --portal --record` captures real records;
+then a follow-up completes and re-validates the parser:
+
+- The exact `status` code → Open/Awarded/Cancelled mapping (probe each code's `total`).
 - Whether the portal bid number matches the board-report `native_ref` format (decides how often
   the COALESCE enrich fires vs. a distinct row — either is correct; measured, not assumed).
-- Whether awarded records expose a supplier/value (decides if the `agency_award` path is built
-  now or deferred).
-- The precise JSON field names for title/dates/status/detail-URL.
+- Whether awarded records expose a supplier/value (decides if the `agency_award` path is built).
+- The precise JSON field names and date/status formats — replace the synthetic fixture with the
+  real one and adjust `parse_listing`.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-18-bidsandtenders-portal-listings-design.md
+++ b/docs/superpowers/specs/2026-07-18-bidsandtenders-portal-listings-design.md
@@ -1,0 +1,139 @@
+# bids&tenders portal listing capture (#135) — design
+
+2026-07-18. The remaining half of #135: now that TRCA and the Zoo have granted written
+permission (recorded in `docs/permissions/2026-07-18-{trca,toronto-zoo}.md`, gates flipped
+`enabled: True` in `config.BIDS_TENDERS_PORTALS`), capture the public listing metadata from
+their bids&tenders portals. The board-report capture (merged in #136) already gives awards and
+bidders; this adds the solicitation *listing* side — status, dates, categories — for the same
+bodies, and keeps it current as open bids come and go.
+
+## The finding that shapes it
+
+The portal is a JS single-page app, but its grid loads from a plain-HTTP JSON endpoint — **no
+browser required** (unlike the council/Ariba scrapers). Probed live 2026-07-18:
+
+- `GET /Module/Tenders/en` returns the landing HTML carrying a `NodeId` (a per-portal GUID) and
+  an ASP.NET `__RequestVerificationToken` (hidden field + a paired cookie set on the response).
+- `POST /Module/Tenders/en/Tender/Search/<NodeId>?status=<n>&limit=<n>&start=<n>&dir=desc&from=&to=&sort=ClosingDate desc,Id`
+  with body `{keywords: "", __RequestVerificationToken: <token>}` and the session cookie returns
+  `{"success": true, "data": [ …records… ], "total": <n>}`.
+- Without the session cookie + token the endpoint 302s to an error page. The pairing is standard
+  ASP.NET antiforgery: the cookie set on the landing GET must accompany the hidden-field token.
+- Both portals expose the same endpoint, differing only by host and `NodeId`
+  (TRCA `950af760-…`, Zoo `d572c998-…`).
+
+Because it is plain HTTP, it can join the unattended nightly path.
+
+## Decisions (settled in brainstorming)
+
+- **Scope: everything** — Open, Closing, Closed, and Awarded (every `status` code the endpoint
+  accepts). The fullest archive. Kept polite despite the breadth (see rate-limiting).
+- **Scheduling: nightly, off-peak**, folded into `tb nightly`, isolated like every other step;
+  also runnable on demand. Matches the permissions' "nightly, off-peak, low-impact" wording and
+  the "open bids vanish" rationale.
+- **Storage: the existing `agency_solicitation`** keyspace, not a new table — the payoff of the
+  shared buyer-keyed design (#135).
+- **Awards: solicitation now; award only if cleanly present.** Write `agency_award` from a
+  portal-awarded row *only if* the awarded JSON exposes a supplier/value field at fixture-record
+  time. Do not half-build an award path on a maybe.
+- **No bid documents, ever** — they sit behind the Vendor clickwrap; the grants cover listing
+  metadata only.
+
+## Architecture
+
+Pure/impure split in `sources/bids_tenders.py` (replacing the current gate-only stub, whose
+`PermissionError`-on-disabled behaviour is retained):
+
+### Impure half — `fetch_listings(http, portal) -> Iterable[dict]`
+
+1. Re-raise `PermissionError` if `not portal["enabled"]` (unchanged from the stub — a future
+   portal added without a recorded grant stays blocked).
+2. **Establish a session**: `GET {portal_url}Module/Tenders/en`, following redirects and
+   accumulating cookies on the client; extract `NodeId` and `__RequestVerificationToken` from the
+   returned HTML.
+3. **Fetch each status** in `_STATUS_CODES` (the set the endpoint accepts — confirmed at fixture
+   time; provisionally the codes behind Open/Closing/Closed/Awarded). For each, page with
+   `limit`/`start` until `start >= total`, yielding every record. A `size` cap per page (e.g. 50)
+   keeps requests modest.
+4. **Rate-limit**: a deliberate `time.sleep` between every HTTP request (a small constant, e.g.
+   1–2 s), so a full sweep stays low-impact — the explicit condition both bodies set.
+5. Attach `buyer_slug` and `status_code` to each yielded record so the pure half needs no
+   external context.
+
+`HttpClient` gains a small `post_form(url, params, data)` helper if it lacks one (it has
+`post_json`; the portal needs form-encoded body + query params + persisted cookies — httpx.Client
+already persists cookies, so this is a thin addition, not a new client).
+
+### Pure half — `parse_listing(record, buyer_id) -> AgencySolicitation` (and optional `AgencyAward`)
+
+Maps one JSON record to a model. `native_ref` is the portal's bid number, normalized by the same
+trim/uppercase/whitespace-collapse the board-report path uses, so a portal row and a board-report
+row for the same procurement share a key and COALESCE into one enriched row. Fields:
+`title`, `status` (mapped from the status code / the record's own status text), `posted_date`,
+`closing_date`, `portal_url` (the record's own detail URL), `source="bids_tenders"`. Tested
+against recorded JSON fixtures — no network, no browser.
+
+### Store — `store_listings(conn, buyer_id, records) -> dict`
+
+Upserts each parsed `AgencySolicitation` with `overwrite=True`: the portal owns the listing
+fields (status/dates), so a nightly re-fetch keeps an open bid current, while COALESCE still
+protects a board-report-supplied title from being nulled. If (and only if) an awarded record
+carries a supplier/value, also upsert an `AgencyAward` (`source="bids_tenders"`), giving a second
+source that cross-checks the board-report award parser. Returns counts.
+
+### CLI / scheduling
+
+- `tb enrich-agencies --portal` runs the capture on demand (per-body isolated: TRCA failing never
+  stops Zoo, the `_cmd_enrich_agencies` pattern already in place).
+- `tb nightly` gains an isolated portal step — a failure records to `sync_run` and never stops
+  sync/export, exactly as the award-summary and sync steps are isolated today.
+
+## Data flow
+
+`fetch_listings` (session → paged JSON per status, rate-limited) → `parse_listing` (pure, per
+record) → `store_listings` (COALESCE upsert into `agency_solicitation`, optional `agency_award`)
+→ `build_supplier_dimension` picks up any new award suppliers → export's `buyers` section already
+surfaces `agency_solicitation`/`agency_award`, so listings appear with no export change.
+
+## Error handling
+
+- Gate: `PermissionError` if a portal is disabled — unchanged.
+- Session failure (landing GET fails, token/NodeId not found): raise a clear error naming the
+  portal; the per-body isolation in the CLI/nightly records it and moves on.
+- A single status/page failing (HTTP error) is logged and skipped so the rest of the sweep still
+  lands, mirroring the board-report download's per-item resilience (#135 live-fix).
+- The whole capture is per-body isolated; partial rows commit (archive semantics).
+
+## Testing
+
+- Pure `parse_listing` tests against recorded JSON fixtures under
+  `tests/fixtures/agencies/` (real responses captured under the granted permission — the
+  fixture-recording step the gate always anticipated). Cover: an open row, a closed row, an
+  awarded row (with and, if it occurs, without a supplier field), and a row missing optional
+  fields.
+- `store_listings` tested against an in-memory DB: a portal row COALESCE-enriching an existing
+  board-report row (same `native_ref`), and a portal-only row.
+- The session/fetch path stays untested by unit tests (nothing to record without a live call),
+  exactly as the Ariba/council fetch halves are; a live `tb enrich-agencies --portal` run is the
+  real-world verification, and — per the hard lesson of #136 — its recall is *measured* against
+  the live `total` the endpoint reports, not assumed.
+
+## Open items resolved at fixture-record time (not blockers)
+
+- The exact `status` code → Open/Closing/Closed/Awarded mapping (probe each code's `total`).
+- Whether the portal bid number matches the board-report `native_ref` format (decides how often
+  the COALESCE enrich fires vs. a distinct row — either is correct; measured, not assumed).
+- Whether awarded records expose a supplier/value (decides if the `agency_award` path is built
+  now or deferred).
+- The precise JSON field names for title/dates/status/detail-URL.
+
+## Out of scope
+
+- Bid documents (Vendor clickwrap).
+- Other bids&tenders bodies (Ontario municipalities) — outside the archive.
+- Any write/login/submission on the portal — read-only, anonymous, as the grants require.
+
+## Recording
+
+On completion, comment on #135 that the portal half landed; #109 (Zoo) and #132 (TRCA) get a
+pointer. #135 can then close.

--- a/scrapers/tests/fixtures/agencies/SOURCES.md
+++ b/scrapers/tests/fixtures/agencies/SOURCES.md
@@ -50,3 +50,13 @@ find nothing on the real *year* page. (Discovery no longer walks the year page a
 it POSTs GetCalendarMeetings, above.) `escribe_document_urls` still runs on the meeting
 *detail* pages, which ARE server-rendered with `FileStream.ashx` anchors; this
 hand-written fixture exercises that extractor on the anchor shapes it must find.
+
+## bids_tenders_record_sample.json — SYNTHETIC (#135)
+
+Hand-built, NOT a real capture. As of 2026-07-18 both permitted bids&tenders portals (TRCA,
+Zoo) are empty (total=0, all statuses), so no real listing record exists to record. This
+fixture matches the field names documented in the portal's grid JS
+(Module/Tenders/Resources/scriptsV2/home/index.js: Id, Title, ClosingDate, Documents,
+Addendums, PlanTakers) and exercises parse_listing's mapping mechanics only. `parse_listing`
+is PROVISIONAL until `tb enrich-agencies --portal --record` captures a real record and replaces
+this fixture (#135 deferred item).

--- a/scrapers/tests/fixtures/agencies/bids_tenders_record_sample.json
+++ b/scrapers/tests/fixtures/agencies/bids_tenders_record_sample.json
@@ -1,0 +1,13 @@
+{
+  "Id": "0f9a1b2c-3d4e-5f60-7182-93a4b5c6d7e8",
+  "ReferenceNumber": "RFT-2026-014",
+  "Title": "Trail Bridge Replacement - Example Creek",
+  "ClosingDate": "2026-08-15T14:00:00",
+  "DatePosted": "2026-07-20T09:00:00",
+  "StatusText": "Open",
+  "Documents": 3,
+  "Addendums": 0,
+  "PlanTakers": 5,
+  "buyer_slug": "trca",
+  "status_code": 1
+}

--- a/scrapers/tests/test_agencies.py
+++ b/scrapers/tests/test_agencies.py
@@ -161,16 +161,11 @@ def test_gate_blocks_a_portal_without_permission():
     ungranted = {"slug": "example", "portal_url": "https://example.bidsandtenders.ca/",
                  "enabled": False, "permission": None}
     with _pytest.raises(PermissionError):
-        fetch_listings(None, ungranted)
+        next(fetch_listings(ungranted))          # generator: gate fires on first pull
 
 
-def test_enabled_portal_has_no_capture_yet():
-    # TRCA and the Zoo have granted permission, so the gate is open — but the listing parser
-    # is still unwritten, so fetch_listings surfaces NotImplementedError, not a silent no-op.
-    import pytest as _pytest
-    from toronto_bids import config
-    from toronto_bids.sources.bids_tenders import fetch_listings
-    enabled = [p for p in config.BIDS_TENDERS_PORTALS if p["enabled"]]
-    assert enabled, "expected at least one enabled portal (TRCA/Zoo permissions recorded)"
-    with _pytest.raises(NotImplementedError):
-        fetch_listings(None, enabled[0])
+def test_search_params_never_include_sort():
+    from toronto_bids.sources.bids_tenders import _search_params
+    p = _search_params(status=1, start=0, limit=50)
+    assert "sort" not in p                        # sort= triggers a server error (verified)
+    assert p == {"status": 1, "limit": 50, "start": 0, "dir": "desc", "from": "", "to": ""}

--- a/scrapers/tests/test_bids_tenders.py
+++ b/scrapers/tests/test_bids_tenders.py
@@ -49,6 +49,7 @@ def test_store_listings_inserts_portal_row(conn):
     row = conn.execute("SELECT native_ref, title, status, source FROM agency_solicitation").fetchone()
     assert row["native_ref"] == "RFT-2026-014"
     assert row["source"] == "bids_tenders"
+    assert row["title"] == "Trail Bridge Replacement - Example Creek"
 
 
 def test_store_listings_enriches_a_board_report_row(conn):

--- a/scrapers/tests/test_bids_tenders.py
+++ b/scrapers/tests/test_bids_tenders.py
@@ -1,7 +1,13 @@
 import json
 import pathlib
+import sqlite3
 
-from toronto_bids.sources.bids_tenders import parse_listing
+import pytest
+
+from toronto_bids.buyers import seed_buyers
+from toronto_bids.models import AgencySolicitation
+from toronto_bids.sources.bids_tenders import parse_listing, store_listings
+from toronto_bids.store import db
 
 FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "agencies"
 
@@ -26,3 +32,39 @@ def test_parse_listing_falls_back_to_id_when_no_reference():
     rec = _sample(); del rec["ReferenceNumber"]
     row = parse_listing(rec, buyer_id=7)
     assert row.native_ref == "0F9A1B2C-3D4E-5F60-7182-93A4B5C6D7E8"   # Id, uppercased
+
+
+@pytest.fixture
+def conn():
+    c = db.connect(":memory:")
+    db.init_db(c)
+    yield c
+    c.close()
+
+
+def test_store_listings_inserts_portal_row(conn):
+    ids = seed_buyers(conn)
+    n = store_listings(conn, [_sample()], ids)
+    assert n == 1
+    row = conn.execute("SELECT native_ref, title, status, source FROM agency_solicitation").fetchone()
+    assert row["native_ref"] == "RFT-2026-014"
+    assert row["source"] == "bids_tenders"
+
+
+def test_store_listings_enriches_a_board_report_row(conn):
+    ids = seed_buyers(conn)
+    # A board-report row already exists for the same ref, with a title but no dates/status.
+    db.upsert_row(conn, AgencySolicitation(
+        buyer_id=ids["trca"], native_ref="RFT-2026-014", title="Board title",
+        status="awarded", source="trca_board"), overwrite=False)
+    store_listings(conn, [_sample()], ids)
+    rows = conn.execute("SELECT title, status, closing_date FROM agency_solicitation "
+                        "WHERE native_ref='RFT-2026-014'").fetchall()
+    assert len(rows) == 1                              # COALESCE-enriched, not duplicated
+    assert rows[0]["title"] == "Board title"           # board title preserved (overwrite guard)
+    assert rows[0]["closing_date"] == "2026-08-15T14:00:00"  # portal filled the empty date
+
+
+def test_store_listings_empty_is_noop(conn):
+    ids = seed_buyers(conn)
+    assert store_listings(conn, [], ids) == 0

--- a/scrapers/tests/test_bids_tenders.py
+++ b/scrapers/tests/test_bids_tenders.py
@@ -93,3 +93,14 @@ def test_run_portal_capture_isolates_a_failing_body(conn, monkeypatch):
     result = bt.run_portal_capture(conn, log=lambda _m: None)
     assert result["toronto-zoo"] == 1             # zoo still captured
     assert "trca" in result and result["trca"] == "FAILED: boom"   # trca isolated, recorded
+
+
+def test_nightly_wires_up_the_portal_step():
+    """Doc-smoke: `tb nightly` (cli._cmd_nightly) actually calls into this module, isolated
+    the same way sync/award_summary are (#135 asks it never stop the export)."""
+    import inspect
+
+    from toronto_bids import cli
+    src = inspect.getsource(cli._cmd_nightly)
+    assert "bids_tenders import run_portal_capture" in src
+    assert "run_portal_capture(conn" in src

--- a/scrapers/tests/test_bids_tenders.py
+++ b/scrapers/tests/test_bids_tenders.py
@@ -1,0 +1,28 @@
+import json
+import pathlib
+
+from toronto_bids.sources.bids_tenders import parse_listing
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "agencies"
+
+
+def _sample():
+    return json.loads((FIXTURES / "bids_tenders_record_sample.json").read_text())
+
+
+def test_parse_listing_maps_documented_fields():
+    row = parse_listing(_sample(), buyer_id=7)
+    assert row.buyer_id == 7
+    assert row.native_ref == "RFT-2026-014"          # ReferenceNumber, normalized
+    assert row.title == "Trail Bridge Replacement - Example Creek"
+    assert row.status == "Open"
+    assert row.closing_date == "2026-08-15T14:00:00"
+    assert row.posted_date == "2026-07-20T09:00:00"
+    assert row.portal_url.endswith("/Tender/Detail/0f9a1b2c-3d4e-5f60-7182-93a4b5c6d7e8")
+    assert row.source == "bids_tenders"
+
+
+def test_parse_listing_falls_back_to_id_when_no_reference():
+    rec = _sample(); del rec["ReferenceNumber"]
+    row = parse_listing(rec, buyer_id=7)
+    assert row.native_ref == "0F9A1B2C-3D4E-5F60-7182-93A4B5C6D7E8"   # Id, uppercased

--- a/scrapers/tests/test_bids_tenders.py
+++ b/scrapers/tests/test_bids_tenders.py
@@ -69,3 +69,27 @@ def test_store_listings_enriches_a_board_report_row(conn):
 def test_store_listings_empty_is_noop(conn):
     ids = seed_buyers(conn)
     assert store_listings(conn, [], ids) == 0
+
+
+def test_record_listings_writes_one_file_per_record(tmp_path):
+    from toronto_bids.sources.bids_tenders import record_listings
+    recs = [dict(_sample(), status_code=1), dict(_sample(), status_code=3)]
+    n = record_listings(recs, tmp_path)
+    assert n == 2
+    written = sorted(p.name for p in tmp_path.glob("*.json"))
+    assert all(name.startswith("trca-") for name in written)
+
+
+def test_run_portal_capture_isolates_a_failing_body(conn, monkeypatch):
+    from toronto_bids.sources import bids_tenders as bt
+    ids = seed_buyers(conn)
+
+    def fake_fetch(portal, **_kw):
+        if portal["slug"] == "trca":
+            raise RuntimeError("boom")            # one body fails
+        yield dict(_sample(), buyer_slug="toronto-zoo")
+
+    monkeypatch.setattr(bt, "fetch_listings", fake_fetch)
+    result = bt.run_portal_capture(conn, log=lambda _m: None)
+    assert result["toronto-zoo"] == 1             # zoo still captured
+    assert "trca" in result and result["trca"] == "FAILED: boom"   # trca isolated, recorded

--- a/scrapers/tests/test_nightly.py
+++ b/scrapers/tests/test_nightly.py
@@ -18,9 +18,10 @@ def nightly(conn, monkeypatch, tmp_path):
     monkeypatch.setattr(cli.pipeline, "sync", lambda *a, **k: [])
     monkeypatch.setattr(cli.HttpClient, "__init__", lambda self, *a, **k: None)
     monkeypatch.setattr(cli.HttpClient, "close", lambda self: None)
-    from toronto_bids.sources import award_summary
+    from toronto_bids.sources import award_summary, bids_tenders
     monkeypatch.setattr(award_summary, "download_award_summaries", lambda *a, **k: 0)
     monkeypatch.setattr(award_summary, "store_award_summary_bids", lambda *a, **k: 0)
+    monkeypatch.setattr(bids_tenders, "run_portal_capture", lambda *a, **k: {})
     monkeypatch.setattr(notify, "post", lambda *a, **k: False)
     return lambda: cli.main(["nightly"])
 
@@ -60,6 +61,26 @@ def test_a_raising_award_summary_step_does_not_stop_the_export(nightly, monkeypa
     monkeypatch.setattr(award_summary, "download_award_summaries", boom)
     assert nightly() == 1
     assert (tmp_path / "export" / "bids.json").exists()
+
+
+def test_a_raising_portal_step_does_not_stop_the_export(nightly, monkeypatch, tmp_path):
+    """The portal step (bids_tenders.run_portal_capture) is isolated the same way sync and
+    award_summary are: a failure records to `failures` and the export still runs."""
+    from toronto_bids.sources import bids_tenders
+    def boom(*a, **k):
+        raise RuntimeError("portal down")
+    monkeypatch.setattr(bids_tenders, "run_portal_capture", boom)
+    assert nightly() == 1
+    assert (tmp_path / "export" / "bids.json").exists()
+
+
+def test_a_failed_portal_body_is_recorded_but_does_not_fail_the_run_alone(nightly, monkeypatch):
+    """run_portal_capture already isolates per-body; a `FAILED: ...` string in its result dict
+    is surfaced into `failures` (and therefore the exit code), without raising."""
+    from toronto_bids.sources import bids_tenders
+    monkeypatch.setattr(bids_tenders, "run_portal_capture",
+                         lambda *a, **k: {"trca": "FAILED: boom", "toronto-zoo": 0})
+    assert nightly() == 1
 
 
 def test_the_summary_is_posted(nightly, monkeypatch):

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -447,6 +447,14 @@ def _cmd_nightly(args) -> int:
                     store_award_summary_bids(conn, log=out)
                 except Exception as exc:
                     failures.append(("award_summary", str(exc)))
+                try:
+                    from toronto_bids.sources.bids_tenders import run_portal_capture
+                    res = run_portal_capture(conn, log=out)
+                    for slug, v in res.items():
+                        if isinstance(v, str) and v.startswith("FAILED"):
+                            failures.append((f"portal:{slug}", v))
+                except Exception as exc:
+                    failures.append(("portal", str(exc)))
             finally:
                 try:
                     http.close()

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -103,6 +103,12 @@ def build_parser() -> argparse.ArgumentParser:
                            "council extra; implies --fetch for the Zoo's PDFs)")
     p_ag.add_argument("--virtual-display", action="store_true",
                       help="Run --scrape's headed browser under Xvfb")
+    p_ag.add_argument("--portal", action="store_true",
+                      help="Capture bids&tenders portal listings for enabled+permitted bodies "
+                           "(plain HTTP, rate-limited). Currently a no-op while portals are empty.")
+    p_ag.add_argument("--record", action="store_true",
+                      help="With --portal: also dump each raw JSON record under "
+                           "<DATA_DIR>/agencies/portal_recordings/ to seed parser fixtures.")
     return parser
 
 
@@ -519,6 +525,19 @@ def _cmd_enrich_agencies(args) -> int:
                       f"{got['awards']} awards")
             except Exception as exc:
                 failures.append(("zoo", str(exc)))
+
+        if args.portal:
+            try:
+                from toronto_bids.sources.bids_tenders import run_portal_capture
+                only = None if not args.only else {"trca": "trca", "zoo": "toronto-zoo"}[args.only]
+                res = run_portal_capture(conn, record=args.record,
+                                         only={only} if only else None, log=out)
+                print(f"  portal listings      : {res}")
+                for slug, v in res.items():
+                    if isinstance(v, str) and v.startswith("FAILED"):
+                        failures.append((f"portal:{slug}", v))
+            except Exception as exc:
+                failures.append(("portal", str(exc)))
 
         try:
             print(f"  suppliers            : {build_supplier_dimension(conn)}")

--- a/scrapers/toronto_bids/config.py
+++ b/scrapers/toronto_bids/config.py
@@ -109,3 +109,7 @@ BIDS_TENDERS_PORTALS = [
     {"slug": "trca", "portal_url": "https://trca.bidsandtenders.ca/",
      "enabled": True, "permission": "docs/permissions/2026-07-18-trca.md"},
 ]
+
+# Raw bids&tenders listing JSON captured by `--record`, one file per record — the seed for
+# real parser fixtures once a portal has data (#135).
+PORTAL_RECORDINGS_DIR = DATA_DIR / "agencies" / "portal_recordings"

--- a/scrapers/toronto_bids/sources/bids_tenders.py
+++ b/scrapers/toronto_bids/sources/bids_tenders.py
@@ -1,18 +1,83 @@
-"""The bids&tenders portal source (#135) — GATED, and currently a gate only.
+"""The bids&tenders portal source (#135) — listing metadata, PROVISIONAL parser.
 
-Listing capture is written when the first written permission lands in docs/permissions/:
-the parser needs recorded fixtures, and recording a fixture means fetching the portal,
-which is exactly what the gate forbids until then. Bid DOCUMENTS are out of scope
-regardless of permission state — they sit behind the Vendor clickwrap.
+Reads public bid listings from a body's bids&tenders portal via its plain-HTTP JSON grid
+endpoint (no browser). GATED: fetch_listings raises PermissionError unless the portal's
+config entry is enabled, which happens only when the body's written grant is recorded in
+docs/permissions/ (the PMMD/Ariba precedent). Listings only — bid documents sit behind the
+Vendor clickwrap and are never fetched.
+
+PROVISIONAL: as of 2026-07-18 both permitted portals (TRCA, Zoo) are empty, so parse_listing
+is mapped against the field names documented in the portal's own grid JS but has NOT been
+validated against a real record. When a bid first appears, `tb enrich-agencies --portal
+--record` captures real JSON to fixtures and the parser is completed and re-validated.
 """
+import re
+import time
+
+import httpx
+
+from toronto_bids import config
+from toronto_bids.models import AgencySolicitation
+from toronto_bids.store import db
+
+_LANDING = "Module/Tenders/en"
+_SEARCH = "Module/Tenders/en/Tender/Search/"
+_NODE_RE = re.compile(r'id="NodeId"[^>]*value="([^"]+)"')
+_TOKEN_RE = re.compile(r'name="__RequestVerificationToken"[^>]*value="([^"]+)"')
+# The status codes the endpoint accepts (Open / Awarded / Cancelled / ...). The exact
+# code->label mapping is recorded when data first appears; the sweep covers them all.
+_STATUS_CODES = range(0, 6)
+_PAGE = 50
+_DELAY = 1.5
 
 
-def fetch_listings(http, portal: dict):
+def _search_params(status: int, start: int, limit: int = _PAGE) -> dict:
+    # NEVER include 'sort' — 'sort=ClosingDate desc,Id' (space/comma) triggers a server error
+    # that redirects to Error?aspxerrorpath (verified live 2026-07-18). Default order is fine.
+    return {"status": status, "limit": limit, "start": start, "dir": "desc", "from": "", "to": ""}
+
+
+def fetch_listings(portal: dict, *, delay: float = _DELAY, log=lambda _m: None):
+    """Yield every listing record for a portal, across all statuses, paged and rate-limited.
+
+    Manages its own httpx.Client (the antiforgery cookie set on the landing GET must persist
+    to the search POSTs — a session concern specific to this source, not the shared HttpClient).
+    Yields each raw JSON record with `buyer_slug` and `status_code` attached. On an empty portal
+    (total=0, the current reality) this yields nothing — a clean no-op.
+    """
     if not portal.get("enabled"):
         raise PermissionError(
             f"bids&tenders portal '{portal['slug']}' is not enabled: fetching requires the "
             f"body's written permission recorded in docs/permissions/ (see #135 / #103). "
             f"Current permission record: {portal.get('permission')!r}")
-    raise NotImplementedError(
-        "Listing capture is unwritten by design — record fixtures under the granted "
-        "permission first, then implement normalize() against them (spec 2026-07-18).")
+    base = portal["portal_url"].rstrip("/") + "/"
+    client = httpx.Client(
+        headers={"User-Agent": config.USER_AGENT, "X-Requested-With": "XMLHttpRequest"},
+        timeout=config.HTTP_TIMEOUT, follow_redirects=True)
+    try:
+        land = client.get(base + _LANDING).text
+        node_m, tok_m = _NODE_RE.search(land), _TOKEN_RE.search(land)
+        if not (node_m and tok_m):
+            raise RuntimeError(f"bids&tenders {portal['slug']}: no NodeId/token on landing page")
+        node, token = node_m.group(1), tok_m.group(1)   # FIRST token (bidDetail-scoped one 302s)
+        for status in _STATUS_CODES:
+            start = 0
+            while True:
+                time.sleep(delay)                        # rate-limit (permission condition)
+                resp = client.post(base + _SEARCH + node,
+                                   params=_search_params(status, start),
+                                   data={"keywords": "", "__RequestVerificationToken": token})
+                try:
+                    payload = resp.json()
+                except ValueError:
+                    log(f"  {portal['slug']} status={status} start={start}: non-JSON, skipping")
+                    break
+                rows = payload.get("data") or []
+                total = payload.get("total") or 0
+                for rec in rows:
+                    yield {**rec, "buyer_slug": portal["slug"], "status_code": status}
+                start += len(rows)
+                if not rows or start >= total:
+                    break
+    finally:
+        client.close()

--- a/scrapers/toronto_bids/sources/bids_tenders.py
+++ b/scrapers/toronto_bids/sources/bids_tenders.py
@@ -13,6 +13,7 @@ validated against a real record. When a bid first appears, `tb enrich-agencies -
 """
 import re
 import time
+from dataclasses import replace
 
 import httpx
 
@@ -113,3 +114,24 @@ def parse_listing(record: dict, buyer_id: int) -> AgencySolicitation:
         portal_url=portal_url,
         source="bids_tenders",
     )
+
+
+def store_listings(conn, records, buyer_ids: dict) -> int:
+    """Upsert each parsed listing into agency_solicitation. overwrite=True: the portal owns the
+    listing fields (status/dates), so a nightly re-fetch keeps an open bid current, while
+    COALESCE still protects a board-report-supplied title from being nulled. Skips a record
+    whose buyer_slug is not a seeded buyer. Returns rows upserted."""
+    n = 0
+    for record in records:
+        buyer_id = buyer_ids.get(record.get("buyer_slug"))
+        if buyer_id is None:
+            continue
+        row = parse_listing(record, buyer_id)
+        # Don't overwrite an existing board-report title with the portal's title.
+        # With overwrite=True, COALESCE(excluded.title, {table}.title) will preserve
+        # the existing non-NULL title if we pass None here.
+        row = replace(row, title=None)
+        db.upsert_row(conn, row, overwrite=True)
+        n += 1
+    conn.commit()
+    return n

--- a/scrapers/toronto_bids/sources/bids_tenders.py
+++ b/scrapers/toronto_bids/sources/bids_tenders.py
@@ -13,7 +13,6 @@ validated against a real record. When a bid first appears, `tb enrich-agencies -
 """
 import re
 import time
-from dataclasses import replace
 
 import httpx
 
@@ -117,21 +116,19 @@ def parse_listing(record: dict, buyer_id: int) -> AgencySolicitation:
 
 
 def store_listings(conn, records, buyer_ids: dict) -> int:
-    """Upsert each parsed listing into agency_solicitation. overwrite=True: the portal owns the
-    listing fields (status/dates), so a nightly re-fetch keeps an open bid current, while
-    COALESCE still protects a board-report-supplied title from being nulled. Skips a record
-    whose buyer_slug is not a seeded buyer. Returns rows upserted."""
+    """Upsert each parsed listing into agency_solicitation with overwrite=False (backfill):
+    fills any NULL field — a portal-only solicitation gets its full record including title,
+    while a board-report row keeps its title/status and only has its empty dates filled in.
+    (Nightly status refresh of an open bid is intentionally NOT done here — revisited when the
+    portals have real data and the parser is validated, #135.) Skips a record whose buyer_slug
+    is not a seeded buyer. Returns rows upserted."""
     n = 0
     for record in records:
         buyer_id = buyer_ids.get(record.get("buyer_slug"))
         if buyer_id is None:
             continue
         row = parse_listing(record, buyer_id)
-        # Don't overwrite an existing board-report title with the portal's title.
-        # With overwrite=True, COALESCE(excluded.title, {table}.title) will preserve
-        # the existing non-NULL title if we pass None here.
-        row = replace(row, title=None)
-        db.upsert_row(conn, row, overwrite=True)
+        db.upsert_row(conn, row, overwrite=False)
         n += 1
     conn.commit()
     return n

--- a/scrapers/toronto_bids/sources/bids_tenders.py
+++ b/scrapers/toronto_bids/sources/bids_tenders.py
@@ -11,12 +11,14 @@ is mapped against the field names documented in the portal's own grid JS but has
 validated against a real record. When a bid first appears, `tb enrich-agencies --portal
 --record` captures real JSON to fixtures and the parser is completed and re-validated.
 """
+import json
 import re
 import time
 
 import httpx
 
 from toronto_bids import config
+from toronto_bids.buyers import seed_buyers
 from toronto_bids.models import AgencySolicitation
 from toronto_bids.store import db
 
@@ -132,3 +134,41 @@ def store_listings(conn, records, buyer_ids: dict) -> int:
         n += 1
     conn.commit()
     return n
+
+
+def record_listings(records, out_dir) -> int:
+    """Write each raw record to out_dir/<slug>-<status>-<n>.json — the seed for real fixtures
+    once a portal has data. Returns the count written."""
+    import pathlib
+    out = pathlib.Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    n = 0
+    for record in records:
+        slug = record.get("buyer_slug", "unknown")
+        status = record.get("status_code", "x")
+        (out / f"{slug}-{status}-{n}.json").write_text(json.dumps(record, indent=1, default=str))
+        n += 1
+    return n
+
+
+def run_portal_capture(conn, *, record: bool = False, only=None, log=lambda _m: None) -> dict:
+    """Fetch + store (and optionally record) every enabled portal, per-body isolated: one
+    body's failure is caught and reported, never stops the others. Returns {slug: count | 'FAILED: ...'}."""
+    buyer_ids = seed_buyers(conn)
+    result = {}
+    for portal in config.BIDS_TENDERS_PORTALS:
+        if not portal["enabled"]:
+            continue
+        if only and portal["slug"] not in only:
+            continue
+        try:
+            records = list(fetch_listings(portal, log=log))
+            if record:
+                written = record_listings(records, config.PORTAL_RECORDINGS_DIR)
+                log(f"  {portal['slug']}: recorded {written} raw record(s)")
+            result[portal["slug"]] = store_listings(conn, records, buyer_ids)
+            log(f"  {portal['slug']}: {result[portal['slug']]} listing(s) stored")
+        except Exception as exc:                       # per-body isolation (empty portal is fine; a real error is caught)
+            result[portal["slug"]] = f"FAILED: {exc}"
+            log(f"  FAILED {portal['slug']}: {exc}")
+    return result

--- a/scrapers/toronto_bids/sources/bids_tenders.py
+++ b/scrapers/toronto_bids/sources/bids_tenders.py
@@ -81,3 +81,35 @@ def fetch_listings(portal: dict, *, delay: float = _DELAY, log=lambda _m: None):
                     break
     finally:
         client.close()
+
+
+# Portal base per slug, for building a record's detail URL. Derived from config so the two
+# stay in sync.
+_PORTAL_BASE = {p["slug"]: p["portal_url"].rstrip("/") for p in config.BIDS_TENDERS_PORTALS}
+
+_WS = re.compile(r"\s+")
+
+
+def _native_ref(record: dict) -> str:
+    """The body's own bid identifier, normalized like the board-report path (trim/upper/
+    collapse-ws) so a portal row and a board-report row for one procurement share a key."""
+    raw = record.get("ReferenceNumber") or record.get("BidNumber") or record.get("Id") or ""
+    return _WS.sub(" ", str(raw)).strip().upper()
+
+
+def parse_listing(record: dict, buyer_id: int) -> AgencySolicitation:
+    """Map one raw portal record to an AgencySolicitation. PROVISIONAL (see module docstring):
+    field names/formats are from the grid JS, unverified until a real record is captured."""
+    base = _PORTAL_BASE.get(record.get("buyer_slug"), "")
+    rid = record.get("Id")
+    portal_url = f"{base}/Module/Tenders/en/Tender/Detail/{rid}" if (base and rid) else None
+    return AgencySolicitation(
+        buyer_id=buyer_id,
+        native_ref=_native_ref(record),
+        title=record.get("Title"),
+        status=record.get("StatusText") or record.get("Status"),
+        posted_date=record.get("DatePosted") or record.get("PostDate"),
+        closing_date=record.get("ClosingDate") or record.get("BidClosingDate"),
+        portal_url=portal_url,
+        source="bids_tenders",
+    )


### PR DESCRIPTION
The portal half of #135 (the board-report half merged in #136). Now that TRCA and the Zoo have granted written permission (recorded in `docs/permissions/`, gates flipped), this **arms** a plain-HTTP capture of their bids&tenders portal listings into the existing `agency_solicitation` keyspace. Design: `docs/superpowers/specs/2026-07-18-bidsandtenders-portal-listings-design.md`.

## The honest state: armed, not yet capturing

**Both permitted portals are currently empty** — I verified live that TRCA and the Zoo return `total=0` for every status across a 2010–2027 range (TRCA's homepage literally says "no open bids"; its real history lives on eSCRIBE, already captured in #136). So this PR ships **verified infrastructure that correctly no-ops today** and starts archiving automatically the moment a bid appears. A live `tb enrich-agencies --portal --record` run returns `{toronto-zoo: 0, trca: 0}`, records 0 files, exits 0 — the honest verification available now.

## What's built

- **`fetch_listings`** — the grid's plain-HTTP JSON endpoint, no browser: `POST /Module/Tenders/en/Tender/Search/<NodeId>` with a session cookie + the **first** antiforgery token. Two live gotchas are baked in and tested: use the first token (the bidDetail-scoped one 302s), and **never send the `sort` param** (its space/comma triggers a server error). Paged, rate-limited (a deliberate `sleep` before every request, per both bodies' "low-impact" conditions), and **gated** — raises `PermissionError` unless the body's grant is recorded.
- **`parse_listing` — PROVISIONAL.** Mapped to the field names documented in the portal's own grid JS, but validated only against a clearly-labelled **synthetic** fixture. It is honestly marked provisional in the module docstring, `SOURCES.md`, and the fixture, because there's no real record to validate against yet — deliberately *not* repeating the "fixtures pass while real data is wrong" trap from #136.
- **`store_listings`** — `overwrite=False` backfill into `agency_solicitation`: a portal-only solicitation keeps its full record; a same-`native_ref` board-report row keeps its title and only has its empty dates filled (one row, no data loss).
- **`--record` mode** — dumps raw JSON per record to seed a real parser fixture the moment a portal has data.
- **CLI + nightly** — `tb enrich-agencies --portal [--record]`, plus an isolated `tb nightly` step (a portal failure records to `sync_run` and never stops the export). Per-body isolated: TRCA failing never stops the Zoo.

**No bid documents, ever** — they sit behind the Vendor clickwrap; listings only, read-only, anonymous.

## Testing

537 tests pass, fully offline (the nightly test mocks the portal step so it never hits the live sites). Built across 5 TDD tasks, each spec- and quality-reviewed; a whole-branch review on the most capable model confirmed the load-bearing guarantees (no-`sort`, the gate, no-data-loss, per-body + nightly isolation, no-real-network-in-tests) and caught one doc/code mismatch (fixed).

## Deferred to first-real-data (an explicit follow-up, tracked on #135)

When a TRCA or Zoo bid first appears, `--record` captures a real record and a follow-up completes and *re-validates* the parser — the exact status-code→label mapping, whether portal bid numbers align with the board-report refs, whether awarded rows expose a supplier/value (deciding a portal `agency_award` path), and the real field/date formats. Also then: whether `store_listings` should overwrite status on a nightly re-fetch (it currently backfills). **#135 stays open** for that trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
