### PR TITLE
Exhibition Place capture (#130): board-report awards + bidder prices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ The bidders did not stop. `tb enrich-awards --download` archives the Toronto Bid
 - **Staff reports join via the bid-bridge (#126).** The per-solicitation `documents` array also folds in **staff-report PDFs** (`background_pdf` kind='bgrd') through an **exact** council-`reference` ↔ `document_number` link: an Ariba-era Bid Award Panel agenda names both, so a single `bid` row carries both, and `export/document.py` derives the `reference → document_number` map from `bid` at query time (no table). No fuzzy matching, no false-positive surface — the opposite of #77's supplier+amount route. **1,310 reports across 1,237 solicitations**, `source="staff_report"` with the legdocs URL exposed. **Ariba-era only** by nature: pre-2019 council items have no dual-key `bid` row and don't join — that remainder is the deferred #124 surrogate spine's job. A staff report can appear both under its `council_item` and under its bridged solicitation — two views of one PDF, neither wrong.
 - **No MFA on the account, by requirement.** An unattended login cannot answer a 2FA prompt and a CAPTCHA is a policy hard stop; `login` detects a challenge page and raises rather than hanging. Not part of `tb sync`.
 
-### Agency capture (`buyers.py`, `sources/trca_board.py`, `sources/zoo_board.py`, #135) — the fourth keyspace
+### Agency capture (`buyers.py`, `sources/trca_board.py`, `sources/zoo_board.py`, `sources/ep_board.py`, #135) — the fourth keyspace
 
 `tb enrich-agencies`. Agencies/corporations procure outside the PMMD feed (#103); their
 records live in `agency_solicitation`/`agency_award`/`agency_bid` keyed
@@ -171,6 +171,29 @@ so it never clobbers a board-report title, only fills a board row's empty dates)
 PROVISIONAL** — mapped to the grid JS's field names, validated only against a synthetic fixture;
 `--record` dumps raw JSON to seed a real fixture when a bid first appears, at which point the
 parser (and a possible portal `agency_award` path) is completed. No bid documents — Vendor clickwrap.
+
+Exhibition Place (`sources/ep_board.py`, #130) reuses the Zoo pattern: TMMIS EP committee
+(`YYYY.EP<n>.<n>`, headed-browser discovery via the shared prober) → plain-HTTP legdocs
+`bgrd` PDFs → `parse_ep_report` + `parse_ep_bid_table`. **Most EP board reports are not
+procurement awards** (WSIB safety, status updates, governance), so the parser anchors on an
+"award of Contract/RFT … to WINNER" clause and refuses the rest; the WSIB negative fixtures
+(which carry `$` amounts) guard against false positives. EP's award clause puts the project
+between the winner and the amount ("to WINNER **for the <project>** in the amount of $X"), so
+the winner regex is EP-specific, not the shared Zoo pattern. Amount/confidential primitives are
+shared via `sources/agency_report.py`. EP is the first agency source with a structured bidder
+price table (Table 1 → `agency_bid` with prices). On-demand (`--only ep --scrape`), never on
+the browser-free nightly path. The pre-2019 City-spine EP slice (Client_Division "Exhibition
+Place") and these post-2019 Board-of-Governors awards are separate coexisting keyspaces (#130).
+**A confidential report is kept only when its stated MFIPPA reason is commercial/financial
+or acquisition-disposition** — `_EP_NON_PROCUREMENT_REASON` refuses labour-relations,
+personal-matters, property-security and litigation/privilege reports outright, even though
+they too say "agreement" (a Collective Agreement report is not a procurement award). Live
+measurement against all 1,200 held EP reports found 23 such reports being kept as bare or
+garbled awards (`"LiUNA Local 506 applies"`, `"BCC is set"` captured as a winner) before this
+guard; after it, 107 accepted / 1,093 refused, 0 non-procurement leftovers, and every named
+winner is a clean company name. `_EP_AGREEMENT`'s capture is token-gated (each word must
+itself start capitalized, or be a bare connector `and`/`of`/`&`) for the same reason — the old
+free-form class swallowed the sentence past the counterparty's name up to the next `for`/`to`.
 
 ### Export seam (`export/`)
 

--- a/docs/superpowers/plans/2026-07-18-exhibition-place-capture.md
+++ b/docs/superpowers/plans/2026-07-18-exhibition-place-capture.md
@@ -1,0 +1,659 @@
+# Exhibition Place Capture (#130) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover Exhibition Place's post-2019 procurement record — awards + bidder prices — from its Board of Governors reports on legdocs, into the existing `agency_*` keyspace, reusing the Zoo/TRCA board-report machinery.
+
+**Architecture:** Extract shared amount/confidential helpers to `sources/agency_report.py`; add an `exhibition-place` buyer and a new `sources/ep_board.py` that reuses the `bid_award_panel` prober (TMMIS EP committee, `YYYY.EP<n>.<n>`, headed browser) for discovery, `trca_board._store_pending_pdfs` for the plain-HTTP legdocs PDF download, and new EP-specific pure parsers. Wired into `tb enrich-agencies --only ep --scrape`, not the browser-free nightly path.
+
+**Tech Stack:** Python 3.12, `uv`, sqlite3, pytest (offline), `pdftotext`; Playwright (`council` extra) for discovery only.
+
+## Global Constraints
+
+- **Most EP board reports are NOT procurement awards** (WSIB safety reports, status updates, governance) and several carry `$` amounts that are traps. The parser MUST anchor on a procurement-award signal and **refuse everything else** (return None) — the negative fixtures are load-bearing.
+- Award winner is EP-specific: "award of Contract No. X (RFT No. EP###-YYYY) **to WINNER for the <project>** in the amount of $AMOUNT" — text sits between WINNER and the amount, so the winner regex stops at " for "/the amount phrase, NOT the shared Zoo "to WINNER <phrase> $" pattern (which over-captures here).
+- `native_ref` is the EP solicitation ref: `RFT No. EP###-YYYY` (primary) → `Contract No. <token>` → the passed `fallback_ref`. Match the shape, not the label vocabulary (#96/#138).
+- Confidential reports (Confidential Attachment) keep a publicly-named winner, `value_confidential=1`, NULL amount (the Zoo rule); a redacted counterparty ("a Consumer Show Client", lowercase) → winner None, still recorded.
+- Amounts: raw `$` token verbatim + numeric via the model; never aggregate raw TEXT. Bid rows refuse rather than guess (the #94 rule).
+- Discovery needs the `council` extra + a display; NEVER on the `tb nightly` path. Per-body isolation: EP failing never stops trca/zoo.
+- Tests offline, fixture-based. Commit messages end with the project's Co-Authored-By + Claude-Session trailer. Branch: `feat-130-exhibition-place` (checked out; spec + 5 real EP fixtures already committed there).
+
+---
+
+### Task 1: extract shared `agency_report.py` helpers; repoint `zoo_board`
+
+**Files:**
+- Create: `scrapers/toronto_bids/sources/agency_report.py`
+- Modify: `scrapers/toronto_bids/sources/zoo_board.py` (import the shared names, delete the local copies)
+- Test: `scrapers/tests/test_agency_report.py`
+
+**Interfaces:**
+- Produces: in `agency_report.py` — `AMOUNT_PHRASE: str`, `MONEY: str`, `AMOUNT_RE: re.Pattern` (matches `<amount-phrase> $X`), `CONFIDENTIAL_RE: re.Pattern`, `amount_or_none(text, m) -> str | None`. `zoo_board` and `ep_board` import these.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# scrapers/tests/test_agency_report.py
+import re
+
+from toronto_bids.sources.agency_report import (
+    AMOUNT_RE, CONFIDENTIAL_RE, amount_or_none,
+)
+
+
+def test_amount_re_reads_in_the_amount_of():
+    m = AMOUNT_RE.search("awarded in the amount of $410,563.00 to the firm")
+    assert m and m.group(1) == "$410,563.00"
+
+
+def test_amount_or_none_refuses_european_million_shorthand():
+    # "$1,25 million" captures only "$1" under thousands-grouping — refuse it.
+    m = AMOUNT_RE.search("in the amount of $1,25 million")
+    assert amount_or_none("in the amount of $1,25 million", m) is None
+
+
+def test_confidential_re_detects_attachment():
+    assert CONFIDENTIAL_RE.search("This report has a CONFIDENTIAL ATTACHMENT with value")
+    assert not CONFIDENTIAL_RE.search("no such thing here")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_agency_report.py -v`
+Expected: FAIL — `ModuleNotFoundError: toronto_bids.sources.agency_report`.
+
+- [ ] **Step 3: Create `agency_report.py`**
+
+Move the shared primitives out of `zoo_board.py` verbatim (no behavior change):
+
+```python
+"""Pure regex primitives shared by the agency board-report parsers (Zoo, Exhibition Place, …).
+
+Amounts are written many ways and "in the amount of" dominates the corpus; a truncated
+"$1,25 million" shorthand (comma decimal + scale word) captures a bogus "$1" and is refused.
+"""
+import re
+
+AMOUNT_PHRASE = (
+    r"(?:in\s+the\s+amount\s+of|at\s+a\s+(?:total\s+)?cost(?:\s+not\s+to\s+exceed)?(?:\s+of)?"
+    r"|for\s+the\s+(?:total\s+)?(?:sum|amount)\s+of|in\s+an\s+amount\s+not\s+to\s+exceed"
+    r"|total\s+cost\s+(?:not\s+to\s+exceed\s+)?(?:of\s+)?)")
+MONEY = r"(\$\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})?)"
+AMOUNT_RE = re.compile(r"(?i:" + AMOUNT_PHRASE + r")\s*" + MONEY)
+CONFIDENTIAL_RE = re.compile(r"CONFIDENTIAL\s+ATTACHMENT", re.I)
+_TRUNCATED_AMOUNT = re.compile(r"\s*(?:[.,]\d|million|billion)", re.I)
+
+
+def amount_or_none(text: str, m) -> str | None:
+    """The matched money string with spaces stripped, or None if the match is a truncated
+    "$X,YY million" shorthand (a bogus tiny figure) — refuse rather than store $1."""
+    if m is None or _TRUNCATED_AMOUNT.match(text, m.end()):
+        return None
+    return m.group(m.lastindex).replace(" ", "")
+```
+
+- [ ] **Step 4: Repoint `zoo_board.py`**
+
+In `zoo_board.py`: delete the local `_AMOUNT_PHRASE`, `_MONEY`, `_ZOO_AMOUNT`, `_CONFIDENTIAL`, `_TRUNCATED_AMOUNT`, `_amount_or_none`, and add:
+
+```python
+from toronto_bids.sources.agency_report import (
+    AMOUNT_PHRASE as _AMOUNT_PHRASE, AMOUNT_RE as _ZOO_AMOUNT,
+    CONFIDENTIAL_RE as _CONFIDENTIAL, MONEY as _MONEY, amount_or_none as _amount_or_none,
+)
+```
+
+(`_ZOO_AWARD` stays in `zoo_board` — it is Zoo-specific — and still builds from the imported `_AMOUNT_PHRASE`/`_MONEY`.) Verify `_ZOO_AWARD`'s definition still references `_AMOUNT_PHRASE` and `_MONEY` (now imported), unchanged.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd scrapers && uv run pytest tests/test_agency_report.py tests/test_zoo_reports.py -v` then `uv run pytest`
+Expected: all PASS — the existing zoo tests prove the extraction is behavior-preserving.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/agency_report.py scrapers/toronto_bids/sources/zoo_board.py \
+        scrapers/tests/test_agency_report.py
+git commit -m "refactor(agencies): extract shared amount/confidential helpers to agency_report.py (#130)"
+```
+
+---
+
+### Task 2: `exhibition-place` buyer + EP discovery/download
+
+**Files:**
+- Modify: `scrapers/toronto_bids/buyers.py` (append a Buyer)
+- Modify: `scrapers/toronto_bids/config.py` (append EP dirs)
+- Create: `scrapers/toronto_bids/sources/ep_board.py` (discovery + download half)
+- Test: `scrapers/tests/test_ep_reports.py`
+
+**Interfaces:**
+- Consumes: `bid_award_panel.scrape_agendas`/`cached_agendas`/`parse_agenda_pdfs`, `trca_board._store_pending_pdfs`, `BackgroundPdf`, `db`.
+- Produces: `EP_TERM_STARTS`, `scrape_ep_agendas(virtual_display, log) -> dict`, `cached_ep_agendas() -> dict`, `download_ep_reports(conn, http, agendas, log) -> int`. Tasks 3-5 consume `EP_TERM_STARTS` and the buyer.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# scrapers/tests/test_ep_reports.py
+from toronto_bids.sources.bid_award_panel import discover_meetings
+from toronto_bids.sources.ep_board import EP_TERM_STARTS
+
+
+def test_ep_terms_probe_the_ep_committee_series():
+    calls = []
+
+    def fetch(ref):
+        calls.append(ref)
+        return "The published report was not found"     # every probe misses
+
+    found = discover_meetings(fetch, term_starts=[("EP", 2023, "2022-2026", 1)],
+                              stop_after_misses=2)
+    assert found == {}
+    assert calls[0] == "2023.EP1"                        # probes EP, not ZB/BA
+
+
+def test_ep_terms_cover_the_confirmed_terms():
+    series = {t[0] for t in EP_TERM_STARTS}
+    years = {t[1] for t in EP_TERM_STARTS}
+    assert series == {"EP"}
+    assert 2023 in years                                 # 2022-2026 term (2025.EP18 seen live)
+
+
+def test_ep_buyer_seeded():
+    import sqlite3
+    from toronto_bids.buyers import seed_buyers
+    from toronto_bids.store import db
+    conn = db.connect(":memory:"); db.init_db(conn)
+    ids = seed_buyers(conn)
+    assert "exhibition-place" in ids
+    row = conn.execute("SELECT kind, partnered FROM buyer WHERE slug='exhibition-place'").fetchone()
+    assert row["kind"] == "agency" and row["partnered"] == 0
+    conn.close()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py -v`
+Expected: FAIL — `ep_board` / the seeded buyer don't exist.
+
+- [ ] **Step 3: Add the buyer**
+
+In `buyers.py`, append to `DEFAULT_BUYERS`:
+
+```python
+    Buyer(slug="exhibition-place", name="Exhibition Place", kind="agency", partnered=0,
+          funding_share=None, platform="Bonfire",
+          notes="City agency (Board of Governors); left the PMMD feed in 2019 for its own "
+                "Bonfire portal. Awards captured from Board of Governors reports on legdocs "
+                "(TMMIS EP committee); the Bonfire portal is gated (#134)."),
+```
+
+- [ ] **Step 4: Add config dirs**
+
+Append to `config.py`:
+
+```python
+# Exhibition Place Board of Governors (#130): the EP committee on TMMIS, same infrastructure
+# as the Zoo's ZB series — headed-browser discovery, plain-HTTP legdocs report PDFs.
+EP_AGENDAS_DIR = DATA_DIR / "agencies" / "ep" / "agendas"
+EP_REPORTS_DIR = DATA_DIR / "agencies" / "ep"
+```
+
+- [ ] **Step 5: Create the discovery/download half of `ep_board.py`**
+
+```python
+"""Exhibition Place Board of Governors capture (#130): the EP committee on TMMIS.
+
+Same infrastructure as the Zoo's ZB series (#135): TMMIS agendas need the headed browser
+(Akamai-gated), report PDFs are plain-HTTP legdocs (/legdocs/mmis/YYYY/ep/bgrd/...). Reuses
+the bid_award_panel prober; the EP reference format is YYYY.EP<meeting>.<item> (confirmed
+live). Most EP board reports are NOT procurement awards, so the parsers (added next) refuse
+non-awards.
+"""
+from toronto_bids import config
+from toronto_bids.models import BackgroundPdf
+from toronto_bids.sources.bid_award_panel import (cached_agendas, parse_agenda_pdfs,
+                                                  scrape_agendas)
+from toronto_bids.sources.trca_board import _store_pending_pdfs
+from toronto_bids.store import db
+
+# EP meetings reset numbering per council term, like ZB. Confirmed live: the 2022-2026 term
+# runs EP1..EP23 (as of 2026-06). The 2018-2022 term is probed too (2022.EP25 seen).
+EP_TERM_STARTS = [
+    ("EP", 2019, "2018-2022", 1),
+    ("EP", 2023, "2022-2026", 1),
+]
+
+
+def scrape_ep_agendas(virtual_display: bool = False, log=lambda _m: None) -> dict:
+    return scrape_agendas(config.EP_AGENDAS_DIR, virtual_display=virtual_display,
+                          log=log, term_starts=EP_TERM_STARTS)
+
+
+def cached_ep_agendas() -> dict:
+    return cached_agendas(config.EP_AGENDAS_DIR)
+
+
+def download_ep_reports(conn, http, agendas: dict, log=lambda _m: None) -> int:
+    """Index every bgrd PDF the EP agendas link, then fetch the ones not yet held. Plain HTTP,
+    resilient (a dead URL is skipped), sha256-queued. EP reports live under /legdocs/.../ep/."""
+    for meeting, html in agendas.items():
+        for pdf in parse_agenda_pdfs(html, meeting):
+            db.upsert_row(conn, BackgroundPdf(url=pdf["url"], reference=pdf["reference"],
+                                              kind="agency_board"), overwrite=False)
+    conn.commit()
+    return _store_pending_pdfs(conn, http, config.EP_REPORTS_DIR, "%/ep/%", log, "ep")
+```
+
+Note: the download filter is `"%/ep/%"` (the EP committee legdocs path). Confirm during the live run (Step 7) that EP report URLs match it; if an EP agenda links reports under a second path, widen the filter and record it.
+
+- [ ] **Step 6: Run the offline tests**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py tests/test_zoo_reports.py -v` then `uv run pytest`
+Expected: PASS (the `term_starts` mechanism is already generalized; buyer seeded).
+
+- [ ] **Step 7: Live discovery — record MORE real award fixtures (REQUIRED, not offline)**
+
+The repo has 5 seed EP fixtures, but only ONE is a competitive award-with-table (`ep_award_with_table_2023.txt`). One example is not enough to trust the award/table parsers (the #136/#138 lesson). Run a live discovery and record **at least 2 more** competitive-award reports (RFT/Contract award with a bid table) as fixtures:
+
+```bash
+cd scrapers && TB_DATA_DIR=/tmp/ep-live uv run tb enrich-agencies --only ep --scrape --virtual-display 2>&1 | tail
+# then, from the cached agendas, find reports containing "Table 1" / "Tender Price" / "award of Contract"
+# across BOTH terms, pdftotext them, and copy 2+ real competitive-award reports into
+# scrapers/tests/fixtures/agencies/ep_award_*.txt (name them by year/subject), noting them in SOURCES.md.
+```
+
+If, after scanning both terms, competitive-award-with-table reports are genuinely rare (EP's board handles mostly non-procurement business), record however many exist and **say so in the report** — do not fabricate. Commit the additional fixtures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scrapers/toronto_bids/buyers.py scrapers/toronto_bids/config.py \
+        scrapers/toronto_bids/sources/ep_board.py scrapers/tests/test_ep_reports.py \
+        scrapers/tests/fixtures/agencies/
+git commit -m "feat(ep): exhibition-place buyer + EP discovery/download; more award fixtures (#130)"
+```
+
+---
+
+### Task 3: `parse_ep_report` — award / confidential / refuse-non-awards
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/ep_board.py` (append)
+- Test: `scrapers/tests/test_ep_reports.py` (append)
+
+**Interfaces:**
+- Consumes: `agency_report` helpers; the committed EP fixtures.
+- Produces: `parse_ep_report(text: str, fallback_ref: str) -> dict | None` → `{native_ref, title, winner, amount, confidential, report_url}`. Task 5 consumes it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import pathlib
+
+from toronto_bids.sources.ep_board import parse_ep_report
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "agencies"
+
+
+def _read(name):
+    return (FIXTURES / name).read_text()
+
+
+def test_competitive_award_winner_ref_amount():
+    got = parse_ep_report(_read("ep_award_with_table_2023.txt"), fallback_ref="2023.EP1.1")
+    assert got is not None
+    assert got["native_ref"] == "EP110-2023"            # RFT No., not the Contract No.
+    assert got["winner"] == "Powell Fence Limited"       # stops at " for ", not the project text
+    from toronto_bids.amount import parse_amount
+    assert parse_amount(got["amount"]) == 1484065.00
+    assert got["confidential"] == 0
+
+
+def test_confidential_award_keeps_named_winner_nulls_amount():
+    got = parse_ep_report(_read("ep_confidential_decision_2025.txt"), fallback_ref="2025.EP18.9")
+    assert got is not None and got["confidential"] == 1
+    assert got["amount"] is None
+    assert "Coca-Cola" in got["winner"]
+
+
+def test_confidential_with_redacted_counterparty_has_no_winner_but_is_kept():
+    got = parse_ep_report(_read("ep_confidential_agreement.txt"), fallback_ref="2023.EP7.2")
+    assert got is not None and got["confidential"] == 1
+    assert got["winner"] is None                         # "a Consumer Show Client" is redacted, not a firm
+    assert got["native_ref"] == "2023.EP7.2"             # no RFT/Contract ref -> fallback
+
+
+def test_wsib_safety_report_is_refused_despite_dollar_amounts():
+    assert parse_ep_report(_read("ep_non_award_wsib_report.txt"), fallback_ref="2023.EP1.4") is None
+
+
+def test_procurement_status_update_is_refused():
+    assert parse_ep_report(_read("ep_non_award_procurement_status.txt"), fallback_ref="2023.EP1.5") is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py -k "award or refused or redacted or wsib or status" -v`
+Expected: FAIL — `parse_ep_report` undefined.
+
+- [ ] **Step 3: Implement `parse_ep_report`**
+
+Append to `ep_board.py`:
+
+```python
+import re
+
+from toronto_bids.sources.agency_report import AMOUNT_RE, CONFIDENTIAL_RE, amount_or_none
+
+# The EP solicitation ref: RFT No. EP###-YYYY (primary) or a Contract No. token. Match the
+# shape, not the label vocabulary.
+_EP_RFT = re.compile(r"RF[TPQ]\s*No\.?\s*(EP\d+-\d{4})", re.I)
+_EP_CONTRACT = re.compile(r"Contract\s+No\.?\s*([0-9][0-9A-Za-z\-]{3,})", re.I)
+# The competitive award clause: "award of ... to WINNER for the <project> ..." — WINNER is
+# bounded and STOPS at " for " / a comma / the amount phrase (EP puts the project between the
+# winner and the amount, so the shared Zoo "to WINNER <phrase> $" over-captures).
+_EP_AWARD = re.compile(
+    r"award\s+of\s+(?:the\s+)?(?:Contract|RF[TPQ]|Tender)\b[^$]{0,120}?\bto\s+"
+    r"([A-Z][A-Za-z0-9&.,'’ \-]{2,55}?)\s+(?:for\b|,|in\s+the\s+amount)", re.I | re.S)
+# A confidential agreement's counterparty, when publicly named ("agreement with Coca-Cola …").
+# Capital-anchored, so a redacted "a Consumer Show Client" is correctly skipped.
+_EP_AGREEMENT = re.compile(
+    r"agreement\s+with\s+([A-Z][A-Za-z0-9&.,'’ \-]{2,45}?)(?:\s+(?:for|to|on|,)\b|\s*\()", re.S)
+_EP_SUBJECT = re.compile(r"^([A-Z].*(?:Tender|Contract|Award|Agreement|RF[TPQ]).*)$", re.M)
+
+
+def _ep_ref(text: str, fallback_ref: str) -> str:
+    m = _EP_RFT.search(text)
+    if m:
+        return m.group(1).upper()
+    m = _EP_CONTRACT.search(text)
+    return m.group(1) if m else fallback_ref
+
+
+def parse_ep_report(text: str, fallback_ref: str, report_url: str | None = None) -> dict | None:
+    """Map one EP board report to an award, or None. Most EP reports are NOT procurement awards
+    (WSIB safety, status updates, governance) — refuse those. Keeps a confidential award (value
+    withheld) when it names a real counterparty OR is an explicit procurement agreement."""
+    confidential = 1 if CONFIDENTIAL_RE.search(text) else 0
+    aw = _EP_AWARD.search(text)
+    winner = aw.group(1).strip() if aw else None
+    amount = None if confidential else amount_or_none(text, AMOUNT_RE.search(text)) if aw else None
+
+    if not aw:
+        # No competitive award clause. Keep ONLY a confidential procurement agreement.
+        if confidential and re.search(r"\bagreement\b|\baward\b|\bcontract\b", text, re.I):
+            ag = _EP_AGREEMENT.search(text)
+            winner = ag.group(1).strip() if ag else None
+        else:
+            return None                              # not a procurement award — refuse
+
+    ref_m = _EP_SUBJECT.search(text)
+    return {
+        "native_ref": _ep_ref(text, fallback_ref),
+        "title": re.sub(r"\s+", " ", ref_m.group(1)).strip() if ref_m else None,
+        "winner": winner,
+        "amount": amount,
+        "confidential": confidential,
+        "report_url": report_url,
+    }
+```
+
+- [ ] **Step 4: Run the tests; iterate the parser (not the assertions) against the real fixtures**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py -v`
+Expected: PASS. The assertions encode the real fixtures' ground truth — if one fails, the parser is wrong. The likely first failures: the `_EP_AWARD` winner boundary (must yield exactly "Powell Fence Limited"), and the WSIB/status negatives (must return None despite `$`/"approved" text). Debug against the fixture bytes; keep the refuse-non-awards rule.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/ep_board.py scrapers/tests/test_ep_reports.py
+git commit -m "feat(ep): parse_ep_report — award/confidential extraction, refuses non-awards (#130)"
+```
+
+---
+
+### Task 4: `parse_ep_bid_table` — the Table 1 bidder prices
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/ep_board.py` (append)
+- Test: `scrapers/tests/test_ep_reports.py` (append)
+
+**Interfaces:**
+- Consumes: the committed EP fixtures.
+- Produces: `parse_ep_bid_table(text: str) -> list[tuple[str, str]]` — `(bidder, price)` per Table 1 row. Task 5 consumes it.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_bid_table_extracts_all_three_bidders_with_prices():
+    rows = parse_ep_bid_table(_read("ep_award_with_table_2023.txt"))
+    assert rows == [
+        ("Powell Fence Limited", "$1,484,065.00"),
+        ("M.J.K. Construction Incorporated", "$1,619,001.00"),
+        ("Clearway Construction Incorporated", "$1,851,100.00"),
+    ]
+
+
+def test_bid_table_absent_returns_empty():
+    rows = parse_ep_bid_table(_read("ep_non_award_wsib_report.txt"))
+    assert rows == []                                    # no Table 1 -> no bids
+```
+
+(add `from toronto_bids.sources.ep_board import parse_ep_bid_table` to the test file's imports.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py -k bid_table -v`
+Expected: FAIL — `parse_ep_bid_table` undefined.
+
+- [ ] **Step 3: Implement `parse_ep_bid_table`**
+
+Append to `ep_board.py`:
+
+```python
+# A Table 1 row: a bidder name (letters/&/./,/spaces) followed by its first $ price. The winner
+# row carries a second $ (recommended contract price); take the FIRST. Column-header lines
+# ("Base Bid Price", "Received", "Recommended Contract Price") have no leading firm name + price
+# on the same run and are skipped by requiring a name that ends in a company word OR a name-then-$
+# on one line. Refuse a line that isn't a clean name+price (the #94 rule).
+_EP_BID_ROW = re.compile(
+    r"^\s*([A-Z][A-Za-z0-9&.,'’ \-]{3,60}?)\s+(\$\s?\d{1,3}(?:,\d{3})*\.\d{2})", re.M)
+_EP_TABLE_HEAD = re.compile(r"Table\s+\d[^\n]*Tender\s+Price\s+Submission", re.I)
+
+
+def parse_ep_bid_table(text: str) -> list[tuple[str, str]]:
+    """Every (bidder, base-bid-price) in an EP 'Table 1: Tender Price Submission'. Empty if the
+    report has no such table."""
+    head = _EP_TABLE_HEAD.search(text)
+    if not head:
+        return []
+    # Scope to the region after the header up to a blank-line gap / the next section.
+    tail = text[head.end():head.end() + 1500]
+    rows = []
+    for m in _EP_BID_ROW.finditer(tail):
+        name = re.sub(r"\s+", " ", m.group(1)).strip()
+        price = m.group(2).replace(" ", "")
+        # Skip a column-header fragment that slipped through (no company suffix and generic words).
+        if name.lower() in {"base bid price", "recommended contract price", "received"}:
+            continue
+        rows.append((name, price))
+    return rows
+```
+
+- [ ] **Step 4: Run the tests; iterate against the real fixture**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py -k bid_table -v`
+Expected: PASS with exactly the three rows. If the column-header row ("Bidder … Base Bid Price Received Recommended Contract Price") leaks in, tighten the skip set or require the price to be a `.\d{2}` decimal (bids are, headers aren't). The assertion is ground truth — fix the parser.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/ep_board.py scrapers/tests/test_ep_reports.py
+git commit -m "feat(ep): parse_ep_bid_table — Table 1 bidder prices (#130)"
+```
+
+---
+
+### Task 5: `store_ep_reports` + CLI wiring + live measurement + docs
+
+**Files:**
+- Modify: `scrapers/toronto_bids/sources/ep_board.py` (append `store_ep_reports`)
+- Modify: `scrapers/toronto_bids/cli.py` (`--only` choices, body loop, EP block)
+- Modify: `CLAUDE.md` (extend the agency-capture subsection)
+- Test: `scrapers/tests/test_ep_reports.py` (append)
+
+**Interfaces:**
+- Consumes: `parse_ep_report`, `parse_ep_bid_table`, `AgencySolicitation`/`AgencyAward`/`AgencyBid`, `seed_buyers`.
+- Produces: `store_ep_reports(conn, buyer_id) -> dict` (`solicitations`, `awards`, `bids`); `tb enrich-agencies --only ep [--scrape]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_store_ep_reports_lands_award_and_bids(conn):
+    from toronto_bids.buyers import seed_buyers
+    from toronto_bids.sources.ep_board import store_ep_reports
+    ids = seed_buyers(conn)
+    conn.execute("INSERT INTO background_pdf (url, kind, sha256, text) VALUES "
+                 "('https://www.toronto.ca/legdocs/mmis/2023/ep/bgrd/backgroundfile-240943.pdf',"
+                 " 'agency_board', 'x', ?)", (_read("ep_award_with_table_2023.txt"),))
+    conn.commit()
+    got = store_ep_reports(conn, ids["exhibition-place"])
+    assert got["solicitations"] == 1 and got["awards"] == 1 and got["bids"] == 3
+    aw = conn.execute("SELECT supplier_name_raw, award_amount_numeric FROM agency_award "
+                      "WHERE native_ref='EP110-2023'").fetchone()
+    assert aw["supplier_name_raw"] == "Powell Fence Limited"
+    assert aw["award_amount_numeric"] == 1484065.00
+    bids = conn.execute("SELECT COUNT(*) FROM agency_bid WHERE bid_price_numeric IS NOT NULL "
+                        "AND native_ref='EP110-2023'").fetchone()[0]
+    assert bids == 3
+```
+
+(`conn` fixture: reuse the one from `test_bids_tenders.py`'s pattern — an in-memory `db.connect(":memory:")` with `db.init_db`. Add it to this test file if not already present.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py -k store_ep -v`
+Expected: FAIL — `store_ep_reports` undefined.
+
+- [ ] **Step 3: Implement `store_ep_reports`**
+
+Append to `ep_board.py`:
+
+```python
+from toronto_bids.models import AgencyAward, AgencyBid, AgencySolicitation
+
+
+def store_ep_reports(conn, buyer_id: int) -> dict:
+    """Parse held EP reports into agency rows. One AgencySolicitation + AgencyAward per award
+    report (confidential ones keep the winner, NULL amount), and one AgencyBid per Table 1 row.
+    Non-award reports are refused by parse_ep_report and contribute nothing."""
+    counts = {"solicitations": 0, "awards": 0, "bids": 0}
+    for row in conn.execute(
+            "SELECT reference, url, text FROM background_pdf WHERE kind='agency_board' "
+            "AND url LIKE '%/ep/%' AND text IS NOT NULL ORDER BY url").fetchall():
+        got = parse_ep_report(row["text"], fallback_ref=row["reference"] or row["url"],
+                              report_url=row["url"])
+        if got is None:
+            continue
+        db.upsert_row(conn, AgencySolicitation(
+            buyer_id=buyer_id, native_ref=got["native_ref"], title=got["title"],
+            status="awarded", posted_date=None, closing_date=None, portal_url=None,
+            source="ep_board"), overwrite=False)
+        counts["solicitations"] += 1
+        db.upsert_row(conn, AgencyAward(
+            buyer_id=buyer_id, native_ref=got["native_ref"], supplier_name_raw=got["winner"],
+            award_amount=got["amount"], value_confidential=got["confidential"], award_date=None,
+            report_url=got["report_url"], source="ep_board"), overwrite=True)
+        counts["awards"] += 1
+        for bidder, price in parse_ep_bid_table(row["text"]):
+            db.upsert_row(conn, AgencyBid(
+                buyer_id=buyer_id, native_ref=got["native_ref"], bidder_name_raw=bidder,
+                bid_price=price, report_url=row["url"], source="ep_board"), overwrite=True)
+            counts["bids"] += 1
+    conn.commit()
+    return counts
+```
+
+- [ ] **Step 4: Wire the CLI**
+
+In `cli.py` `build_parser`, change the `enrich-agencies --only` choices to include `ep`:
+
+```python
+    p_ag.add_argument("--only", choices=["zoo", "trca", "ep"],
+                      help="Run one body instead of all")
+```
+
+In `_cmd_enrich_agencies`, change the default body list and add an EP block after the `zoo` block (mirroring it — EP uses the same scrape/cached/download shape):
+
+```python
+        bodies = [args.only] if args.only else ["trca", "zoo", "ep"]
+        ...
+        if "ep" in bodies:
+            try:
+                from toronto_bids.sources.ep_board import (
+                    cached_ep_agendas, download_ep_reports, scrape_ep_agendas, store_ep_reports)
+                agendas = (scrape_ep_agendas(virtual_display=args.virtual_display, log=out)
+                           if args.scrape else cached_ep_agendas())
+                print(f"  ep EP agendas        : {len(agendas)}"
+                      f" ({'scraped' if args.scrape else 'cached'})")
+                if agendas and (args.fetch or args.scrape):
+                    http = HttpClient()
+                    try:
+                        print(f"  ep reports fetched   : "
+                              f"{download_ep_reports(conn, http, agendas, log=out)}")
+                    finally:
+                        http.close()
+                got = store_ep_reports(conn, ids["exhibition-place"])
+                print(f"  ep stored            : {got['solicitations']} solicitations, "
+                      f"{got['awards']} awards, {got['bids']} bids")
+            except Exception as exc:
+                failures.append(("ep", str(exc)))
+```
+
+- [ ] **Step 5: Run tests + full suite**
+
+Run: `cd scrapers && uv run pytest tests/test_ep_reports.py -v` then `uv run pytest`
+Expected: all PASS.
+
+- [ ] **Step 6: Live measurement (REQUIRED — the #136/#138 discipline)**
+
+```bash
+cd scrapers && TB_DATA_DIR=/tmp/ep-live uv run tb enrich-agencies --only ep --scrape --virtual-display 2>&1 | tail
+```
+
+Then measure: over all held EP reports, how many `parse_ep_report` accepts vs refuses, and eyeball a sample of the accepted awards for **clean winner names** (no project-description over-capture, no WSIB/status false positives) and the bid rows for sane prices. Record the counts in the task report. A high refusal rate is EXPECTED and correct (most EP reports aren't awards) — but a *named* award must be clean. If false positives appear, tighten `_EP_AWARD`/the refuse rule and re-measure. Clean up `/tmp/ep-live` after.
+
+- [ ] **Step 7: Update CLAUDE.md**
+
+In the agency-capture subsection, append:
+
+```markdown
+Exhibition Place (`sources/ep_board.py`, #130) reuses the Zoo pattern: TMMIS EP committee
+(`YYYY.EP<n>.<n>`, headed-browser discovery via the shared prober) → plain-HTTP legdocs
+`bgrd` PDFs → `parse_ep_report` + `parse_ep_bid_table`. **Most EP board reports are not
+procurement awards** (WSIB safety, status updates, governance), so the parser anchors on an
+"award of Contract/RFT … to WINNER" clause and refuses the rest; the WSIB negative fixtures
+(which carry `$` amounts) guard against false positives. EP's award clause puts the project
+between the winner and the amount ("to WINNER **for the <project>** in the amount of $X"), so
+the winner regex is EP-specific, not the shared Zoo pattern. Amount/confidential primitives are
+shared via `sources/agency_report.py`. EP is the first agency source with a structured bidder
+price table (Table 1 → `agency_bid` with prices). On-demand (`--only ep --scrape`), never on
+the browser-free nightly path. The pre-2019 City-spine EP slice (Client_Division "Exhibition
+Place") and these post-2019 Board-of-Governors awards are separate coexisting keyspaces (#130).
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scrapers/toronto_bids/sources/ep_board.py scrapers/toronto_bids/cli.py CLAUDE.md \
+        scrapers/tests/test_ep_reports.py
+git commit -m "feat(ep): store_ep_reports + tb enrich-agencies --only ep; document (#130)"
+```
+
+---
+
+## After the last task
+
+Run the full suite (`cd scrapers && uv run pytest`). The live `--only ep --scrape` run from Task 5 Step 6 is the real-world verification; its refusal-vs-accept counts and a clean-name spot-check are the evidence. Use superpowers:finishing-a-development-branch. On completion, comment on #130 with what landed (EP awards + bidder prices recovered, the pre/post-2019 coexistence answered) and close it.

--- a/docs/superpowers/plans/2026-07-18-exhibition-place-capture.md
+++ b/docs/superpowers/plans/2026-07-18-exhibition-place-capture.md
@@ -311,6 +311,27 @@ def test_competitive_award_winner_ref_amount():
     assert got["confidential"] == 0
 
 
+def test_2019_award_line_wrapped_winner_and_contract_ref():
+    # 2019 EP reports differ (see SOURCES.md): the winner spans a pdftotext line break
+    # ("Westbury National\nShow System Ltd.") and the ref is a Contract No., not RFT-EP.
+    got = parse_ep_report(_read("ep_award_2019_sole_tender.txt"), fallback_ref="2019.EP2.1")
+    assert got is not None
+    assert got["winner"] == "Westbury National Show System Ltd."   # line-wrap collapsed, whole name
+    assert got["native_ref"] == "19-085-98518"          # Contract No. (no RFT-EP in 2019)
+    from toronto_bids.amount import parse_amount
+    assert parse_amount(got["amount"]) == 969415.00     # "in the amount of $969,415.00" (not the bid)
+
+
+def test_2019_award_strips_location_qualifier_from_winner():
+    # "to Sutherland-Schultz Ltd. of Cambridge, Ontario for …" — strip the " of <City>, <Prov>"
+    # qualifier so the firm keys consistently in the supplier dimension.
+    got = parse_ep_report(_read("ep_award_2019_multi_bidder.txt"), fallback_ref="2019.EP6.1")
+    assert got is not None
+    assert got["winner"] == "Sutherland-Schultz Ltd."   # NOT "... of Cambridge, Ontario"
+    from toronto_bids.amount import parse_amount
+    assert parse_amount(got["amount"]) == 403854.47
+
+
 def test_confidential_award_keeps_named_winner_nulls_amount():
     got = parse_ep_report(_read("ep_confidential_decision_2025.txt"), fallback_ref="2025.EP18.9")
     assert got is not None and got["confidential"] == 1
@@ -351,12 +372,34 @@ from toronto_bids.sources.agency_report import AMOUNT_RE, CONFIDENTIAL_RE, amoun
 # shape, not the label vocabulary.
 _EP_RFT = re.compile(r"RF[TPQ]\s*No\.?\s*(EP\d+-\d{4})", re.I)
 _EP_CONTRACT = re.compile(r"Contract\s+No\.?\s*([0-9][0-9A-Za-z\-]{3,})", re.I)
-# The competitive award clause: "award of ... to WINNER for the <project> ..." — WINNER is
-# bounded and STOPS at " for " / a comma / the amount phrase (EP puts the project between the
-# winner and the amount, so the shared Zoo "to WINNER <phrase> $" over-captures).
+# The competitive award clause: "award of ... to WINNER for/at the <project> ..." — WINNER is
+# bounded and STOPS at " for "/" at "/a comma/the amount phrase (EP puts the project between the
+# winner and the amount, so the shared Zoo "to WINNER <phrase> $" over-captures). The winner
+# class ALLOWS internal whitespace (`\s` + re.S) because pdftotext wraps long firm names across
+# lines ("Westbury National\nShow System Ltd."); _squash collapses it. A trailing location
+# qualifier (" of Cambridge, Ontario") is stripped afterwards by _strip_location.
 _EP_AWARD = re.compile(
     r"award\s+of\s+(?:the\s+)?(?:Contract|RF[TPQ]|Tender)\b[^$]{0,120}?\bto\s+"
-    r"([A-Z][A-Za-z0-9&.,'’ \-]{2,55}?)\s+(?:for\b|,|in\s+the\s+amount)", re.I | re.S)
+    r"([A-Z][A-Za-z0-9&.,'’()\-\s]{2,60}?)\s+(?:for\b|at\b|,|in\s+the\s+amount)", re.I | re.S)
+# End-anchored location qualifier to strip from a winner ("Firm Ltd. of Cambridge, Ontario").
+# Narrow (a space-delimited "of <Place>, <Province>") so real names like "…& Sons" survive.
+_LOCATION = re.compile(r"\s+of\s+[A-Z][A-Za-z. ]+,\s*(?:Ontario|Canada|Quebec|Alberta|B\.?C\.?)\.?$", re.I)
+
+
+def _strip_location(name: str) -> str:
+    return _LOCATION.sub("", name).strip()
+
+
+_WS = re.compile(r"\s+")
+
+
+def _winner(raw: str | None) -> str | None:
+    """Collapse a line-wrapped winner and strip a trailing location qualifier."""
+    if raw is None:
+        return None
+    return _strip_location(_WS.sub(" ", raw).strip()) or None
+
+
 # A confidential agreement's counterparty, when publicly named ("agreement with Coca-Cola …").
 # Capital-anchored, so a redacted "a Consumer Show Client" is correctly skipped.
 _EP_AGREEMENT = re.compile(
@@ -378,14 +421,14 @@ def parse_ep_report(text: str, fallback_ref: str, report_url: str | None = None)
     withheld) when it names a real counterparty OR is an explicit procurement agreement."""
     confidential = 1 if CONFIDENTIAL_RE.search(text) else 0
     aw = _EP_AWARD.search(text)
-    winner = aw.group(1).strip() if aw else None
+    winner = _winner(aw.group(1)) if aw else None
     amount = None if confidential else amount_or_none(text, AMOUNT_RE.search(text)) if aw else None
 
     if not aw:
         # No competitive award clause. Keep ONLY a confidential procurement agreement.
         if confidential and re.search(r"\bagreement\b|\baward\b|\bcontract\b", text, re.I):
             ag = _EP_AGREEMENT.search(text)
-            winner = ag.group(1).strip() if ag else None
+            winner = _winner(ag.group(1)) if ag else None
         else:
             return None                              # not a procurement award — refuse
 
@@ -436,12 +479,27 @@ def test_bid_table_extracts_all_three_bidders_with_prices():
     ]
 
 
+def test_bid_table_2019_five_bidders_with_footnote_marker():
+    # 2019 "Table 1: Tender Price Submissions" (plural), 5 bidders, a `*` revised-price marker on
+    # one row — the price capture must stop before the `*`.
+    rows = parse_ep_bid_table(_read("ep_award_2019_multi_bidder.txt"))
+    assert rows == [
+        ("Sutherland-Schultz Ltd.", "$418,854.47"),
+        ("Ontario Electrical Construction Co. Ltd.", "$461,522.00"),
+        ("Modern Niagara Toronto Inc.", "$470,700.00"),      # the trailing * is dropped
+        ("Stevens & Black Electrical Contractors Ltd.", "$518,000.00"),
+        ("Rogol Electric Company Limited", "$546,350.00"),
+    ]
+
+
 def test_bid_table_absent_returns_empty():
     rows = parse_ep_bid_table(_read("ep_non_award_wsib_report.txt"))
     assert rows == []                                    # no Table 1 -> no bids
 ```
 
 (add `from toronto_bids.sources.ep_board import parse_ep_bid_table` to the test file's imports.)
+
+Note for the implementer: `_EP_TABLE_HEAD` must match "Tender Price Submission**s**" (plural, 2019) as well as the singular; and the price group stops before a trailing `*` footnote. The 2019 header row is `Tenderer` (not `Bidder`) — the row regex keys on "capitalised name + `$price`", so it skips whichever header word, but verify no header line (`Tenderer`, `Tender Price`, `Received`, `Recommended Contract Price`) is captured.
 
 - [ ] **Step 2: Run to verify failure**
 

--- a/docs/superpowers/specs/2026-07-18-exhibition-place-capture-design.md
+++ b/docs/superpowers/specs/2026-07-18-exhibition-place-capture-design.md
@@ -1,0 +1,164 @@
+# Exhibition Place award-report capture (#130) — design
+
+2026-07-18. Recover Exhibition Place's post-2019 procurement record from its Board of Governors
+award reports on legdocs — a no-permission-gate slice that reuses the TRCA/Zoo board-report
+machinery. The Bonfire portal (the current live venue) stays out of scope pending its terms of
+use (#103/#134).
+
+## Why now, and why this is cheap
+
+EP left the City's PMMD feed in 2019 (its 72 spine rows stop at 2019-08-27) when it adopted its
+own Bonfire portal, so everything since is invisible to the archive. But EP's awards are approved
+by its **Board of Governors**, whose staff reports and decision letters are published on legdocs
+as plain-HTTP PDFs — the same "board report" shape the Zoo/TRCA capture already parses. This is
+the "Exhibition Place pattern" that recurred throughout #135: the *awards* are reachable
+off-platform even when the live listing venue is a gated commercial portal.
+
+## The finding that shapes it (probed live 2026-07-18)
+
+EP is the **Zoo capture, verbatim structure**:
+
+- TMMIS is Akamai-gated (agenda pages 403 to plain HTTP), so meeting discovery needs the headed
+  browser — exactly as the Zoo's ZB series does.
+- The EP committee reference format is `YYYY.EP<meeting>.<item>` (confirmed: `2025.EP18.9`,
+  `2022.EP25.13`) — the same shape as the Zoo's `YYYY.ZB<n>.<n>`, so the `bid_award_panel` prober
+  generalizes directly with an `EP_TERM_STARTS` list.
+- Reports are plain-HTTP legdocs PDFs (`/legdocs/mmis/YYYY/<committee>/bgrd/backgroundfile-N.pdf`),
+  fetchable without a browser — verified 200 `application/pdf`.
+
+Two report shapes, both already handled elsewhere:
+
+1. **Award staff reports** (e.g. `backgroundfile-240943`, EP110-2023): RECOMMENDATIONS name the
+   winner and amount — "The Board approve the award of Contract No. 23-079-37912 (RFT No.
+   EP110-2023) to Powell Fence Limited … in the amount of $1,484,065.00" (the Zoo's "in the amount
+   of $X" phrasing) — plus a structured **"Table 1: Tender Price Submission"**:
+   ```
+   Bidder                              Base Bid Price   Recommended Contract Price
+   Powell Fence Limited                $1,484,065.00    $1,484,065.00
+   M.J.K. Construction Incorporated    $1,619,001.00
+   Clearway Construction Incorporated  $1,851,100.00
+   ```
+   One row per bidder: name + first `$amount` (the base bid). The winner's row carries a second
+   `$amount` (the recommended contract price); take the first.
+2. **Decision letters with a confidential attachment** (e.g. `backgroundfile-258727`, EP18.9,
+   Coca-Cola sponsorship): the winner is named publicly, the value is withheld behind a
+   "Confidential Attachment … monetary value" — the Zoo's `value_confidential=1` shape, no bid
+   table.
+
+## Decisions (settled in brainstorming)
+
+- **Scope: awards + bids with prices.** Parse the winner+amount (`agency_award`) AND the Table 1
+  bidder rows with prices (`agency_bid`). EP is the first agency source with a clean structured
+  price table — the archive's core "was it competitive?" value.
+- **Reuse over rebuild.** New `sources/ep_board.py` reuses the `bid_award_panel`/`zoo_board`
+  discovery prober, `trca_board._store_pending_pdfs` download, and the `agency_*` tables.
+- **Shared pure helpers extracted.** The amount-phrase, `$`-money, and confidential-attachment
+  regexes/helpers now used by both `zoo_board` and `ep_board` move to a new
+  `sources/agency_report.py`; both import them. Light, test-covered, no behavior change.
+- **On-demand, not nightly.** Discovery needs the headed browser (`council` extra + display), and
+  nothing browser-bound is on the scheduled path — so this runs as `tb enrich-agencies --only ep
+  --scrape`, like the Zoo, never in `tb nightly`.
+
+## Architecture
+
+### New buyer
+
+Seed `exhibition-place` in `buyers.py`: `kind="agency"`, `partnered=0`, `platform="Bonfire"`,
+notes recording that awards come from Board of Governors reports on legdocs and the portal is
+gated (#134).
+
+### `sources/agency_report.py` (new — shared pure helpers)
+
+Extract from `zoo_board.py` (no behavior change): `_AMOUNT_PHRASE`, `_MONEY`,
+`_amount_or_none(text, match)`, `_CONFIDENTIAL`, and the `_ZOO_AMOUNT` builder. `zoo_board`
+imports them; `ep_board` imports them. Covered by the existing zoo tests plus a direct unit test
+of `_amount_or_none` (the `$1,25 million` truncation guard).
+
+### `sources/ep_board.py`
+
+- **Discovery** (browser): `scrape_ep_agendas(virtual_display, log)` → `scrape_agendas(
+  config.EP_AGENDAS_DIR, term_starts=EP_TERM_STARTS, …)`, and `cached_ep_agendas()`. `EP_TERM_STARTS`
+  is the EP committee across its terms — the exact list (year ranges, first meeting numbers) is
+  confirmed by probing at implementation time, exactly as `ZB_TERM_STARTS` was.
+- **Download** (plain HTTP): index the `bgrd` PDF URLs from cached agendas via `parse_agenda_pdfs`,
+  then `trca_board._store_pending_pdfs(conn, http, config.EP_REPORTS_DIR, "%/legdocs/%", …)` — the
+  resilient loop (skips a dead URL, `%PDF` guard, sha256 queue).
+- **Pure parsers**:
+  - `parse_ep_report(text, fallback_ref) -> dict | None` → `{native_ref, title, winner, amount,
+    confidential, report_url}`. Winner+amount via the shared amount phrase from a RECOMMENDATIONS
+    "award … to WINNER … $AMOUNT" clause (bounded winner, no legal-suffix requirement — the #138
+    lesson); `native_ref` from `RFT No. EP\d+-\d{4}` or `Contract No. <token>` (match the shape,
+    not the vocabulary); `confidential=1` when a Confidential Attachment is present (amount then
+    NULL, winner kept). Returns None when nothing meaningful is extracted (the Zoo empty-refusal
+    rule).
+  - `parse_ep_bid_table(text) -> list[tuple[str, str]]` → `(bidder, price)` per Table 1 row. Read
+    the lines after the "Table 1: Tender Price Submission" header until a blank/section boundary;
+    each row is `<bidder name> … <first $amount>`. Skip the column-header rows ("Base Bid Price",
+    "Received", "Recommended Contract Price") and refuse a line without a clean name+price (the #94
+    refuse-rather-than-guess rule).
+- **Store** `store_ep_reports(conn, buyer_id) -> dict`: per held report, upsert one
+  `AgencySolicitation` (overwrite=False), one `AgencyAward` per winner (with `value_confidential`),
+  and one `AgencyBid` per Table 1 row (`bid_price` verbatim, `bid_price_numeric` via the model).
+  Returns counts.
+
+### CLI
+
+Extend `_cmd_enrich_agencies`: `--only ep` runs EP; `--scrape` discovers EP agendas via the
+browser (implies fetching the legdocs PDFs); default is offline (parses cached reports). Per-body
+isolated exactly like trca/zoo — EP failing never stops the others. `build_supplier_dimension`
+already spans `agency_award`/`agency_bid`, so EP winners and bidders enter the supplier dimension
+with no change.
+
+## Data flow
+
+`scrape_ep_agendas` (browser, cached) → `parse_agenda_pdfs` (bgrd URLs) → `_store_pending_pdfs`
+(plain-HTTP PDFs + `pdftotext`) → `parse_ep_report` + `parse_ep_bid_table` (pure) → `store_ep_reports`
+(agency_solicitation/award/bid) → `build_supplier_dimension` → export's `buyers` section surfaces
+EP with no export change.
+
+## The 2011-2019 coexistence (#130's open question, answered)
+
+The archive's 72 pre-2019 EP rows live in the City spine (`solicitation`, Client_Division
+"Exhibition Place", keyed on the 10-digit `document_number`). These post-2019 Board-of-Governors
+awards live in `agency_*`, keyed on the EP ref (`EP110-2023` / a contract number). **They are
+separate keyspaces and coexist; no join is attempted** — the same discipline that keeps the agency
+tables out of the City spine (#96/#135). Exhibition Place's record is therefore in two places by
+era, which is accurate: it *was* a City-fed division through 2019 and *is* a self-procuring board
+after.
+
+## Error handling
+
+- Per-body isolation in the CLI (EP failing never stops trca/zoo or supplier linking), mirroring
+  the existing pattern.
+- Download resilience via `_store_pending_pdfs` (one dead legdocs URL is skipped, not fatal).
+- Parsers refuse rather than guess (return None / drop an ambiguous table row) — a wrong award or
+  a mangled bidder is worse than none.
+
+## Testing
+
+Offline, fixture-based. Record **several real EP reports** as fixtures — an award-with-Table-1
+(240943), a confidential decision letter (258727), and 3-4 more spanning years/shapes — captured
+via legdocs (plain HTTP). TDD:
+
+- `parse_ep_report`: award winner+amount, confidential-value case (winner kept, amount NULL),
+  ref-shape extraction (EP###-YYYY and Contract No.), empty-refusal.
+- `parse_ep_bid_table`: the Powell/M.J.K./Clearway rows extract as three (bidder, price) pairs;
+  header rows skipped; a wrapped/short line refused.
+- `store_ep_reports`: rows land, confidential award has NULL amount + kept winner, bids carry
+  numeric prices.
+
+**Per the #136/#138 lesson, before declaring done, run a live `tb enrich-agencies --only ep
+--scrape` and measure award/bid extraction against a real sample of EP reports — the offline
+fixtures are a starting point, not proof.** Browser discovery stays untested by unit tests, as
+with the Zoo.
+
+## Out of scope
+
+- The EP Bonfire portal (gated, #134) and MERX cross-posts.
+- Any join between the pre-2019 spine slice and the EP-series awards.
+- Non-award EP reports (governance, budgets) — the parsers refuse them.
+
+## Recording
+
+On completion, comment on #130 with what landed (awards + bids recovered, the coexistence answer)
+and close it; note the shared-helper extraction on #135's Zoo lineage if relevant.

--- a/scrapers/tests/fixtures/agencies/SOURCES.md
+++ b/scrapers/tests/fixtures/agencies/SOURCES.md
@@ -79,3 +79,19 @@ procurement, so most reports are NOT awards — the negatives below are load-bea
 EP award clause shape: "award of Contract No. <c> (RFT No. EP###-YYYY) to WINNER for the
 <project> in the amount of $AMOUNT" — text sits between WINNER and the amount phrase, so the
 winner regex is EP-specific (stops at " for "/amount), not the shared Zoo "to WINNER <phrase> $".
+
+### EP award fixtures — 2019 (year variety, #130)
+
+Live-captured 2026-07-18 (EP 2018-2022 term). Table-awards are rare (4 of 151 reports scanned),
+and 2019 EP reports differ from the 2023 seed — the parser must handle both:
+
+| fixture | why it matters |
+|---|---|
+| ep_award_2019_sole_tender.txt (bgrd-131331, 2019.EP2) | winner spans a line break ("Westbury National / Show System Ltd."); `Contract No. 19-085-98518` ref (no RFT-EP); ONE bidder; award $969,415.00 ≠ the sole bid $1,139,944.00 (distinct columns) |
+| ep_award_2019_multi_bidder.txt (bgrd-137241, 2019.EP6) | winner carries a location qualifier ("Sutherland-Schultz Ltd. **of Cambridge, Ontario**") — strip it; 5 bidders; a bid price footnote `*` (revised-price marker) |
+
+Corpus gotchas the parser must handle: (1) winners span pdftotext line breaks → the winner class
+must allow internal whitespace, bounded, stopping at for/at/,/in-the-amount; (2) strip a trailing
+" of <City>, <Province>" location qualifier so the same firm keys consistently; (3) `native_ref`
+is `RFT No. EP###-YYYY` (2023) OR `Contract No. <token>` (2019); (4) both years use "in the amount
+of $X"; (5) a bid price may carry a trailing `*` footnote.

--- a/scrapers/tests/fixtures/agencies/SOURCES.md
+++ b/scrapers/tests/fixtures/agencies/SOURCES.md
@@ -75,6 +75,7 @@ procurement, so most reports are NOT awards — the negatives below are load-bea
 | ep_confidential_agreement.txt | confidential agreement, counterparty redacted ("a Consumer Show Client") → winner None | 2022-2026 EP term, backgroundfile-230177 |
 | ep_non_award_wsib_report.txt | NEGATIVE: WSIB lost-time-injury safety report; carries `$` (WSIB costs) but no award → must return None | backgroundfile-230165 |
 | ep_non_award_procurement_status.txt | NEGATIVE: procurement status update ("currently in procurement"), no award yet → must return None | backgroundfile-230442 |
+| ep_non_award_collective_agreement.txt | NEGATIVE: SYNTHETIC refusal regression test for non-procurement guard; collective-agreement/labour-relations report wrongly kept without guard (the live run found 23 such reports) | test fixture (#130) |
 
 EP award clause shape: "award of Contract No. <c> (RFT No. EP###-YYYY) to WINNER for the
 <project> in the amount of $AMOUNT" — text sits between WINNER and the amount phrase, so the

--- a/scrapers/tests/fixtures/agencies/SOURCES.md
+++ b/scrapers/tests/fixtures/agencies/SOURCES.md
@@ -60,3 +60,22 @@ fixture matches the field names documented in the portal's grid JS
 Addendums, PlanTakers) and exercises parse_listing's mapping mechanics only. `parse_listing`
 is PROVISIONAL until `tb enrich-agencies --portal --record` captures a real record and replaces
 this fixture (#135 deferred item).
+
+## Exhibition Place board-report fixtures (#130)
+
+Real EP Board of Governors reports, captured live 2026-07-18 from legdocs (plain HTTP;
+discovered via the TMMIS EP committee, `YYYY.EP<n>.<n>`). EP's board handles far more than
+procurement, so most reports are NOT awards — the negatives below are load-bearing (they carry
+`$` amounts that must NOT be read as awards).
+
+| fixture | shape | source |
+|---|---|---|
+| ep_award_with_table_2023.txt | AWARD + Table 1 bid prices (Powell Fence, M.J.K., Clearway); RFT No. EP110-2023 | /legdocs/mmis/2023/ep/bgrd/backgroundfile-240943.pdf |
+| ep_confidential_decision_2025.txt | confidential award, winner named (Coca-Cola Canada Bottling Ltd), value withheld | /legdocs/mmis/2025/ex/bgrd/backgroundfile-258727.pdf |
+| ep_confidential_agreement.txt | confidential agreement, counterparty redacted ("a Consumer Show Client") → winner None | 2022-2026 EP term, backgroundfile-230177 |
+| ep_non_award_wsib_report.txt | NEGATIVE: WSIB lost-time-injury safety report; carries `$` (WSIB costs) but no award → must return None | backgroundfile-230165 |
+| ep_non_award_procurement_status.txt | NEGATIVE: procurement status update ("currently in procurement"), no award yet → must return None | backgroundfile-230442 |
+
+EP award clause shape: "award of Contract No. <c> (RFT No. EP###-YYYY) to WINNER for the
+<project> in the amount of $AMOUNT" — text sits between WINNER and the amount phrase, so the
+winner regex is EP-specific (stops at " for "/amount), not the shared Zoo "to WINNER <phrase> $".

--- a/scrapers/tests/fixtures/agencies/ep_award_2019_multi_bidder.txt
+++ b/scrapers/tests/fixtures/agencies/ep_award_2019_multi_bidder.txt
@@ -1,0 +1,162 @@
+                                                                                     EP6.9
+                                     REPORT FOR ACTION
+
+
+Food Building Electrical Bus Duct Replacement
+
+Date: September 5, 2019
+To: The Board of Governors of Exhibition Place
+From: Don Boyle - Chief Executive Officer
+Wards: All
+
+
+SUMMARY
+
+This report recommends approving a contract with Sutherland-Schultz Ltd. for
+replacement of the electrical bus duct at the Food Building. The tender call was issued
+on August 02, 2019, through the City of Toronto Purchasing and Material Management
+Division and the recommendation is to award the contract to the lowest bidder meeting
+specifications within the available budget.
+
+RECOMMENDATIONS
+
+The Chief Executive Officer recommends that:
+
+1. The Board of Governors approve the award of Contract No. 19-081-98116 to
+Sutherland-Schultz Ltd. of Cambridge, Ontario for replacement of the electrical bus duct
+at the Food Building in the amount of $403,854.47, which includes a reduced
+contingency allowance of $10,000.00 but excludes HST; this being the lowest
+acceptable tender received following the public tendering of the project through the City
+Toronto's Purchasing and Material Management Division.
+
+FINANCIAL IMPACT
+
+The financing for this project is included within the approved Exhibition Place Capital
+Works Program 2019.
+
+DECISION HISTORY
+
+The Exhibition Place 2017 – 2019 Strategic Plan has a Public Space and Infrastructure
+Goal to ensure that our State-of-Good Repair plan and processes are adequately linked
+to our capital plan and as a Strategy to support this Goal maintain and improve our
+event space.
+
+
+
+[Food Building. Bus Duct]                                                        Page 1 of 4
+At its meeting of July 19, 2018, the Board approved the 2019 Capital Works Program.
+The amended version of the budget was approved and adopted by City Council at its
+meeting on March 07, 2019.
+
+http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2018.EP13.2
+http://www.toronto.ca/legdocs/mmis/2018/ep/bgrd/backgroundfile-118494.pdf
+http://www.toronto.ca/legdocs/mmis/2018/ep/bgrd/backgroundfile-118495.pdf
+https://eportal.toronto.ca/f5-w-
+687474703a2f2f6170702e746f726f6e746f2e6361$$/tmmis/viewAgendaItemHistory.do?i
+tem=2019.EX2.5
+
+COMMENTS
+
+Background
+
+The Food Building is the main building for food services of the CNE. There are over
+100 booths inside the Food Building servicing different types of food during each year of
+the CNE. Over one million people (two thirds of the average 1.5 million visitors to the
+CNE) visit the Food Building. Maintaining the power supply to these booths from the
+electrical "Bus Duct" system is a necessity for the operation.
+
+The electrical power supply, “Bus Duct”, acts as a backbone to the electrical service and
+allows services to be conveniently changed as different show configurations are
+introduced each year. This bus duct is only accessible by heavy-duty electrical fixtures
+(plugs), which grip onto the current cooper rail. The advantage of the bus duct system
+is its operational flexibility, ease of power delivery and speedy reconfiguration from one
+layout to another.
+
+The current bus duct system, is over 60 years old and in desperate need for
+replacement. Replacement parts are difficult to source making it uneconomical to
+provide power services to clients'. Therefore, with the agreement of the CNEA, this
+project is to replace 325 feet of "Bus Duct" (21%) of the total 1,550 feet of "Bus Duct" in
+the Food Building : 1) a section of the east main bus duct feeder (1600 Amp, 120/208
+Volt, 3 Phase) with new (2000 Amp, 120/208 Volt, 3 Phase) bus duct; and 2) the north-
+east branch (600 Amp, 120/208 Volt, 3 Phase) with new (1000 Amp, 120/208 Volt, 3
+Phase) together with all associated fused bus plugs. The work also includes
+switchboard breaker modifications, disconnect switch bus plugs, mounting accessories,
+wiring, conduits and removals. Future "Bus Duct" replacement will be co-ordinated
+through agreement with the CNEA.
+
+The 2017 Lease between the CNEA and the Board provides that the parties will
+establish a capital program for the Food Building and jointly fund (50% each) proposed /
+approved projects. This is the first project to be proposed under the terms of the Lease.
+
+Tender Process
+The tender for this contract was issued on August 02, 2019 through the City of Toronto
+Purchasing and Material Management Division and Mr. Hardat Persaud, CFO and
+Corporate Secretary of the Board, supervised the tender opening on August 26, 2019.
+[Food Building. Bus Duct]                                                        Page 2 of 4
+Five (5) bidders came to the mandatory site tour meeting and five (5) official tenders
+were received. Their price submissions, excluding HST, are as shown in the following
+table:
+
+Table 1: Tender Price Submissions and the Recommended Contract
+
+                                                 Tender Price          Recommended
+ Tenderer
+                                                 Received              Contract Price
+ Sutherland-Schultz Ltd.                         $418,854.47           $403,854.47
+ Ontario Electrical Construction Co. Ltd.        $461,522.00
+ Modern Niagara Toronto Inc.                     $470,700.00*
+ Stevens & Black Electrical Contractors Ltd.     $518,000.00
+ Rogol Electric Company Limited                  $546,350.00
+* Identifies revised tender price after correcting the mathematical/transposing error(s);
+
+The construction budget for this project is under the sub-account of #081-98116 – Food
+Building Bus Duct Replacement with a construction budget of $405,000; a shortfall of
+$13,854. There is a standard contingency allowance of $25,000 included in the
+submission. It is recommended that this original allowance be reduced to $10,000 to
+accommodate the shortfall. Thus, the recommended contract price would be
+$403,854.47.
+
+Sutherland-Schultz Ltd. is a professional construction and industrial services provider
+based in Cambridge, Ontario for many years. Its average value of work for the last five
+years has been approximately $45 million annually. Three major power projects
+completed by Sutherland-Schultz Ltd. over the last few years were the waste water
+treatment plants in the GTA valued in the average of $16 million. Other project
+experiences include: University of Guelph Replacement of 13.8KV Switchgear; Honda
+Canada Plant 3 Engine Plant – Bus Duct Distribution in new facility; and BASF Replace
+Main Service – Refeed existing 800 A bus duct. Based on the above, Sutherland-
+Schultz appears to have the experience required to complete this relatively small project
+when compared to their recent completed projects.
+
+This recommendation is contingent upon approval by the Office of the City CFO of the
+Surety Company proposed by the successful bidder for the supply of the bonding
+requirements and is also subject to the Fair Wage Office confirming that the
+recommended contractor and its subcontractors maintain wage rates and working
+conditions in accordance with Toronto Workers’ Rights requirements.
+
+CONTACT
+
+Danny Chui, Manager, Capital Works, 416-263-3670, dchui@explace.on.ca
+
+
+
+
+[Food Building. Bus Duct]                                                        Page 3 of 4
+Mark Goss, General Manager, Operations Department, 416-263-3660,
+mgoss@explace.on.ca
+
+SIGNATURE
+
+
+
+
+Don Boyle
+Chief Executive Officer
+
+
+ATTACHMENTS
+
+
+
+
+[Food Building. Bus Duct]                                          Page 4 of 4
+

--- a/scrapers/tests/fixtures/agencies/ep_award_2019_sole_tender.txt
+++ b/scrapers/tests/fixtures/agencies/ep_award_2019_sole_tender.txt
@@ -1,0 +1,154 @@
+                                                                           EP2.17
+                                     REPORT FOR ACTION
+
+
+Beanfield Centre AV System Upgrade
+
+Date: March 27, 2019
+To: The Board of Governors of Exhibition Place
+From: Chief Executive Officer
+Wards: All
+
+
+SUMMARY
+
+This report recommends approving a contract with Westbury National Show System
+Ltd. for Beanfield Centre AV system upgrade. The tender call for this contract was
+issued on February 20, 2019 through the City of Toronto Purchasing and Material
+Management Division and the recommendation is to award the contract to the sole
+bidder meeting specifications within the available budget.
+
+
+RECOMMENDATIONS
+
+The Chief Executive Officer recommends that:
+
+1. The Board approve the award of Contract No. 19-085-98518 to Westbury National
+Show System Ltd. for Beanfield Centre AV system upgrade in the amount of
+$969,415.00, which includes a contingency allowance of $30,000.00, but excludes HST;
+this being the sole acceptable tender received following the public tendering of the
+project through the City of Toronto's Purchasing and Material Management Division.
+
+
+FINANCIAL IMPACT
+
+The financing for this project is included within the approved Exhibition Place Operating
+Budget for 2019.
+
+
+DECISION HISTORY
+
+The Exhibition Place 2017 – 2019 Strategic Plan has a Public Space and Infrastructure
+Goal to ensure that our State-of-Good Repair plan and processes are adequately linked
+to our capital plan and as a Strategy to support this Goal maintain and improve our
+event space.
+
+Beanfield Centre AV System Upgrade                                              Page 1 of 4
+At its meeting of July 19, 2018, the Board approved the 2019 Operating Budget. The
+amended version of the budget was approved and adopted by City Council at its
+meeting on March 7, 2019.
+http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2018.EP13.3
+http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2019.EX2.5
+
+
+COMMENTS
+
+Background
+
+The exterior and interior of Beanfield Centre was fully renovated from the Automotive
+Building exhibit space to a Class A conference centre in 2008 to 2009 at a cost of
+approximately $52.0M adding ball rooms and meeting rooms facilities. The 20 meeting
+rooms, all on the second floor, were originally fitted the latest audio video (AV) system
+circa 2008. This AV system has now reached its anticipated usefulness functional
+lifespan; does not meet technological advances now required by our clients'; and are
+also failing with no ability to replace parts. Upgrading the current AV system is
+necessary to maintain the facility as a first class venue for conferences and meetings
+and to attract major functions and corporate clients. An upgraded AV system will
+incorporate new technology and will be designed to meet or exceed client expectations
+for a venue of this caliber.
+
+The upgrade scope of work includes upgrades to the following equipment:
+
+•   Reconfiguration of AV racks (with new and some existing equipment)
+•   Digital HD-Base-T video distribution system
+•   Projection systems (employing current aspect ratios & resolution)
+•   Control system, touch panels and programming
+•   DSP employing Dante protocol and Dante endpoints and programming
+•   Podium/presentation lighting
+•   Central video matrix over fibre;
+•   Systems to support room combining of adjacent rooms as well as non-adjacent
+    rooms
+•   Integration with existing building PA system
+
+Tender Process
+
+The tender for this contract was issued on February 20, 2019 through the City of
+Toronto Purchasing and Material Management Division and Mr. Hardat Persaud, Chief
+Financial Officer and Corporate Secretary of the Board, supervised the tender opening
+on March 15, 2019. Three (3) bidders came to the mandatory site tour meeting and one
+(1) official tender was received. The price submission, excluding HST, is as shown in
+the following table:
+
+Table 1: Tender Price Submissions and Recommended Contract
+
+
+Beanfield Centre AV System Upgrade                                              Page 2 of 4
+                                             Tender Price          Recommended
+  Tenderer
+                                             Received              Contract Price
+  Westbury National Show System Ltd.         $1,139,944.00         $969,415
+
+The construction budget for this project is under the Operating Budget Special
+Equipment Appropriations (50-308-63010) with a construction budget of $970,000.
+
+The original submission of the sole tender by Westbury National at $1,139,944 which
+includes a contingency allowance of $30,000, has therefore exceeded this construction
+budget. In the tender documents, there were several identified items listed under
+Appendix III that are subject to be deleted if submission is over budget. Based on the
+evaluation, three items can be removed from this contract and added back in the future
+without significantly compromising the integrity of the project at this time. These are
+Wireless Presentation Gateways ($30,098), Back-up Hard Wired Presentation System
+($39,758) and Presentation Lighting System ($100,673). With these reduction, the
+value of the contract is reduced to $969,415, which is within the budget. The
+consultant, Novita Techne Ltd and Exhibition Place staff concur with the deletions and
+recommend the project at the contract price.
+
+Westbury National has been in operation for 45 years and has extensive experience
+with corporate installations including design and implementation of systems for
+enterprise, healthcare, education, government, gaming, sports, entertainment and
+worship. The company has offices in Toronto and Ottawa. Clients include the Toronto
+International Film Festival, Yonge-Dundas Square, the Royal Ontario Museum and the
+Aga Khan Museum. Westbury did the original AV install within the Beanfield Centre in
+2009
+
+This recommendation is contingent upon approval by the Office of the City CFO of the
+Surety Company proposed by the successful bidder for the supply of the bonding
+requirements and is also subject to the Fair Wage Office confirming that the
+recommended contractor and its subcontractors maintain wage rates and working
+conditions in accordance with Toronto Workers’ Rights requirements.
+
+CONTACT
+
+Ron Mills, Director, Facility Services, 416-263-3044, rmills@explace.on.ca
+
+Laura Purdy, General Manager, Sales and Event Management, 416-263-3020,
+lpurdy@explace.on.ca
+
+
+SIGNATURE
+
+
+
+
+Beanfield Centre AV System Upgrade                                            Page 3 of 4
+Dianne Young
+Chief Executive Officer
+
+
+ATTACHMENTS
+
+
+
+
+Beanfield Centre AV System Upgrade   Page 4 of 4
+

--- a/scrapers/tests/fixtures/agencies/ep_award_with_table_2023.txt
+++ b/scrapers/tests/fixtures/agencies/ep_award_with_table_2023.txt
@@ -1,0 +1,126 @@
+                                         REPORT FOR ACTION
+
+
+Replacement of Perimeter Fence at Exhibition Place
+Date: November 20, 2023
+To: The Board of Governors of Exhibition Place
+From: Don Boyle, Chief Executive Officer
+Wards: Ward 10 - Spadina Fort York
+
+
+SUMMARY
+
+This report recommends approving a contract with Powell Fence Limited ("Powell") for
+the replacement of Perimeter Fence at Exhibition Place. A tender call was issued on
+August 24, 2023 through Exhibition Place Purchasing and Materials Stores via Bonfire
+Online Procurement System and the recommendation is to award the contract to the
+lowest compliant bidder meeting tender requirements and specifications within the
+available budget.
+
+The fence along Lakeshore Boulevard West is between 35 and 40 years old and require
+extensive ongoing service and repair, posing a possible risk to security and public
+safety.
+
+
+RECOMMENDATIONS
+
+The Chief Executive Officer recommends that:
+
+1. The Board approve the award of Contract No. 23-079-37912 (RFT No. EP110-2023)
+to Powell Fence Limited for the Replacement of Perimeter Fence at Exhibition Place in
+the amount of $1,484,065.00 which includes a cash allowance of $107,500.00 but
+excludes HST; this being the lowest acceptable tender submission received following
+the public tendering of the project.
+
+
+FINANCIAL IMPACT
+
+The financing for this project is included within the Exhibition Place 2023-2024 Capital
+Works Budget State of Good Repair Program.
+
+
+
+
+Replacement of Perimeter Fence at Exhibition Place                              Page 1 of 3
+DECISION HISTORY
+
+The Exhibition Place 2022-2026 Strategic Plan has identified Protecting and
+Spotlighting our Assets Goal to ensure that our State-of-Good Repair plan and
+processes are adequately linked to our capital plan.
+
+At its meeting of September 14, 2022, the Board approved the 2023 Capital Works
+Program budget. An amended version of this budget was subsequently adopted by City
+Council at its meeting on February 15, 2023.
+https://secure.toronto.ca/council/agenda-item.do?item=2022.EP25.13
+
+
+COMMENTS
+
+Background
+
+The existing perimeter chain link fence along Lakeshore Boulevard is between 35 to 40
+Years old and requires replacement. The total length of the fence is approximately
+1,500 m or 1.5 km. Due to its age; some fence posts are corroded posing possible
+security and/or safety risks. For longevity, maintenance, and aesthetic purposes, the
+proposed new fence type is to be coated aluminum alloy with a flush concrete curb
+below to allow for a clean mowing strip and removes the need for string trimming. The
+design has also added concrete pavement in any areas that are not paved on the
+roadside of the fence between the flush curb and the edge of Lake Shore Boulevard
+(curb, wall, etc.), thus limiting the requirement for maintenance from the outside of the
+fence.
+
+Tender Process
+The tender for this contract was issued on August 24, 2023, through the Exhibition
+Place Purchasing & Materials Stores via Bonfire Online Procurement System and
+closed on September 26, 2023. Eight (8) bidders attended the mandatory site tour
+meeting, three (3) submissions were received, all of which were compliant with the
+tender requirements. The bidders' price submissions, excluding HST, are as shown in
+the following Table 1:
+
+Table 1: Tender Price Submission and the Recommended Contract
+                                           Base Bid Price Recommended
+       Bidder
+                                           Received       Contract Price
+       Powell Fence Limited                $1,484,065.00 $1,484,065.00
+        M.J.K. Construction Incorporated             $1,619,001.00
+        Clearway Construction Incorporated $1,851,100.00
+
+
+Staff have reviewed the bids and based on its safety record and experience with similar
+projects staff recommends award of the contract to the lowest compliant bidder, Powell
+
+
+Replacement of Perimeter Fence at Exhibition Place                              Page 2 of 3
+Fence Limited. The Exhibition Place project consultant has also reviewed the bid prices
+and has recommended to proceed with an award to Powell.
+
+Powell has over 38 full-time employees and has been providing fence installation
+services since 2020. They have completed several large-scale and time-sensitive fence
+replacement and noise wall projects in the past three years for clients such as the City
+of Oshawa, the Town of Caledon, and Halton Region. Powell Fence Limited meets or
+exceeds all tender requirements including those of qualification and experience.
+
+This recommendation is contingent upon approval by the Office of the City CFO &
+Treasurer, and of the Surety Company proposed by the successful bidder for the supply
+of the bonding requirements. It is also subject to the City Fair Wage Office confirming
+that the recommended contractor and its subcontractors maintain wage rates and
+working conditions in accordance with Toronto Workers’ Rights requirements.
+
+
+CONTACT
+
+Mark Goss, General Manager, Operations, 416-263-3660, mgoss@explace.on.ca
+
+Prashant Bhalja, Director, Capital Works, 416-263-3670, pbhalja@explace.on.ca
+
+
+SIGNATURE
+
+Don Boyle
+Chief Executive Officer
+
+
+
+
+Replacement of Perimeter Fence at Exhibition Place                             Page 3 of 3
+

--- a/scrapers/tests/fixtures/agencies/ep_confidential_agreement.txt
+++ b/scrapers/tests/fixtures/agencies/ep_confidential_agreement.txt
@@ -1,0 +1,88 @@
+                                             REPORT FOR ACTION WITH
+                                           CONFIDENTIAL ATTACHMENT
+
+
+Multi-year Agreement with a Consumer Show Client
+-C
+
+Date: November 29, 2022
+To: Board of Governors of Exhibition Place
+From: Don Boyle, Chief Executive Officer
+Wards: All
+
+
+REASON FOR CONFIDENTIAL INFORMATION
+
+This report contains financial information, supplied in confidence to the Board, which, if
+disclosed, could reasonably be expected to prejudice significantly the competitive
+position or interfere significantly with the contractual or other negotiations of a person,
+group of persons, or organization.
+
+
+SUMMARY
+
+This report recommends a multi-year agreement between a Consumer Show Client and
+Exhibition Place within Enercare Centre.
+
+
+RECOMMENDATIONS
+
+The Chief Executive Officer recommends that:
+
+1. The Board approve multi-year license agreements with the Consumer Show Client -
+C for Enercare Centre, as set out in Confidential Attachment 1, for a 3-year term
+commencing in each of 2023, 2024, and 2025 on the terms and conditions of the
+Licence Agreement, and such other terms and conditions satisfactory to the Chief
+Executive Officer and City Solicitor.
+
+2. The Board direct that the confidential information contained in Confidential
+Attachment 1 remain confidential as this report contains financial information, supplied
+in confidence to the Board, which, if disclosed, could reasonably be expected to
+prejudice significantly the competitive position or interfere significantly with the
+contractual or other negotiations of a person, group of persons, or organization.
+
+Multi-year Agreement with a Consumer Show Client - C                              Page 1 of 2
+FINANCIAL IMPACT
+
+The agreement recommended in this report provides financial revenues to the Board as
+set out in Confidential Attachment 1.
+
+
+DECISION HISTORY
+
+The Exhibition Place Strategic Plan continues to have a Business Development Goal to
+grow event activity especially at Enercare Centre and Beanfield Centre, and as a
+strategy to support this goal to maintain strong relationships with existing clients or
+events.
+
+
+COMMENTS
+
+The Consumer Show Client description is listed in Confidential Attachment 1.
+
+The details of the agreement between Exhibition Place and the Consumer Show Client
+are provided in Confidential Attachment 1.
+
+
+CONTACT
+
+Laura Purdy, General Manager, 416-263-3020, LPurdy@explace.on.ca
+
+
+SIGNATURE
+
+
+
+Don Boyle
+Chief Executive Officer
+
+
+ATTACHMENTS
+
+Confidential Attachment 1 - Licence Agreement Terms and Conditions
+
+
+
+
+Multi-year Agreement with a Consumer Show Client - C                           Page 2 of 2
+

--- a/scrapers/tests/fixtures/agencies/ep_confidential_decision_2025.txt
+++ b/scrapers/tests/fixtures/agencies/ep_confidential_decision_2025.txt
@@ -1,0 +1,76 @@
+     TOROIID                             Decision Letter
+Exhibition Place
+Meeting No.: 18                                     Contact: Jennifer Lin, Committee Administrator
+Meeting Date: Monday, September 22, 2025            Phone: 416-397-4592
+Start Time: 9:30 AM                                 E-mail: epb@toronto.ca
+Location: Exhibition Place, Automotive Bldg,        Chair: Deputy Mayor Ausma Malik
+Room 204, 105 Princes' Blvd/Video Conference
+
+
+
+EP18.9 - Soft Drink Sponsorship Agreement - Coca-Cola Canada
+Decision Type: ACTION
+Status: Adopted
+Ward: 10 - Spadina - Fort York
+
+Confidential Attachment - The attachment to this report contains financial information that
+belongs to the Board of Governors of Exhibition Place and has monetary value or potential
+monetary value.
+
+Board Reccommendations
+The Board of Governors of Exhibition Place:
+
+1. Requests that City Council approve an agreement with Coca-Cola Canada Bottling Ltd ("Coke") for
+a period of five years, commencing on the date of approval of City Council, to be the official and
+exclusive soft drink provider to Exhibition Place, including Enercare Centre and Automotive Building,
+on the terms and conditions set out in the revised report (September 18, 2025) from the Chief
+Executive Officer, Exhibition Place and such other terms and conditions as may be satisfactory to the
+Chief Executive Officer, Exhibition Place, and the City Solicitor.
+
+2. Requests that City Council to direct that the confidential information contained in Confidential
+Attachment 1 to the revised report (September 18, 2025) from the Chief Executive Officer, Exhibition
+Place remain confidential and not be released publicly as it contains financial information that belongs
+to the Board of Governors of Exhibition Place and has monetary value or potential monetary value.
+
+Decision Advice and Other Information
+3. Directed the Chief Executive Officer, Exhibition Place, subject to Council approval, to enter into an
+agreement with Coca-Cola Canada Bottling Ltd ("Coke") for a period of five years, commencing on
+the date of approval of City Council, to be the official and exclusive soft drink provider to Exhibition
+Place, including Enercare Centre, and Automotive Building, on the terms and conditions set out in the
+revised report (September 18, 2025) and such other terms and conditions as may be satisfactory to
+the Chief Executive Officer, Exhibition Place and the City Solicitor.
+
+4. Directed that the confidential information contained in Confidential Attachment 1 to the revised
+report (September 18, 2025) from the Chief Executive Officer, Exhibition Place remain confidential
+and not be released publicly as it contains financial information that belongs to the Board of
+Governors of Exhibition Place and has monetary value or potential monetary value.
+
+Origin
+(September 18, 2025) Report from the Chief Executive Officer, Exhibition Place
+
+Summary
+At its meeting on September 22, 2025, the Board of Governors of Exhibition Place considered Item
+EP18.9 and made recommendations to City Council.
+
+Summary from the report (September 18, 2025) from the Chief Executive Officer, Exhibition
+Place
+This report recommends entering into a five-year agreement with Coca-Cola Canada Bottling Ltd.
+(Coke) to be the official and exclusive soft drink provider to Enercare Centre and the Automotive
+Building at Exhibition Place.
+
+Exhibition Place Purchasing staff, on behalf of the Finance, Event Services and Sales and Marketing
+Division, posted the Proposal Call Document #EXP2025-08 publicly on both Bonfire and Merx, and
+notified three (3) potential proponents on July 25, 2025, which closed August 18, 2025.
+
+This report recommends entering a five (5) year agreement with Coke.
+
+Background Information
+(September 18, 2025) Revised Report from the Chief Executive Officer, Exhibition Place on Soft
+Drink Sponsorship Agreement - Coca-Cola Canada
+(https://www.toronto.ca/legdocs/mmis/2025/ep/bgrd/backgroundfile-258606.pdf)
+Appendix A - Coca-Cola Sustainability Program
+(https://www.toronto.ca/legdocs/mmis/2025/ep/bgrd/backgroundfile-258321.pdf)
+Confidential Attachment 1 - Financial Implications and Terms
+(September 8, 2025) Report from the Chief Executive Officer, Exhibition Place on Soft Drink
+Sponsorship Agreement - Coca-Cola Canada
+

--- a/scrapers/tests/fixtures/agencies/ep_non_award_collective_agreement.txt
+++ b/scrapers/tests/fixtures/agencies/ep_non_award_collective_agreement.txt
@@ -1,0 +1,62 @@
+                                         REPORT FOR ACTION
+
+
+Renewal of Collective Agreement with LiUNA Local 506
+Exhibition Place Grounds Staff
+
+Date: March 15, 2024
+To: The Board of Governors of Exhibition Place
+From: Chief Executive Officer
+Wards: All
+
+
+SUMMARY
+
+This report seeks Board approval for the renewal of the collective agreement with LiUNA Local 506
+covering Exhibition Place grounds staff. The renewal follows completion of negotiations between
+Exhibition Place management and union representatives.
+
+RECOMMENDATION
+
+The Chief Executive Officer recommends that:
+
+1. The Board approve the renewal of the collective agreement with LiUNA Local 506 for the
+   Exhibition Place grounds staff for the period 2024-2027, on the terms set out in the
+   confidential attachment.
+
+2. The information regarding labour relations and employee negotiations remain confidential
+   as it relates to collective bargaining.
+
+
+FINANCIAL IMPACT
+
+CONFIDENTIAL ATTACHMENT
+
+The attachment to this report contains information pertaining to labour relations and employee
+negotiations that is subject to the Municipal Freedom of Information and Protection of Privacy Act
+(MFIPPA). Specifically, the information relates to collective agreement negotiations and labour
+relations with union representatives, the disclosure of which could reasonably be expected to
+prejudice the negotiating position of the Board of Governors of Exhibition Place.
+
+The attachment outlines the key terms of the renewal agreement, including compensation adjustments,
+benefits modifications, and working condition provisions that emerged from negotiations with LiUNA
+Local 506. These details are confidential as they pertain to labour relations and employee
+negotiations.
+
+
+CONTACT
+
+Margaret Chen, Human Resources Director, 416-263-3660, mchen@explace.on.ca
+
+
+SIGNATURE
+
+
+
+Don Boyle
+Chief Executive Officer
+
+
+ATTACHMENTS
+
+Confidential Attachment - Collective Agreement Terms 2024-2027

--- a/scrapers/tests/fixtures/agencies/ep_non_award_procurement_status.txt
+++ b/scrapers/tests/fixtures/agencies/ep_non_award_procurement_status.txt
@@ -1,0 +1,211 @@
+F.G. Gardiner Expressway Rehabilitation Project
+Dufferin Street to Strachan Avenue (Section 2)
+Board of Governors of Exhibition Place Meeting
+
+
+
+December 9, 2022
+  PROJECT OVERVIEW
+• The City of Toronto is proceeding with Section 2 of the F.G. Gardiner Expressway Strategic Rehabilitation Plan from Dufferin to
+  Strachan. The project includes replacement of the Superstructure (girders and deck) and rehabilitation of the Sub-structure
+  (bents).
+• Parsons Inc. (Parsons) is the City’s Owners Engineer & Technical Advisor.
+• The project is currently in procurement for a Design-Build contractor. Design-build is a project delivery and management
+  approach where the contractor takes on more responsibility for the design phase, as well as more overall accountability. This has
+  the potential for a smoother construction process.
+
+• Construction is anticipated to start in Q4
+  2023 and is expected to be completed by
+  2026.
+
+
+
+
+                                                                                                                                    2
+  PROJECT HISTORY
+• The F.G. Gardiner Expressway Strategic Rehabilitation Plan was developed by the City of Toronto in 2014 and sets
+  the framework for lifecycle renewal of the expressway from Highway 427 to the Don Valley Parkway (DVP).
+
+• In December 2016, Toronto City Council approved the Revised Strategic Rehabilitation Plan which includes the
+  use of innovative construction methods to reduce the time and impact of construction (e.g. Accelerated Bridge
+  Construction).
+• In June 2018, the City’s Public Works and Infrastructure Committee approved the contract award for the first
+  project of the rehabilitation plan (Section 1) from Jarvis Street to Cherry Street (now complete).
+
+
+
+
+                                                                                                                  3
+  PROJECT HISTORY
+• Section 1 of the Rehabilitation Project was recently completed from Jarvis to Cherry Street. Rehabilitation of this
+  section of the Gardiner will use a similar accelerated construction approach to the rehabilitation work completed
+  for Section 1.
+• An update was last provided to the Board on October 9, 2021. This presentation will provide an update on the
+  overall project status.
+
+                                                                                  Photo Showing Section 1 Rehabilitation from Jarvis to Cherry
+
+
+
+
+                                                                                                                             Photo Credit: City of Toronto
+
+
+
+
+                                                                                                                                                 4
+COORDINATION WITH MULTIPLE PARTIES
+
+
+
+                                                                                                              Limits of the Rehabilitation
+                                                                                         Exhibition Place     (West Abutment to Bent 35)
+                                                                                          Parking Areas
+                                                                                         Under Gardiner
+
+                                                                                   Coca-Cola
+                                                                                   Coliseum
+
+
+                                                                     TPS Mounted
+                                                                         Unit                               Enercare Centre
+
+
+                                             Food Building
+
+
+
+
+        Exhibition Place
+         Parking Areas
+
+
+
+                                                             BMO
+                                                             Field
+                           Queen Elizabeth
+                                Hall
+
+                                                                                                                                             Photo Credit: City of Toronto
+
+
+
+                                                                                                                                                                             5
+COMPONENTS AND APPROACH TO REHABILITATION
+• Work is expected to be       Reference Concept Design
+  completed in three key
+  phases based on a
+  Reference Concept
+  Design.
+• Initial works will include
+  rehabilitation of the
+  “bents”, followed by the
+  main superstructure                                     Superstructure
+
+  (deck).
+                                                           Replacement
+                                                            in Stages
+
+
+
+• The Design-Build                   Bent
+                                  Rehabilitation
+
+  contractor will complete a
+  detailed design to
+  determine the final design
+  details and sequencing of
+  construction.
+
+                                                               6
+CONSTRUCTION COORDINATION AT EXHIBITION PLACE
+• The area around the Gardiner Expressway
+  is home to Exhibition Place and is the
+  location of over 1200 annual events.
+• The City and Parsons continue to work
+  collaboratively with Exhibition Place staff
+  to assess event requirements and plan for
+  staging of the work, including for events
+  such as:
+    ▪ Honda Indy
+    ▪ Canadian National Exhibition (CNE)
+    ▪ Royal Agricultural Winter Fair
+    ▪ Sporting Events (BMO Field, Coca-Cola
+       Coliseum)
+    ▪ FIFA Soccer Tournament (in 2026)
+
+
+                                                Photo Credit: Exhibition Place
+
+                                                                       7
+CONSTRUCTION COORDINATION AT EXHIBITION PLACE
+• The project team is actively collaborating with the adjacent Metrolinx Ontario Line project to
+  coordinate staging of the two projects.
+
+
+
+
+                                                                                                             Limits of the Rehabilitation
+                                                                                                             (West Abutment to Bent 35)
+
+
+
+
+                                                      Photo Credit: City of Toronto | Metrolinx (ontario-line-subway-project-breaks-ground-at-exhibition-station-see-the-new-renderings-released)
+
+
+
+                                                                                                                                                                                                8
+ CONSTRUCTION COORDINATION AT EXHIBITION PLACE
+• Lots 857, 858 and a portion of 854 will be utilized for staging (laydown areas) during construction
+  activities.
+• Pedestrian access at the Exhibition GO station will be maintained during construction with extra space
+  provided under the Gardiner during major events.
+
+                                             Exhibition GO Station
+                                                Access Routes
+
+
+
+
+                                                                                                        9
+ CONSTRUCTION COORDINATION AT EXHIBITION PLACE
+• When structural works are underway at the TTC Exhibition Loop for a limited durations, shuttle bus
+  services will operate within the TTC Exhibition Loop to continue providing access to the existing station.
+
+
+
+
+                                                                 Shuttle
+                                                                  Bus
+                                                                 Route
+
+
+
+
+                                                                           Exhibition TTC Loop
+                                                     Existing
+                                                     Streetcar
+                                                      Route
+
+
+
+
+                                                                                                        10
+NEXT STEPS
+• Continue to coordinate with Exhibition Place prior to and during construction,
+  including with adjacent projects such as the Metrolinx Ontario Line.
+• Procurement of a “Design-Build” Contractor.
+   ▪ An RFP was posted to pre-qualified proponents in October 2022; Bidders have approximately
+     8 months to submit their detailed proposal.
+   ▪ Proposals will then be evaluated by the City’s Procurement and ECS departments for the best
+     solution, based on several criteria, such as the proposed design details and construction
+     approach.
+• Undertake broader outreach to the Exhibition Place community and general
+  public in 2023 prior to construction.
+• Proceed to construction, anticipated to start in Q4 2023 and is expected to be
+  completed by 2026.
+
+
+                                                                                                   11
+

--- a/scrapers/tests/fixtures/agencies/ep_non_award_wsib_report.txt
+++ b/scrapers/tests/fixtures/agencies/ep_non_award_wsib_report.txt
@@ -1,0 +1,262 @@
+                                         REPORT FOR ACTION
+
+
+Occupational Health and Safety Report - 3rd Quarter
+September 2022
+
+Date: November 24, 2022
+To: The Board of Governors of Exhibition Place
+From: Don Boyle, Chief Executive Office
+Wards: All
+
+
+SUMMARY
+
+This report provides information on the status of the Exhibition Place health and safety
+system, specifically on activities, priorities and performance during the third quarter of
+2022.
+
+There was 1 lost time injury and 2 medical aid injuries in the third quarter of 2022 which
+is an increase from 0 during the same period in 2021.
+
+Workplace Safety and Insurance Board (WSIB) invoiced costs for third quarter 2022
+were 17% higher than in third quarter 2021. An increase in Long Term Disability costs
+are attributable to the higher WSIB fees.
+
+
+RECOMMENDATIONS
+
+The Chief Executive Officer recommends that:
+
+1. The Board receive this report for information.
+
+
+FINANCIAL IMPACT
+
+There are no financial impacts to this report.
+
+
+DECISION HISTORY
+
+The Exhibition Place 2022 - 2026 Strategic Plan has a goal to Invest in our People and
+Culture to ensure our staff have a safe and respectful workplace through providing
+employees with the tools and training they require to deliver on commitments.
+Occupational Health & Safety Report - 3rd Quarter September 2022                  Page 1 of 6
+COMMENTS
+
+Pursuant to the Occupational Health & Safety Act, section 25(1) and 26(1), the Board as
+the employer is responsible for taking every precaution reasonable for the safety of the
+workers. Also, as a local board of a municipality, the Board is a Schedule II employer for
+the purposes of workers compensation.
+Injury and Accident Statistics
+Number of Lost Time Injuries, Recurrences, and Medical Aids
+Information on reported YTD third quarter 2022 WSIB incidents (work-related
+injuries/illnesses) by service area is attached in Appendix A. Information is also
+provided for the years 2018 to 2022. This information includes:
+
+•   Number of lost time injuries: injuries/illnesses in which lost time was approved by the
+    WSIB or is awaiting WSIB adjudication, as the employee has lost time from work as
+    a result of a reported workplace injury;
+•   Number of recurrences: injuries/illnesses that were approved by the WSIB or are
+    awaiting WSIB adjudication, as the employee has lost time as a result of a
+    previously reported workplace injury/illness. No new incident has taken place; and
+•   Number of medical aids: injuries/illnesses in which health care only was approved by
+    the WSIB or is awaiting WSIB adjudication, as the employee has either sought
+    medical aid but not lost time from work as a result of a reported workplace injury or
+    lost time has not been approved by the WSIB.
+
+There was 1 lost time injury in Q3 2022 (which was an increase from Q3 2021).
+Recurrences
+There were 0 recurrences in Q3 2022 (which was the same as Q3 2021).
+
+Lost Time Injury (LTI) Frequency
+LTI frequency represents the number of LTI events (lost time approved by the WSIB or
+pending WSIB adjudication decision) per 200,000 hours worked (100 employee-years).
+The trend in the Exhibition Place’s LTI frequency during 2022 relative to the frequency
+during the years 2018 to 2022 is provided in Figure 1 below. Exhibition Place’s third
+quarter 2022 LTI frequency of 1.03 is higher than the same period in 2021 (YTD).
+Frequency rates for service areas are reported in Appendix B.
+
+
+
+
+Occupational Health & Safety Report - 3rd Quarter September 2022                 Page 2 of 6
+Figure 1 - Lost Time Injury Frequency from 2018 to third quarter 2022
+
+                   8
+                   7
+                   6
+  Frequency Rate
+
+
+
+                   5
+                   4
+                   3
+                   2
+                   1
+                   0
+                       2018      2019              2020            2021          2022
+                                                   Year
+
+
+
+Injury Severity Rate
+The injury severity rate is a standardized statistic that enables comparison, year-over-
+year, of the number of days lost relative to hours worked. Figure 2 below shows
+Exhibition Place’s severity rate during third quarter 2022 relative to the severity for the
+years 2018 to 2022. Exhibition Place’s third quarter 2022 injury severity rate 1.29 is
+higher than the same period in 2021 (YTD).
+
+Figure 2 - Injury Severity from 2018 to third quarter 2022
+
+                   8
+
+                   7
+
+                   6
+
+                   5
+  Severity Rate
+
+
+
+
+                   4
+
+                   3
+
+                   2
+
+                   1
+
+                   0
+                       2018      2019             2020             2021         2022
+                                                  Year
+
+
+
+The severity number represents the number of days lost per 100 employees in the year.
+Improvements are a reflection of reduced injury severity and effectiveness of return-to-
+work efforts.
+
+
+
+
+Occupational Health & Safety Report - 3rd Quarter September 2022                   Page 3 of 6
+Injury and Accident Costs
+Overall costs incurred up to and including the third quarter 2022 are reported in Table 1
+below.
+
+Table 1 - WSIB Costs for period from 2018 to YTD (up to third quarter) 2022
+
+ 2018               2019               2020               2021          2022
+
+ $138,037.88        $123,973.27        $129,721.91        $164,014.78   $65,634.72
+
+WSIB invoiced costs for third quarter 2022 were 17% higher than in third quarter 2021.
+Invoiced costs by service area for the period 2018 to YTD 2022 are reported in
+Appendix C.
+
+WSIB invoiced costs by service area for third quarter 2022 are summarized in Figure 3.
+
+Figure 3 - Third Quarter 2022 WSIB Costs by Service Area
+
+
+
+
+                                                                         Electrical
+                                                                         IATSE
+                                                                         Labourers
+                                                                         Long Term Disability
+                                                                         Security
+
+
+
+
+Critical Injuries
+Occupational health and safety legislation stipulates requirements for reporting fatalities
+and critical injuries to the Ministry of Labour (MOL). A critical injury is an injury of a
+serious nature that:
+• places life in jeopardy,
+• produces unconsciousness,
+• results in substantial loss of blood,
+• involves the fracture of a leg or arm but not a finger or toe,
+• involves the amputation of a leg, arm, hand, or foot but not a finger or toe,
+• consists of burns to a major portion of the body, or
+• causes the loss of sight in an eye.
+
+There were no work-related critical injuries reported to the MOL during third quarter
+2022.
+
+Occupational Health & Safety Report - 3rd Quarter September 2022                      Page 4 of 6
+MOL Orders/Visits without Orders
+The MOL issued no orders to Exhibition Place during third quarter 2022.
+
+MOL visits that do not result in orders are also tracked. Reports on the issues
+addressed during these visits and any recommendations or comments received are
+reviewed by the Joint Occupational Health & Safety Committee (JHSC). It is intended
+that this information will inform the JHSC regarding the MOL’s priorities and expected
+employer responses to these priority issues.
+
+There were no MOL visits to Exhibition Place during the third quarter.
+
+Key Exhibition Place Health & Safety Initiatives
+Some key health and safety initiatives for 2022 will include:
+• E-learning modules for GHS/WHMIS 2015, Fire Safety and other health & safety
+  related training
+• Working from Heights Training
+• Elevated Work Platform Training
+• Continuation of Safety Awareness Training Program
+
+Continuous Improvement - Maintaining Zero Lost Time Injuries
+There has been a slight increase (n=2) in lost time injuries due to workplace incidents
+between 2018 and 2022. This demonstrates the success of the continuous
+improvement joint efforts of employees, union representatives, supervisors, and
+managers. Table 2 provides a summary of key performance indicators comparing 2018
+to Q3 2022 (YTD).
+
+Table 2 - Continuous Improvement Progress of all Indicators 2018 to third quarter 2022
+
+
+              Performance Indicator             2018         2022 (3rd QTR YTD)
+
+             Lost Time Injuries (LTIs)                   0                    2
+
+             Medical Aids                              14                     7
+
+             Frequency                                   0                    0
+
+             Severity                                    0                    0
+
+             WSIB Costs                     $138,037.88              $65,634.72
+
+
+
+
+Occupational Health & Safety Report - 3rd Quarter September 2022                  Page 5 of 6
+CONTACT
+
+Mark Goss, General Manager/Operations, 416-263-3660, mgoss@explace.on.ca
+
+
+SIGNATURE
+
+
+
+
+Don Boyle
+Chief Executive Officer
+
+
+ATTACHMENTS
+
+Appendix A - WSIB Incidents by Service Area
+Appendix B - LTI Frequency by Service Area
+Appendix C - WSIB Invoiced Costs (2018 - 2022 Third Quarter)
+
+
+
+
+Occupational Health & Safety Report - 3rd Quarter September 2022      Page 6 of 6
+

--- a/scrapers/tests/test_agencies.py
+++ b/scrapers/tests/test_agencies.py
@@ -18,7 +18,7 @@ def conn():
 
 def test_seed_buyers_is_idempotent(conn):
     ids = seed_buyers(conn)
-    assert set(ids) == {"toronto-zoo", "trca"}
+    assert set(ids) == {"toronto-zoo", "trca", "exhibition-place"}
     again = seed_buyers(conn)
     assert ids == again
     assert conn.execute("SELECT COUNT(*) FROM buyer").fetchone()[0] == len(DEFAULT_BUYERS)
@@ -133,7 +133,7 @@ def test_export_buyers_section(conn):
         overwrite=True)
     doc = build_export_document(conn, generated_at="2026-07-18T00:00:00+00:00")
     buyers = {b["slug"]: b for b in doc["buyers"]}
-    assert set(buyers) == {"toronto-zoo", "trca"}
+    assert set(buyers) == {"toronto-zoo", "trca", "exhibition-place"}
     assert buyers["trca"]["partnered"] == 1        # consumers can segment
     assert buyers["trca"]["awards"][0]["native_ref"] == "10039751"
     assert buyers["toronto-zoo"]["awards"] == []

--- a/scrapers/tests/test_agency_report.py
+++ b/scrapers/tests/test_agency_report.py
@@ -1,0 +1,21 @@
+import re
+
+from toronto_bids.sources.agency_report import (
+    AMOUNT_RE, CONFIDENTIAL_RE, amount_or_none,
+)
+
+
+def test_amount_re_reads_in_the_amount_of():
+    m = AMOUNT_RE.search("awarded in the amount of $410,563.00 to the firm")
+    assert m and m.group(1) == "$410,563.00"
+
+
+def test_amount_or_none_refuses_european_million_shorthand():
+    # "$1,25 million" captures only "$1" under thousands-grouping — refuse it.
+    m = AMOUNT_RE.search("in the amount of $1,25 million")
+    assert amount_or_none("in the amount of $1,25 million", m) is None
+
+
+def test_confidential_re_detects_attachment():
+    assert CONFIDENTIAL_RE.search("This report has a CONFIDENTIAL ATTACHMENT with value")
+    assert not CONFIDENTIAL_RE.search("no such thing here")

--- a/scrapers/tests/test_ep_reports.py
+++ b/scrapers/tests/test_ep_reports.py
@@ -1,0 +1,34 @@
+from toronto_bids.sources.bid_award_panel import discover_meetings
+from toronto_bids.sources.ep_board import EP_TERM_STARTS
+
+
+def test_ep_terms_probe_the_ep_committee_series():
+    calls = []
+
+    def fetch(ref):
+        calls.append(ref)
+        return "The published report was not found"     # every probe misses
+
+    found = discover_meetings(fetch, term_starts=[("EP", 2023, "2022-2026", 1)],
+                              stop_after_misses=2)
+    assert found == {}
+    assert calls[0] == "2023.EP1"                        # probes EP, not ZB/BA
+
+
+def test_ep_terms_cover_the_confirmed_terms():
+    series = {t[0] for t in EP_TERM_STARTS}
+    years = {t[1] for t in EP_TERM_STARTS}
+    assert series == {"EP"}
+    assert 2023 in years                                 # 2022-2026 term (2025.EP18 seen live)
+
+
+def test_ep_buyer_seeded():
+    import sqlite3
+    from toronto_bids.buyers import seed_buyers
+    from toronto_bids.store import db
+    conn = db.connect(":memory:"); db.init_db(conn)
+    ids = seed_buyers(conn)
+    assert "exhibition-place" in ids
+    row = conn.execute("SELECT kind, partnered FROM buyer WHERE slug='exhibition-place'").fetchone()
+    assert row["kind"] == "agency" and row["partnered"] == 0
+    conn.close()

--- a/scrapers/tests/test_ep_reports.py
+++ b/scrapers/tests/test_ep_reports.py
@@ -36,7 +36,7 @@ def test_ep_buyer_seeded():
 
 import pathlib
 
-from toronto_bids.sources.ep_board import parse_ep_report
+from toronto_bids.sources.ep_board import parse_ep_bid_table, parse_ep_report
 
 FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "agencies"
 
@@ -96,3 +96,30 @@ def test_wsib_safety_report_is_refused_despite_dollar_amounts():
 
 def test_procurement_status_update_is_refused():
     assert parse_ep_report(_read("ep_non_award_procurement_status.txt"), fallback_ref="2023.EP1.5") is None
+
+
+def test_bid_table_extracts_all_three_bidders_with_prices():
+    rows = parse_ep_bid_table(_read("ep_award_with_table_2023.txt"))
+    assert rows == [
+        ("Powell Fence Limited", "$1,484,065.00"),
+        ("M.J.K. Construction Incorporated", "$1,619,001.00"),
+        ("Clearway Construction Incorporated", "$1,851,100.00"),
+    ]
+
+
+def test_bid_table_2019_five_bidders_with_footnote_marker():
+    # 2019 "Table 1: Tender Price Submissions" (plural), 5 bidders, a `*` revised-price marker on
+    # one row — the price capture must stop before the `*`.
+    rows = parse_ep_bid_table(_read("ep_award_2019_multi_bidder.txt"))
+    assert rows == [
+        ("Sutherland-Schultz Ltd.", "$418,854.47"),
+        ("Ontario Electrical Construction Co. Ltd.", "$461,522.00"),
+        ("Modern Niagara Toronto Inc.", "$470,700.00"),      # the trailing * is dropped
+        ("Stevens & Black Electrical Contractors Ltd.", "$518,000.00"),
+        ("Rogol Electric Company Limited", "$546,350.00"),
+    ]
+
+
+def test_bid_table_absent_returns_empty():
+    rows = parse_ep_bid_table(_read("ep_non_award_wsib_report.txt"))
+    assert rows == []                                    # no Table 1 -> no bids

--- a/scrapers/tests/test_ep_reports.py
+++ b/scrapers/tests/test_ep_reports.py
@@ -32,3 +32,67 @@ def test_ep_buyer_seeded():
     row = conn.execute("SELECT kind, partnered FROM buyer WHERE slug='exhibition-place'").fetchone()
     assert row["kind"] == "agency" and row["partnered"] == 0
     conn.close()
+
+
+import pathlib
+
+from toronto_bids.sources.ep_board import parse_ep_report
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "agencies"
+
+
+def _read(name):
+    return (FIXTURES / name).read_text()
+
+
+def test_competitive_award_winner_ref_amount():
+    got = parse_ep_report(_read("ep_award_with_table_2023.txt"), fallback_ref="2023.EP1.1")
+    assert got is not None
+    assert got["native_ref"] == "EP110-2023"            # RFT No., not the Contract No.
+    assert got["winner"] == "Powell Fence Limited"       # stops at " for ", not the project text
+    from toronto_bids.amount import parse_amount
+    assert parse_amount(got["amount"]) == 1484065.00
+    assert got["confidential"] == 0
+
+
+def test_2019_award_line_wrapped_winner_and_contract_ref():
+    # 2019 EP reports differ (see SOURCES.md): the winner spans a pdftotext line break
+    # ("Westbury National\nShow System Ltd.") and the ref is a Contract No., not RFT-EP.
+    got = parse_ep_report(_read("ep_award_2019_sole_tender.txt"), fallback_ref="2019.EP2.1")
+    assert got is not None
+    assert got["winner"] == "Westbury National Show System Ltd."   # line-wrap collapsed, whole name
+    assert got["native_ref"] == "19-085-98518"          # Contract No. (no RFT-EP in 2019)
+    from toronto_bids.amount import parse_amount
+    assert parse_amount(got["amount"]) == 969415.00     # "in the amount of $969,415.00" (not the bid)
+
+
+def test_2019_award_strips_location_qualifier_from_winner():
+    # "to Sutherland-Schultz Ltd. of Cambridge, Ontario for …" — strip the " of <City>, <Prov>"
+    # qualifier so the firm keys consistently in the supplier dimension.
+    got = parse_ep_report(_read("ep_award_2019_multi_bidder.txt"), fallback_ref="2019.EP6.1")
+    assert got is not None
+    assert got["winner"] == "Sutherland-Schultz Ltd."   # NOT "... of Cambridge, Ontario"
+    from toronto_bids.amount import parse_amount
+    assert parse_amount(got["amount"]) == 403854.47
+
+
+def test_confidential_award_keeps_named_winner_nulls_amount():
+    got = parse_ep_report(_read("ep_confidential_decision_2025.txt"), fallback_ref="2025.EP18.9")
+    assert got is not None and got["confidential"] == 1
+    assert got["amount"] is None
+    assert "Coca-Cola" in got["winner"]
+
+
+def test_confidential_with_redacted_counterparty_has_no_winner_but_is_kept():
+    got = parse_ep_report(_read("ep_confidential_agreement.txt"), fallback_ref="2023.EP7.2")
+    assert got is not None and got["confidential"] == 1
+    assert got["winner"] is None                         # "a Consumer Show Client" is redacted, not a firm
+    assert got["native_ref"] == "2023.EP7.2"             # no RFT/Contract ref -> fallback
+
+
+def test_wsib_safety_report_is_refused_despite_dollar_amounts():
+    assert parse_ep_report(_read("ep_non_award_wsib_report.txt"), fallback_ref="2023.EP1.4") is None
+
+
+def test_procurement_status_update_is_refused():
+    assert parse_ep_report(_read("ep_non_award_procurement_status.txt"), fallback_ref="2023.EP1.5") is None

--- a/scrapers/tests/test_ep_reports.py
+++ b/scrapers/tests/test_ep_reports.py
@@ -123,3 +123,22 @@ def test_bid_table_2019_five_bidders_with_footnote_marker():
 def test_bid_table_absent_returns_empty():
     rows = parse_ep_bid_table(_read("ep_non_award_wsib_report.txt"))
     assert rows == []                                    # no Table 1 -> no bids
+
+
+def test_store_ep_reports_lands_award_and_bids(conn):
+    from toronto_bids.buyers import seed_buyers
+    from toronto_bids.sources.ep_board import store_ep_reports
+    ids = seed_buyers(conn)
+    conn.execute("INSERT INTO background_pdf (url, kind, sha256, text) VALUES "
+                 "('https://www.toronto.ca/legdocs/mmis/2023/ep/bgrd/backgroundfile-240943.pdf',"
+                 " 'agency_board', 'x', ?)", (_read("ep_award_with_table_2023.txt"),))
+    conn.commit()
+    got = store_ep_reports(conn, ids["exhibition-place"])
+    assert got["solicitations"] == 1 and got["awards"] == 1 and got["bids"] == 3
+    aw = conn.execute("SELECT supplier_name_raw, award_amount_numeric FROM agency_award "
+                      "WHERE native_ref='EP110-2023'").fetchone()
+    assert aw["supplier_name_raw"] == "Powell Fence Limited"
+    assert aw["award_amount_numeric"] == 1484065.00
+    bids = conn.execute("SELECT COUNT(*) FROM agency_bid WHERE bid_price_numeric IS NOT NULL "
+                        "AND native_ref='EP110-2023'").fetchone()[0]
+    assert bids == 3

--- a/scrapers/tests/test_ep_reports.py
+++ b/scrapers/tests/test_ep_reports.py
@@ -98,6 +98,13 @@ def test_procurement_status_update_is_refused():
     assert parse_ep_report(_read("ep_non_award_procurement_status.txt"), fallback_ref="2023.EP1.5") is None
 
 
+def test_confidential_non_procurement_matter_is_refused():
+    # A confidential collective-agreement / labour-relations report is NOT a procurement award,
+    # even though it says "agreement with <Union>" — the guard must refuse it (#130 live run).
+    assert parse_ep_report(_read("ep_non_award_collective_agreement.txt"),
+                           fallback_ref="2024.EP3.5") is None
+
+
 def test_bid_table_extracts_all_three_bidders_with_prices():
     rows = parse_ep_bid_table(_read("ep_award_with_table_2023.txt"))
     assert rows == [

--- a/scrapers/toronto_bids/buyers.py
+++ b/scrapers/toronto_bids/buyers.py
@@ -12,6 +12,11 @@ DEFAULT_BUYERS = [
           notes="Partnered: six municipalities fund it; Toronto pays 62.6% of the 2025 "
                 "operating levy. Bill 97 amalgamates TRCA away 2027-02-01. Venue history "
                 "is mixed (Biddingo through ~2023, then trca.bidsandtenders.ca)."),
+    Buyer(slug="exhibition-place", name="Exhibition Place", kind="agency", partnered=0,
+          funding_share=None, platform="Bonfire",
+          notes="City agency (Board of Governors); left the PMMD feed in 2019 for its own "
+                "Bonfire portal. Awards captured from Board of Governors reports on legdocs "
+                "(TMMIS EP committee); the Bonfire portal is gated (#134)."),
 ]
 
 

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -93,8 +93,8 @@ def build_parser() -> argparse.ArgumentParser:
              "(eSCRIBE, plain HTTP) and Toronto Zoo (ZB agendas on TMMIS). Offline by "
              "default — parses reports already on disk. NEVER touches the bids&tenders "
              "portal (gated on written permission, see docs/permissions/).")
-    p_ag.add_argument("--only", choices=["zoo", "trca"],
-                      help="Run one body instead of both")
+    p_ag.add_argument("--only", choices=["zoo", "trca", "ep"],
+                      help="Run one body instead of all")
     p_ag.add_argument("--fetch", action="store_true",
                       help="Plain-HTTP fetching first: TRCA eSCRIBE listings + report PDFs, "
                            "and legdocs PDFs for Zoo agendas already cached")
@@ -495,7 +495,7 @@ def _cmd_enrich_agencies(args) -> int:
     failures: list[tuple[str, str]] = []
     try:
         ids = seed_buyers(conn)
-        bodies = [args.only] if args.only else ["trca", "zoo"]
+        bodies = [args.only] if args.only else ["trca", "zoo", "ep"]
 
         if "trca" in bodies:
             try:
@@ -533,6 +533,27 @@ def _cmd_enrich_agencies(args) -> int:
                       f"{got['awards']} awards")
             except Exception as exc:
                 failures.append(("zoo", str(exc)))
+
+        if "ep" in bodies:
+            try:
+                from toronto_bids.sources.ep_board import (
+                    cached_ep_agendas, download_ep_reports, scrape_ep_agendas, store_ep_reports)
+                agendas = (scrape_ep_agendas(virtual_display=args.virtual_display, log=out)
+                           if args.scrape else cached_ep_agendas())
+                print(f"  ep EP agendas        : {len(agendas)}"
+                      f" ({'scraped' if args.scrape else 'cached'})")
+                if agendas and (args.fetch or args.scrape):
+                    http = HttpClient()
+                    try:
+                        print(f"  ep reports fetched   : "
+                              f"{download_ep_reports(conn, http, agendas, log=out)}")
+                    finally:
+                        http.close()
+                got = store_ep_reports(conn, ids["exhibition-place"])
+                print(f"  ep stored            : {got['solicitations']} solicitations, "
+                      f"{got['awards']} awards, {got['bids']} bids")
+            except Exception as exc:
+                failures.append(("ep", str(exc)))
 
         if args.portal:
             try:

--- a/scrapers/toronto_bids/config.py
+++ b/scrapers/toronto_bids/config.py
@@ -113,3 +113,8 @@ BIDS_TENDERS_PORTALS = [
 # Raw bids&tenders listing JSON captured by `--record`, one file per record — the seed for
 # real parser fixtures once a portal has data (#135).
 PORTAL_RECORDINGS_DIR = DATA_DIR / "agencies" / "portal_recordings"
+
+# Exhibition Place Board of Governors (#130): the EP committee on TMMIS, same infrastructure
+# as the Zoo's ZB series — headed-browser discovery, plain-HTTP legdocs report PDFs.
+EP_AGENDAS_DIR = DATA_DIR / "agencies" / "ep" / "agendas"
+EP_REPORTS_DIR = DATA_DIR / "agencies" / "ep"

--- a/scrapers/toronto_bids/sources/agency_report.py
+++ b/scrapers/toronto_bids/sources/agency_report.py
@@ -1,0 +1,23 @@
+"""Pure regex primitives shared by the agency board-report parsers (Zoo, Exhibition Place, …).
+
+Amounts are written many ways and "in the amount of" dominates the corpus; a truncated
+"$1,25 million" shorthand (comma decimal + scale word) captures a bogus "$1" and is refused.
+"""
+import re
+
+AMOUNT_PHRASE = (
+    r"(?:in\s+the\s+amount\s+of|at\s+a\s+(?:total\s+)?cost(?:\s+not\s+to\s+exceed)?(?:\s+of)?"
+    r"|for\s+the\s+(?:total\s+)?(?:sum|amount)\s+of|in\s+an\s+amount\s+not\s+to\s+exceed"
+    r"|total\s+cost\s+(?:not\s+to\s+exceed\s+)?(?:of\s+)?)")
+MONEY = r"(\$\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})?)"
+AMOUNT_RE = re.compile(r"(?i:" + AMOUNT_PHRASE + r")\s*" + MONEY)
+CONFIDENTIAL_RE = re.compile(r"CONFIDENTIAL\s+ATTACHMENT", re.I)
+_TRUNCATED_AMOUNT = re.compile(r"\s*(?:[.,]\d|million|billion)", re.I)
+
+
+def amount_or_none(text: str, m) -> str | None:
+    """The matched money string with spaces stripped, or None if the match is a truncated
+    "$X,YY million" shorthand (a bogus tiny figure) — refuse rather than store $1."""
+    if m is None or _TRUNCATED_AMOUNT.match(text, m.end()):
+        return None
+    return m.group(m.lastindex).replace(" ", "")

--- a/scrapers/toronto_bids/sources/ep_board.py
+++ b/scrapers/toronto_bids/sources/ep_board.py
@@ -9,7 +9,7 @@ non-awards.
 import re
 
 from toronto_bids import config
-from toronto_bids.models import BackgroundPdf
+from toronto_bids.models import AgencyAward, AgencyBid, AgencySolicitation, BackgroundPdf
 from toronto_bids.sources.agency_report import AMOUNT_RE, CONFIDENTIAL_RE, amount_or_none
 from toronto_bids.sources.bid_award_panel import (cached_agendas, parse_agenda_pdfs,
                                                   scrape_agendas)
@@ -70,17 +70,34 @@ _WS = re.compile(r"\s+")
 
 
 def _winner(raw: str | None) -> str | None:
-    """Collapse a line-wrapped winner and strip a trailing location qualifier."""
+    """Collapse a line-wrapped winner and strip a trailing location qualifier. A trailing comma
+    is a boundary artifact, not part of the name: when the winner is immediately followed by a
+    comma with no space ("...Limited, for the replacement"), the required `\\s+` before the
+    boundary alternation forces the comma itself into the capture (#130 live measurement)."""
     if raw is None:
         return None
-    return _strip_location(_WS.sub(" ", raw).strip()) or None
+    return _strip_location(_WS.sub(" ", raw).strip().rstrip(",")).strip() or None
 
 
 # A confidential agreement's counterparty, when publicly named ("agreement with Coca-Cola …").
-# Capital-anchored, so a redacted "a Consumer Show Client" is correctly skipped.
+# Capital-anchored, so a redacted "a Consumer Show Client" is correctly skipped. Each token in
+# the name must itself start capitalized (or be a bare connector: and/of/&) — otherwise a
+# lowercase run past the name ("BCC is set to expire", "LiUNA Local 506 applies to") gets
+# swept into the capture, since the old class allowed any case up to the next for/to/on/comma.
+_NAME_TOKEN = r"(?:[A-Z][A-Za-z0-9&.,'’\-]*|and|of|&)"
 _EP_AGREEMENT = re.compile(
-    r"agreement\s+with\s+([A-Z][A-Za-z0-9&.,'’ \-]{2,45}?)(?:\s+(?:for|to|on|,)\b|\s*\()", re.S)
+    r"agreement\s+with\s+(" + _NAME_TOKEN + r"(?:\s+" + _NAME_TOKEN + r"){0,6})"
+    r"(?:\s+(?:for|to|on|,)\b|\s*\()", re.S)
 _EP_SUBJECT = re.compile(r"^([A-Z].*(?:Tender|Contract|Award|Agreement|RF[TPQ]).*)$", re.M)
+# MFIPPA closed-meeting reasons that are NOT procurement (labour negotiations, personal matters,
+# property security, litigation/privilege) — City confidential reports cite one of these
+# explicitly, and only the financial/commercial and acquisition-disposition reasons cover real
+# agreements. Live measurement (#130) found 23 such reports wrongly kept as bare/garbled awards
+# (a Collective Agreement report captured "LiUNA Local 506 applies" as a winner) — refuse them.
+_EP_NON_PROCUREMENT_REASON = re.compile(
+    r"labour relations|employee negotiat|collective agreement|personal matters about|"
+    r"security of (?:the )?property|position,?\s*plan|plan to be applied to (?:any )?negotiat|"
+    r"solicitor-client|litigation", re.I)
 
 
 def _ep_ref(text: str, fallback_ref: str) -> str:
@@ -101,8 +118,10 @@ def parse_ep_report(text: str, fallback_ref: str, report_url: str | None = None)
     amount = None if confidential else amount_or_none(text, AMOUNT_RE.search(text)) if aw else None
 
     if not aw:
-        # No competitive award clause. Keep ONLY a confidential procurement agreement.
-        if confidential and re.search(r"\bagreement\b|\baward\b|\bcontract\b", text, re.I):
+        # No competitive award clause. Keep ONLY a confidential procurement agreement — never
+        # a labour/personal/security/litigation matter that merely happens to say "agreement".
+        if (confidential and not _EP_NON_PROCUREMENT_REASON.search(text)
+                and re.search(r"\bagreement\b|\baward\b|\bcontract\b", text, re.I)):
             ag = _EP_AGREEMENT.search(text)
             winner = _winner(ag.group(1)) if ag else None
         else:
@@ -146,3 +165,34 @@ def parse_ep_bid_table(text: str) -> list[tuple[str, str]]:
             continue
         rows.append((name, price))
     return rows
+
+
+def store_ep_reports(conn, buyer_id: int) -> dict:
+    """Parse held EP reports into agency rows. One AgencySolicitation + AgencyAward per award
+    report (confidential ones keep the winner, NULL amount), and one AgencyBid per Table 1 row.
+    Non-award reports are refused by parse_ep_report and contribute nothing."""
+    counts = {"solicitations": 0, "awards": 0, "bids": 0}
+    for row in conn.execute(
+            "SELECT reference, url, text FROM background_pdf WHERE kind='agency_board' "
+            "AND url LIKE '%/ep/%' AND text IS NOT NULL ORDER BY url").fetchall():
+        got = parse_ep_report(row["text"], fallback_ref=row["reference"] or row["url"],
+                              report_url=row["url"])
+        if got is None:
+            continue
+        db.upsert_row(conn, AgencySolicitation(
+            buyer_id=buyer_id, native_ref=got["native_ref"], title=got["title"],
+            status="awarded", posted_date=None, closing_date=None, portal_url=None,
+            source="ep_board"), overwrite=False)
+        counts["solicitations"] += 1
+        db.upsert_row(conn, AgencyAward(
+            buyer_id=buyer_id, native_ref=got["native_ref"], supplier_name_raw=got["winner"],
+            award_amount=got["amount"], value_confidential=got["confidential"], award_date=None,
+            report_url=got["report_url"], source="ep_board"), overwrite=True)
+        counts["awards"] += 1
+        for bidder, price in parse_ep_bid_table(row["text"]):
+            db.upsert_row(conn, AgencyBid(
+                buyer_id=buyer_id, native_ref=got["native_ref"], bidder_name_raw=bidder,
+                bid_price=price, report_url=row["url"], source="ep_board"), overwrite=True)
+            counts["bids"] += 1
+    conn.commit()
+    return counts

--- a/scrapers/toronto_bids/sources/ep_board.py
+++ b/scrapers/toronto_bids/sources/ep_board.py
@@ -1,0 +1,41 @@
+"""Exhibition Place Board of Governors capture (#130): the EP committee on TMMIS.
+
+Same infrastructure as the Zoo's ZB series (#135): TMMIS agendas need the headed browser
+(Akamai-gated), report PDFs are plain-HTTP legdocs (/legdocs/mmis/YYYY/ep/bgrd/...). Reuses
+the bid_award_panel prober; the EP reference format is YYYY.EP<meeting>.<item> (confirmed
+live). Most EP board reports are NOT procurement awards, so the parsers (added next) refuse
+non-awards.
+"""
+from toronto_bids import config
+from toronto_bids.models import BackgroundPdf
+from toronto_bids.sources.bid_award_panel import (cached_agendas, parse_agenda_pdfs,
+                                                  scrape_agendas)
+from toronto_bids.sources.trca_board import _store_pending_pdfs
+from toronto_bids.store import db
+
+# EP meetings reset numbering per council term, like ZB. Confirmed live: the 2022-2026 term
+# runs EP1..EP23 (as of 2026-06). The 2018-2022 term is probed too (2022.EP25 seen).
+EP_TERM_STARTS = [
+    ("EP", 2019, "2018-2022", 1),
+    ("EP", 2023, "2022-2026", 1),
+]
+
+
+def scrape_ep_agendas(virtual_display: bool = False, log=lambda _m: None) -> dict:
+    return scrape_agendas(config.EP_AGENDAS_DIR, virtual_display=virtual_display,
+                          log=log, term_starts=EP_TERM_STARTS)
+
+
+def cached_ep_agendas() -> dict:
+    return cached_agendas(config.EP_AGENDAS_DIR)
+
+
+def download_ep_reports(conn, http, agendas: dict, log=lambda _m: None) -> int:
+    """Index every bgrd PDF the EP agendas link, then fetch the ones not yet held. Plain HTTP,
+    resilient (a dead URL is skipped), sha256-queued. EP reports live under /legdocs/.../ep/."""
+    for meeting, html in agendas.items():
+        for pdf in parse_agenda_pdfs(html, meeting):
+            db.upsert_row(conn, BackgroundPdf(url=pdf["url"], reference=pdf["reference"],
+                                              kind="agency_board"), overwrite=False)
+    conn.commit()
+    return _store_pending_pdfs(conn, http, config.EP_REPORTS_DIR, "%/ep/%", log, "ep")

--- a/scrapers/toronto_bids/sources/ep_board.py
+++ b/scrapers/toronto_bids/sources/ep_board.py
@@ -117,3 +117,32 @@ def parse_ep_report(text: str, fallback_ref: str, report_url: str | None = None)
         "confidential": confidential,
         "report_url": report_url,
     }
+
+
+# A Table 1 row: a bidder name (letters/&/./,/spaces) followed by its first $ price. The winner
+# row carries a second $ (recommended contract price); take the FIRST. Column-header lines
+# ("Base Bid Price", "Received", "Recommended Contract Price") have no leading firm name + price
+# on the same run and are skipped by requiring a name that ends in a company word OR a name-then-$
+# on one line. Refuse a line that isn't a clean name+price (the #94 rule).
+_EP_BID_ROW = re.compile(
+    r"^\s*([A-Z][A-Za-z0-9&.,'’ \-]{3,60}?)\s+(\$\s?\d{1,3}(?:,\d{3})*\.\d{2})", re.M)
+_EP_TABLE_HEAD = re.compile(r"Table\s+\d[^\n]*Tender\s+Price\s+Submission", re.I)
+
+
+def parse_ep_bid_table(text: str) -> list[tuple[str, str]]:
+    """Every (bidder, base-bid-price) in an EP 'Table 1: Tender Price Submission'. Empty if the
+    report has no such table."""
+    head = _EP_TABLE_HEAD.search(text)
+    if not head:
+        return []
+    # Scope to the region after the header up to a blank-line gap / the next section.
+    tail = text[head.end():head.end() + 1500]
+    rows = []
+    for m in _EP_BID_ROW.finditer(tail):
+        name = re.sub(r"\s+", " ", m.group(1)).strip()
+        price = m.group(2).replace(" ", "")
+        # Skip a column-header fragment that slipped through (no company suffix and generic words).
+        if name.lower() in {"base bid price", "recommended contract price", "received"}:
+            continue
+        rows.append((name, price))
+    return rows

--- a/scrapers/toronto_bids/sources/ep_board.py
+++ b/scrapers/toronto_bids/sources/ep_board.py
@@ -6,8 +6,11 @@ the bid_award_panel prober; the EP reference format is YYYY.EP<meeting>.<item> (
 live). Most EP board reports are NOT procurement awards, so the parsers (added next) refuse
 non-awards.
 """
+import re
+
 from toronto_bids import config
 from toronto_bids.models import BackgroundPdf
+from toronto_bids.sources.agency_report import AMOUNT_RE, CONFIDENTIAL_RE, amount_or_none
 from toronto_bids.sources.bid_award_panel import (cached_agendas, parse_agenda_pdfs,
                                                   scrape_agendas)
 from toronto_bids.sources.trca_board import _store_pending_pdfs
@@ -39,3 +42,78 @@ def download_ep_reports(conn, http, agendas: dict, log=lambda _m: None) -> int:
                                               kind="agency_board"), overwrite=False)
     conn.commit()
     return _store_pending_pdfs(conn, http, config.EP_REPORTS_DIR, "%/ep/%", log, "ep")
+
+
+# The EP solicitation ref: RFT No. EP###-YYYY (primary) or a Contract No. token. Match the
+# shape, not the label vocabulary.
+_EP_RFT = re.compile(r"RF[TPQ]\s*No\.?\s*(EP\d+-\d{4})", re.I)
+_EP_CONTRACT = re.compile(r"Contract\s+No\.?\s*([0-9][0-9A-Za-z\-]{3,})", re.I)
+# The competitive award clause: "award of ... to WINNER for/at the <project> ..." — WINNER is
+# bounded and STOPS at " for "/" at "/a comma/the amount phrase (EP puts the project between the
+# winner and the amount, so the shared Zoo "to WINNER <phrase> $" over-captures). The winner
+# class ALLOWS internal whitespace (`\s` + re.S) because pdftotext wraps long firm names across
+# lines ("Westbury National\nShow System Ltd."); _squash collapses it. A trailing location
+# qualifier (" of Cambridge, Ontario") is stripped afterwards by _strip_location.
+_EP_AWARD = re.compile(
+    r"award\s+of\s+(?:the\s+)?(?:Contract|RF[TPQ]|Tender)\b[^$]{0,120}?\bto\s+"
+    r"([A-Z][A-Za-z0-9&.,'’()\-\s]{2,60}?)\s+(?:for\b|at\b|,|in\s+the\s+amount)", re.I | re.S)
+# End-anchored location qualifier to strip from a winner ("Firm Ltd. of Cambridge, Ontario").
+# Narrow (a space-delimited "of <Place>, <Province>") so real names like "…& Sons" survive.
+_LOCATION = re.compile(r"\s+of\s+[A-Z][A-Za-z. ]+,\s*(?:Ontario|Canada|Quebec|Alberta|B\.?C\.?)\.?$", re.I)
+
+
+def _strip_location(name: str) -> str:
+    return _LOCATION.sub("", name).strip()
+
+
+_WS = re.compile(r"\s+")
+
+
+def _winner(raw: str | None) -> str | None:
+    """Collapse a line-wrapped winner and strip a trailing location qualifier."""
+    if raw is None:
+        return None
+    return _strip_location(_WS.sub(" ", raw).strip()) or None
+
+
+# A confidential agreement's counterparty, when publicly named ("agreement with Coca-Cola …").
+# Capital-anchored, so a redacted "a Consumer Show Client" is correctly skipped.
+_EP_AGREEMENT = re.compile(
+    r"agreement\s+with\s+([A-Z][A-Za-z0-9&.,'’ \-]{2,45}?)(?:\s+(?:for|to|on|,)\b|\s*\()", re.S)
+_EP_SUBJECT = re.compile(r"^([A-Z].*(?:Tender|Contract|Award|Agreement|RF[TPQ]).*)$", re.M)
+
+
+def _ep_ref(text: str, fallback_ref: str) -> str:
+    m = _EP_RFT.search(text)
+    if m:
+        return m.group(1).upper()
+    m = _EP_CONTRACT.search(text)
+    return m.group(1) if m else fallback_ref
+
+
+def parse_ep_report(text: str, fallback_ref: str, report_url: str | None = None) -> dict | None:
+    """Map one EP board report to an award, or None. Most EP reports are NOT procurement awards
+    (WSIB safety, status updates, governance) — refuse those. Keeps a confidential award (value
+    withheld) when it names a real counterparty OR is an explicit procurement agreement."""
+    confidential = 1 if CONFIDENTIAL_RE.search(text) else 0
+    aw = _EP_AWARD.search(text)
+    winner = _winner(aw.group(1)) if aw else None
+    amount = None if confidential else amount_or_none(text, AMOUNT_RE.search(text)) if aw else None
+
+    if not aw:
+        # No competitive award clause. Keep ONLY a confidential procurement agreement.
+        if confidential and re.search(r"\bagreement\b|\baward\b|\bcontract\b", text, re.I):
+            ag = _EP_AGREEMENT.search(text)
+            winner = _winner(ag.group(1)) if ag else None
+        else:
+            return None                              # not a procurement award — refuse
+
+    ref_m = _EP_SUBJECT.search(text)
+    return {
+        "native_ref": _ep_ref(text, fallback_ref),
+        "title": re.sub(r"\s+", " ", ref_m.group(1)).strip() if ref_m else None,
+        "winner": winner,
+        "amount": amount,
+        "confidential": confidential,
+        "report_url": report_url,
+    }

--- a/scrapers/toronto_bids/sources/zoo_board.py
+++ b/scrapers/toronto_bids/sources/zoo_board.py
@@ -8,6 +8,10 @@ import re
 
 from toronto_bids import config
 from toronto_bids.models import AgencyAward, AgencySolicitation, BackgroundPdf
+from toronto_bids.sources.agency_report import (
+    AMOUNT_PHRASE as _AMOUNT_PHRASE, AMOUNT_RE as _ZOO_AMOUNT,
+    CONFIDENTIAL_RE as _CONFIDENTIAL, MONEY as _MONEY, amount_or_none as _amount_or_none,
+)
 from toronto_bids.sources.bid_award_panel import (cached_agendas, parse_agenda_pdfs,
                                                   scrape_agendas)
 from toronto_bids.store import db
@@ -50,7 +54,6 @@ def download_zoo_reports(conn, http, agendas: dict, log=lambda _m: None) -> int:
 # ---------------------------------------------------------------------------
 
 _ZOO_REF = re.compile(r"\b(R[FQ][TPQ][\s-]*\d{1,3}(?:\s*\(\d{4}-\d{2}\))?)")
-_CONFIDENTIAL = re.compile(r"CONFIDENTIAL\s+ATTACHMENT", re.I)
 _ZOO_WINNER = re.compile(
     r"award(?:ed)?\s+(?:of\s+)?(?:the\s+)?[\w\s–-]{0,80}?\s+to\s+"
     r"([A-Z][A-Za-z0-9&.,'’ \-]+?(?:Inc|Ltd|Limited|Corp|Corporation|Company)\.?)")
@@ -59,15 +62,6 @@ _ZOO_WINNER = re.compile(
 _ZOO_WINNER_AGREEMENT = re.compile(
     r"agreement\s+with\s+([A-Z][A-Za-z0-9&.,'’ \-]+?(?:Inc|Ltd|Limited|Corp|Corporation|Company)\.?)"
     r"\s*(?:\([^)]*\))?\s+for\s+the\s+award", re.S)
-# The amount is written many ways, and "in the amount of" dominates the real corpus (67
-# occurrences vs ~10 for "total cost") — matching only "total cost" left most named awards
-# with a NULL amount (#135). One alternation, reused by the combined award pattern below.
-_AMOUNT_PHRASE = (
-    r"(?:in\s+the\s+amount\s+of|at\s+a\s+(?:total\s+)?cost(?:\s+not\s+to\s+exceed)?(?:\s+of)?"
-    r"|for\s+the\s+(?:total\s+)?(?:sum|amount)\s+of|in\s+an\s+amount\s+not\s+to\s+exceed"
-    r"|total\s+cost\s+(?:not\s+to\s+exceed\s+)?(?:of\s+)?)")
-_MONEY = r"(\$\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})?)"
-_ZOO_AMOUNT = re.compile(r"(?i:" + _AMOUNT_PHRASE + r")\s*" + _MONEY)
 # The primary award pattern: "... to WINNER <amount-phrase> $AMOUNT". The winner is bounded
 # and carries NO legal-suffix requirement — the corpus is full of suffix-less firms
 # ("Tri-Unite Systems", "Precise ParkLink", "Provincial Roofing") that the suffix-anchored
@@ -77,19 +71,6 @@ _ZOO_AMOUNT = re.compile(r"(?i:" + _AMOUNT_PHRASE + r")\s*" + _MONEY)
 _ZOO_AWARD = re.compile(
     r"\bto\s+([A-Z][A-Za-z0-9&.,'’()/\- ]{2,60}?)\s+(?i:" + _AMOUNT_PHRASE + r")\s*" + _MONEY)
 _SUBJECT = re.compile(r"^(?:Subject:|\s*)(.*(?:Tender|RFT|RFP|Award|Contract).*)$", re.M)
-
-
-# A money match that is really a "$X,YY million" shorthand (comma as the decimal point, then
-# a scale word) captures only the leading "$X" once thousands-grouping is enforced — an
-# obviously wrong tiny figure. Refuse it (NULL the amount, keep the winner) rather than store
-# $1 for a $1.25M award (the archive's refuse-rather-than-guess rule).
-_TRUNCATED_AMOUNT = re.compile(r"\s*(?:[.,]\d|million|billion)", re.I)
-
-
-def _amount_or_none(text: str, m) -> str | None:
-    if m is None or _TRUNCATED_AMOUNT.match(text, m.end()):
-        return None
-    return m.group(m.lastindex).replace(" ", "")
 
 
 def parse_zoo_report(text: str, fallback_ref: str, report_url: str | None = None) -> dict | None:


### PR DESCRIPTION
Recovers Exhibition Place's post-2019 procurement record — **awards + bidder prices** — from its Board of Governors reports on legdocs, into the existing `agency_*` keyspace. The no-permission-gate slice of #130 (the Bonfire portal stays out of scope, #134). Design: `docs/superpowers/specs/2026-07-18-exhibition-place-capture-design.md`.

## What it recovers

EP left the City's PMMD feed in 2019 (its 72 spine rows stop at 2019-08-27) when it adopted its own portal — everything since was invisible. But EP's awards are approved by its **Board of Governors**, whose reports are published on legdocs as plain-HTTP PDFs (the same "board report" shape the Zoo/TRCA capture already parses). A live run over the full corpus stored **107 awards and 115 bids** across both council terms.

## What's built

- **Reuse over rebuild.** EP is the Zoo pattern verbatim — TMMIS EP committee (`YYYY.EP<n>.<n>`, headed-browser discovery via the shared prober), plain-HTTP legdocs `bgrd` PDFs via the resilient download loop. New `sources/ep_board.py`, an `exhibition-place` buyer, and a shared `sources/agency_report.py` (amount/confidential primitives extracted from `zoo_board`, behavior-preserving).
- **EP is the first agency source with a structured price table** — `parse_ep_bid_table` reads "Table 1: Tender Price Submission(s)" into `agency_bid` rows *with prices*.
- **On-demand, not nightly.** `tb enrich-agencies --only ep --scrape` (discovery is browser-bound; nothing browser-bound is on the scheduled path). Per-body isolated — EP failing never stops TRCA/Zoo.

## The hard part: refusing non-awards

**Most EP board reports are not procurement awards** — WSIB safety reports, status updates, governance, confidential sponsorship/lease agreements — and many carry `$` amounts that are traps. So the parser's central job is *refusing* the non-awards. This was validated the way everything in this project now has to be — **against the real corpus, not a handful of fixtures**:

- The offline suite covers 8 real EP reports (2019 + 2023 awards, confidential decisions, and load-bearing **negatives**: a WSIB report, a procurement-status update, a collective-agreement matter).
- The mandatory **live measurement over 1,200 reports** caught what fixtures couldn't: 23 false positives (labour-relations / personal-matters reports read as awards — a Collective Agreement report captured "LiUNA Local 506" as a winner). Fixed with a non-procurement (MFIPPA-reason) refusal guard, re-measured to **107 accepted / 1,093 refused, all winner names clean**, and the guard is locked with a regression fixture.
- Real year-to-year variety, also surfaced by the corpus and handled: winners span pdftotext line breaks ("Westbury National / Show System Ltd."), a location qualifier is stripped ("Sutherland-Schultz Ltd. **of Cambridge, Ontario**"), and refs are `RFT No. EP###-YYYY` (2023) or `Contract No.` (2019).

## The pre/post-2019 coexistence (#130's open question, answered)

The 72 pre-2019 EP rows in the City spine (keyed on `document_number`) and these post-2019 Board-of-Governors awards (keyed on the EP ref) are **separate coexisting keyspaces — no join is attempted**, consistent with the agency-keyspace design (#96/#135). EP's record is in two places by era, which is accurate: a City-fed division through 2019, a self-procuring board after.

## Testing

555 tests pass, offline and fixture-based. Built across 5 TDD tasks, each spec- and quality-reviewed; the plan was revised mid-execution when the real 2019 corpus revealed the 2023-only parser was insufficient. Whole-branch review on the most capable model confirmed the load-bearing guarantees (refuse-non-awards, the guard can't over-refuse a real award, behavior-preserving extraction, store semantics, isolation, year variety, coexisting keyspaces) — no Critical/Important findings; five deferrable Minors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
