### PR TITLE
fix(export): nest reference-null Award Summary bids instead of dropping them (#145)

### DIFF
--- a/scrapers/tests/test_export_document.py
+++ b/scrapers/tests/test_export_document.py
@@ -295,6 +295,75 @@ def test_staff_report_surfaces_under_solicitation_via_bid_bridge(seeded):
     assert set(report) == {"source", "name", "path", "type", "size_bytes", "url"}
 
 
+def test_reference_null_bid_nests_under_solicitation(seeded):
+    # An Award Summary bid: reference IS NULL, document_number set to a real solicitation.
+    db.upsert_row(seeded, Bid(bidder_name_raw="Post-Panel Co", reference=None,
+                              document_number="5672751291", bid_price="2500",
+                              source="award_summary"), overwrite=True)
+    seeded.commit()
+
+    sol = next(s for s in build_export_document(seeded, generated_at="t")["solicitations"]
+               if s["document_number"] == "5672751291")
+    assert len(sol["bids"]) == 1
+    assert sol["bids"][0]["bidder_name_raw"] == "Post-Panel Co"
+    assert "id" not in sol["bids"][0]
+    assert "document_number" not in sol["bids"][0]   # redundant under the solicitation
+    # It must NOT leak into any council item.
+    assert all(b["bidder_name_raw"] != "Post-Panel Co"
+               for ci in build_export_document(seeded, generated_at="t")["council_items"]
+               for b in ci["bids"])
+
+
+def test_reference_null_bid_with_no_matching_solicitation_goes_to_unlinked_bids(seeded):
+    db.upsert_row(seeded, Bid(bidder_name_raw="Orphan Bidder", reference=None,
+                              document_number="4044346425", bid_price="500",
+                              source="award_summary"), overwrite=True)
+    seeded.commit()
+    doc = build_export_document(seeded, generated_at="t")
+    orphan = [b for b in doc["unlinked_bids"] if b["bidder_name_raw"] == "Orphan Bidder"]
+    assert len(orphan) == 1
+    assert orphan[0]["document_number"] == "4044346425"   # kept for diagnostics
+    assert all(b["bidder_name_raw"] != "Orphan Bidder"
+               for s in doc["solicitations"] for b in s["bids"])
+
+
+def test_reference_bid_stays_under_council_item(conn):
+    from toronto_bids.models import CouncilItem
+    db.upsert_row(conn, CouncilItem(reference="2025.BA5.3", title="Award"), overwrite=True)
+    db.upsert_row(conn, Bid(bidder_name_raw="Panel Bidder", reference="2025.BA5.3",
+                            bid_price="100", source="bid_award_panel"), overwrite=True)
+    conn.commit()
+    doc = build_export_document(conn, generated_at="t")
+    ci = doc["council_items"][0]
+    assert [b["bidder_name_raw"] for b in ci["bids"]] == ["Panel Bidder"]
+    # and it must NOT appear in unlinked_bids
+    assert doc["unlinked_bids"] == []
+
+
+def test_no_bid_is_dropped_counts_reconcile(seeded):
+    from toronto_bids.models import CouncilItem
+    db.upsert_row(seeded, CouncilItem(reference="2020.BA5.3", title="Award"), overwrite=True)
+    db.upsert_row(seeded, Bid(bidder_name_raw="Panel Co", reference="2020.BA5.3",
+                              bid_price="100", source="bid_award_panel"), overwrite=True)
+    db.upsert_row(seeded, Bid(bidder_name_raw="Nested Co", reference=None,
+                              document_number="5672751291", bid_price="200",
+                              source="award_summary"), overwrite=True)
+    db.upsert_row(seeded, Bid(bidder_name_raw="Orphan Co", reference=None,
+                              document_number="4044346425", bid_price="300",
+                              source="award_summary"), overwrite=True)
+    seeded.commit()
+    doc = build_export_document(seeded, generated_at="t")
+    counts = doc["meta"]["counts"]
+    council = sum(len(ci["bids"]) for ci in doc["council_items"])
+    nested = sum(len(s["bids"]) for s in doc["solicitations"])
+    assert council + nested + len(doc["unlinked_bids"]) == counts["bid"]
+
+
+def test_empty_store_has_empty_unlinked_bids(conn):
+    doc = build_export_document(conn, generated_at="t")
+    assert doc["unlinked_bids"] == []
+
+
 def test_unbridged_staff_report_stays_out_of_documents(seeded):
     # A staff report whose reference has no dual-key bid row must not attach to any solicitation.
     db.upsert_row(seeded, BackgroundPdf(

--- a/scrapers/toronto_bids/export/document.py
+++ b/scrapers/toronto_bids/export/document.py
@@ -109,6 +109,23 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
                 "url": report["url"],
             })
 
+    # Bids split by which identifier they carry. A bid with a council `reference` (Bid Award
+    # Panel era) nests under its council item, below. A reference-null bid (Award Summary Form,
+    # the post-panel successor #145) has no council item — it nests under its solicitation by
+    # document_number, or, matching no solicitation, lands in unlinked_bids. Same
+    # nested-or-unlinked contract as awards/postings — nothing is dropped.
+    bids_by_ref: dict = {}
+    bids_by_doc: dict[str, list] = {}
+    unlinked_bids: list = []
+    for bid in _rows(conn, "SELECT * FROM bid ORDER BY reference, document_number, bidder_name_raw, id"):
+        cleaned = _drop(bid, "id")
+        if bid["reference"] is not None:
+            bids_by_ref.setdefault(bid["reference"], []).append(cleaned)
+        elif bid["document_number"] in sol_docs:
+            bids_by_doc.setdefault(bid["document_number"], []).append(_drop(cleaned, "document_number"))
+        else:
+            unlinked_bids.append(cleaned)
+
     solicitations = []
     for sol in _rows(conn, "SELECT * FROM solicitation ORDER BY document_number"):
         sol = _drop(sol, "odata_id")
@@ -116,6 +133,7 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
         sol["awards"] = awards_by_doc.get(doc, [])
         sol["ariba_postings"] = postings_by_doc.get(doc, [])
         sol["documents"] = documents_by_doc.get(doc, [])
+        sol["bids"] = bids_by_doc.get(doc, [])
         solicitations.append(sol)
 
     noncompetitive = [
@@ -150,10 +168,6 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
     )
 
     pdfs_by_ref: dict[str, list] = {}
-    bids_by_ref = {}
-    for bid in _rows(conn, "SELECT * FROM bid ORDER BY reference, bidder_name_raw, id"):
-        bids_by_ref.setdefault(bid["reference"], []).append(_drop(bid, "id"))
-
     for pdf in _rows(conn, "SELECT * FROM background_pdf ORDER BY reference, url"):
         pdfs_by_ref.setdefault(pdf["reference"], []).append(_drop(pdf, "id", "text", "local_path"))
 
@@ -196,5 +210,6 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
         "council_items": council_items,
         "unlinked_ariba_postings": unlinked,
         "unlinked_awards": unlinked_awards,
+        "unlinked_bids": unlinked_bids,
         "buyers": buyers_out,
     }


### PR DESCRIPTION
Fixes #145.

`build_export_document` attached bids to council items solely by `reference`, so the 1,028 Award Summary Form bids (`reference IS NULL`, `document_number` set) — the *entire post-panel bid record* (the Bid Award Panel was abolished 2025-10-01; Award Summary Form bids are its only successor) — matched no council item and vanished from `bids.json`. This also broke the export's own "nothing is silently dropped" invariant (`unlinked_ariba_postings`, `unlinked_awards`).

## Fix

The bid loop now splits by which identifier a bid carries, mirroring how `awards` already nest under solicitations:

| Bid shape | Destination |
|---|---|
| `reference` present (Panel era) | council item — **unchanged** |
| `reference` NULL, `document_number` matches a solicitation | **`solicitations[].bids`** (new) |
| `reference` NULL, no matching solicitation | **`unlinked_bids`** top-level (new; retains `document_number`, like `unlinked_awards`) |

## Acceptance (both criteria from #145)

- **Reconciliation** — `council_items[].bids + solicitations[].bids + unlinked_bids == meta.counts.bid`. Unit test + confirmed on real CLI output.
- **Both destinations tested** — a reference-null bid with a matching solicitation nests under it; one without lands in `unlinked_bids`.

## Testing / verification

- 5 new tests (nest-under-solicitation, unlinked-bids, reference-bid-stays-under-council-item, counts-reconcile, empty-store). **560 pass** (was 555).
- Verified end-to-end through the **real `tb export` CLI** on a store seeded with the exact bug shape: `bids.json` came out with all three bids present and reconciling — the two reference-null bids that previously vanished (one under its solicitation, one in `unlinked_bids`) both reached the artifact.

Unblocks the frontend fixture/build (frontend plan Task 3) — solicitation pages promise the post-panel bid tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
