### PR TITLE
feat(export): carry supplier_key on suppliers — the stable permalink identity (#144)

### DIFF
--- a/scrapers/tests/test_export_document.py
+++ b/scrapers/tests/test_export_document.py
@@ -173,6 +173,9 @@ def test_export_has_suppliers_array_and_retains_supplier_id(conn):
     doc = build_export_document(conn, generated_at="t")
     assert len(doc["suppliers"]) == 1
     assert doc["suppliers"][0]["display_name"] == "Compugen Inc."
+    # supplier_key is the frontend's only stable permalink identity (#144): supplier_id is
+    # rebuilt every sync, display_name shifts as variants accrue.
+    assert doc["suppliers"][0]["supplier_key"] == "compugen inc"
     # variants is parsed to a list for consistency with categories
     assert doc["suppliers"][0]["variants"] == ["Compugen Inc."]
     # supplier_id is retained on nested awards so consumers can join to suppliers[]

--- a/scrapers/toronto_bids/export/document.py
+++ b/scrapers/toronto_bids/export/document.py
@@ -156,8 +156,10 @@ def build_export_document(conn, generated_at: str | None = None) -> dict:
         for firm in _rows(conn, "SELECT * FROM suspended_firm ORDER BY supplier_name_raw, council_authority")
     ]
 
+    # Keep supplier_key: it is the frontend's only stable supplier permalink (#144). supplier_id
+    # is rebuilt from scratch every sync, and display_name shifts as variants accrue.
     suppliers = [
-        _parse_json(_drop(s, "supplier_key"), "variants")
+        _parse_json(dict(s), "variants")
         for s in _rows(conn, "SELECT * FROM supplier ORDER BY display_name")
     ]
 


### PR DESCRIPTION
Fixes #144.

The frontend gives every supplier a permanent page, but the export dropped the only stable identity it could key on. `supplier_id` is rebuilt from scratch every sync (unstable across nights); `display_name` shifts as variants accrue. The normalized `supplier_key` is the stable permalink — and `export/document.py` deliberately dropped it.

## Fix

One line behind the Exporter seam — `_parse_json(dict(s), "variants")` instead of `_drop(s, "supplier_key")` — so `supplier_key` survives into `export["suppliers"]`.

## Acceptance (both met)

- Every entry in `export["suppliers"]` has a non-empty `supplier_key`.
- Existing export tests still pass (**560 pass**).

## Verification

- Test beside `test_export_has_suppliers_array_and_retains_supplier_id` asserts `doc["suppliers"][0]["supplier_key"] == "compugen inc"`.
- Verified end-to-end through the real `tb export` CLI: the emitted `bids.json` carries `supplier_key` on every supplier entry.

Unblocks the frontend fixture/build (frontend plan Task 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
