### PR TITLE
feat(deploy): publish the nightly export to a public data release (#146)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,17 +27,31 @@ cd ~/toronto-bids/scrapers && uv sync --locked
 uv run tb --version
 ```
 
-## 3. The Slack webhook
+## 3. Credentials — the Slack webhook and the publish token
 
-The repo is public. The webhook is a credential and lives only here, mode `0600`:
+The repo is public. Both are credentials and live only here, mode `0600`:
 
 ```shell
 mkdir -p ~/.config/toronto-bids
+umask 077
 read -rs W && printf 'TB_SLACK_WEBHOOK=%s\n' "$W" > ~/.config/toronto-bids/tb.env
 chmod 600 ~/.config/toronto-bids/tb.env
 ```
 
-Unset it and `tb nightly` still runs — it just posts nothing.
+Unset the webhook and `tb nightly` still runs — it just posts nothing.
+
+The **`GH_TOKEN`** is what `deploy/publish-data.sh` uses to upload the nightly export (see
+**Publishing the export**, below). It
+needs `repo` scope on `CivicTechTO/toronto-bids-data` (release write) and `workflow` scope on
+`CivicTechTO/toronto-bids-frontend` (deploy dispatch). Append it to the same file:
+
+```shell
+read -rs T && printf 'GH_TOKEN=%s\n' "$T" >> ~/.config/toronto-bids/tb.env
+chmod 600 ~/.config/toronto-bids/tb.env
+```
+
+Unlike the webhook, `GH_TOKEN` is **required** for publishing — the nightly's publish step fails
+loudly without it (publishing is the deliverable, not a notification).
 
 ## 4. Units
 
@@ -72,6 +86,45 @@ systemctl --user list-timers tb-nightly.timer
 | update | `cd ~/toronto-bids && git pull && cd scrapers && uv sync --locked` |
 
 Updating is deliberately manual.
+
+## Publishing the export — #146
+
+Design: [`docs/superpowers/specs/2026-07-19-publish-data-design.md`](../docs/superpowers/specs/2026-07-19-publish-data-design.md)
+
+The nightly's `ExecStart` is `deploy/tb-nightly-run.sh`, which runs `tb nightly` and then
+`deploy/publish-data.sh`. Publish runs **even after a partial sync** (the export is still valid),
+and the unit fails if **either** step failed — neither masks the other.
+
+`publish-data.sh` uploads `bids.json`, `bids.json.gz`, and `bids.sqlite` to a rolling **`latest`**
+release on `CivicTechTO/toronto-bids-data`, giving the frontend a stable URL:
+
+```
+https://github.com/CivicTechTO/toronto-bids-data/releases/download/latest/bids.json
+```
+
+On the 1st of each month it also cuts a dated `snapshot-YYYY-MM-DD` release (point-in-time
+citation), then triggers the frontend build (`gh workflow run deploy.yml`, best-effort).
+
+**One-time prerequisites** (do these before the first publish):
+
+```shell
+sudo apt install -y gh              # the GitHub CLI (privileged, once)
+# Create the data repo (public). Do this once, from any authenticated machine:
+gh repo create CivicTechTO/toronto-bids-data --public \
+  --description "Nightly export of the Toronto procurement archive (data only)."
+```
+
+Then add `GH_TOKEN` to `~/.config/toronto-bids/tb.env` (§3).
+
+**Self-test before wiring it live** — prints every `gh` command instead of running it, after the
+real artifact/JSON checks and gzip (needs a prior `tb export`, no token, no data repo):
+
+```shell
+cd ~/toronto-bids
+TB_PUBLISH_DRY_RUN=1 TB_DATA_DIR=~/tb-data deploy/publish-data.sh
+# Force the 1st-of-month snapshot path on any day:
+TB_PUBLISH_DRY_RUN=1 TB_PUBLISH_DAY=01 TB_DATA_DIR=~/tb-data deploy/publish-data.sh
+```
 
 ## Ariba document capture (opt-in, headed browser under Xvfb) — #122
 

--- a/deploy/publish-data.sh
+++ b/deploy/publish-data.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Publish the nightly export to a public GitHub release, then trigger the frontend build. (#146)
+#
+# Design: docs/superpowers/specs/2026-07-19-publish-data-design.md
+#
+# Runs on the server AFTER `tb nightly`, wrapped by tb-nightly-run.sh so it runs even after a
+# partial sync — the export is valid whenever any rows exist, and a good artifact must not be
+# withheld over one bad feed (the nightly's own per-step isolation ethos, extended one level out).
+#
+# Uploads bids.json, bids.json.gz, bids.sqlite to a rolling `latest` release, giving the static
+# frontend a stable URL. On the 1st of the month it also cuts a dated snapshot-YYYY-MM-DD release
+# (point-in-time citation). Then it triggers the frontend deploy (best-effort).
+#
+# GH_TOKEN (a credential) lives in ~/.config/toronto-bids/tb.env, mode 0600, never in git — the
+# service pulls it in via EnvironmentFile.
+#
+# Self-test: TB_PUBLISH_DRY_RUN=1 prints every `gh` command instead of running it, after the real
+# artifact/JSON checks and gzip. TB_PUBLISH_DAY / TB_PUBLISH_DATE force the snapshot path on any
+# day; TB_DATA_REPO / TB_FRONTEND_REPO override the targets for a fork.
+#
+# Deliberately NOT `set -e`: every fallible step is guarded with `|| fail`, so publish runs to a
+# definite success/failure rather than dying mid-way and leaving a half-updated release.
+set -uo pipefail
+
+DATA_DIR="${TB_DATA_DIR:-$HOME/tb-data}"
+EXPORT_DIR="$DATA_DIR/export"
+JSON="$EXPORT_DIR/bids.json"
+GZ="$EXPORT_DIR/bids.json.gz"
+SQLITE="$DATA_DIR/bids.sqlite"
+
+DATA_REPO="${TB_DATA_REPO:-CivicTechTO/toronto-bids-data}"
+FRONTEND_REPO="${TB_FRONTEND_REPO:-CivicTechTO/toronto-bids-frontend}"
+
+DAY="${TB_PUBLISH_DAY:-$(date +%d)}"
+SNAPSHOT_DATE="${TB_PUBLISH_DATE:-$(date +%F)}"
+DRY_RUN="${TB_PUBLISH_DRY_RUN:-0}"
+
+fail() { echo "publish-data: $*" >&2; exit 1; }
+
+gh_run() {
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "DRY-RUN gh $*"
+  else
+    gh "$@"
+  fi
+}
+
+# 1. The artifact must exist. On a catastrophic nightly (DB never opened, nothing exported)
+#    there is no file — that is a publish failure, surfaced, not a silent skip.
+[ -f "$JSON" ]   || fail "no export at $JSON — nothing to publish"
+[ -f "$SQLITE" ] || fail "no database at $SQLITE"
+
+# 2. The export must be valid JSON carrying generated_at. A truncated write is worse than no
+#    update — better to fail loudly and keep last night's good release than clobber it with junk.
+GENERATED_AT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["meta"]["generated_at"])' "$JSON")" \
+  || fail "export is not valid JSON with meta.generated_at: $JSON"
+echo "publish-data: export generated_at=$GENERATED_AT"
+
+# 3. A token is required — unlike the optional Slack webhook, publishing is the deliverable.
+if [ "$DRY_RUN" != 1 ] && [ -z "${GH_TOKEN:-}" ]; then
+  fail "GH_TOKEN is unset — cannot publish (add it to ~/.config/toronto-bids/tb.env)"
+fi
+
+# 4. Fresh gzip beside the json.
+gzip -9 -c "$JSON" > "$GZ" || fail "gzip failed"
+
+ASSETS=("$JSON" "$GZ" "$SQLITE")
+
+# 5. Ensure the rolling `latest` release exists, then clobber its assets.
+if ! gh_run release view latest -R "$DATA_REPO" >/dev/null 2>&1; then
+  gh_run release create latest -R "$DATA_REPO" \
+    --title "Latest data" \
+    --notes "Rolling nightly export, overwritten every night. See snapshot-* releases for point-in-time copies." \
+    || fail "could not create the 'latest' release on $DATA_REPO"
+fi
+gh_run release upload latest "${ASSETS[@]}" --clobber -R "$DATA_REPO" \
+  || fail "upload to the 'latest' release on $DATA_REPO failed"
+
+# 6. On the 1st, cut a dated snapshot for citation (idempotent — skip if it already exists).
+if [ "$DAY" = 01 ]; then
+  TAG="snapshot-$SNAPSHOT_DATE"
+  if gh_run release view "$TAG" -R "$DATA_REPO" >/dev/null 2>&1; then
+    echo "publish-data: snapshot $TAG already exists — skipping"
+  else
+    gh_run release create "$TAG" -R "$DATA_REPO" \
+      --title "Snapshot $SNAPSHOT_DATE" \
+      --notes "Point-in-time export, generated_at=$GENERATED_AT." \
+      "${ASSETS[@]}" \
+      || fail "could not create snapshot release $TAG on $DATA_REPO"
+  fi
+fi
+
+# 7. Trigger the frontend build against the new data — BEST-EFFORT. The data is already
+#    published (the acceptance curl passes); a failed downstream trigger must not report the
+#    whole publish as failed and mask that success. A warning is the right signal.
+if ! gh_run workflow run deploy.yml -R "$FRONTEND_REPO"; then
+  echo "publish-data: WARNING — could not trigger the frontend deploy on $FRONTEND_REPO (data is published)" >&2
+fi
+
+echo "publish-data: done"

--- a/deploy/tb-nightly-run.sh
+++ b/deploy/tb-nightly-run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# systemd ExecStart wrapper (#146): run the nightly, then publish the export.
+#
+# Design: docs/superpowers/specs/2026-07-19-publish-data-design.md
+#
+# publish-data.sh runs EVEN AFTER a partial/failed `tb nightly` — the export is still valid
+# whenever any rows exist — and the unit fails if EITHER step failed, so neither masks the other.
+#
+# Deliberately NOT `set -e`: publish must run regardless of the nightly's exit code, so we capture
+# each exit code and combine them ourselves rather than let the first non-zero abort the script.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+UV="${TB_NIGHTLY_UV:-$HOME/.local/bin/uv}"
+
+cd "$HERE/../scrapers" || exit 1
+
+"$UV" run tb nightly
+nightly_rc=$?
+
+"$HERE/publish-data.sh"
+publish_rc=$?
+
+if [ "$nightly_rc" -ne 0 ] || [ "$publish_rc" -ne 0 ]; then
+  echo "tb-nightly-run: nightly_rc=$nightly_rc publish_rc=$publish_rc — unit fails" >&2
+  exit 1
+fi
+echo "tb-nightly-run: nightly and publish both ok"

--- a/deploy/tb-nightly.service
+++ b/deploy/tb-nightly.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=toronto-bids nightly sync, enrich, export, notify
-Documentation=https://github.com/CivicTechTO/toronto-bids/blob/main/docs/superpowers/specs/2026-07-17-deployment-design.md
+Description=toronto-bids nightly sync, enrich, export, notify, publish
+Documentation=https://github.com/CivicTechTO/toronto-bids/blob/main/docs/superpowers/specs/2026-07-19-publish-data-design.md
 After=network-online.target
 Wants=network-online.target
 
@@ -11,8 +11,12 @@ WorkingDirectory=%h/toronto-bids/scrapers
 # live where a `git pull` cannot reach it.
 Environment=TB_DATA_DIR=%h/tb-data
 # The leading '-' makes this optional: no webhook file -> notify.post() no-ops and the run
-# still succeeds. The file holds a credential and is mode 0600; it is never in git.
+# still succeeds. The file holds credentials (TB_SLACK_WEBHOOK, GH_TOKEN) and is mode 0600;
+# it is never in git. GH_TOKEN, unlike the webhook, is required for the publish step (#146).
 EnvironmentFile=-%h/.config/toronto-bids/tb.env
-ExecStart=%h/.local/bin/uv run tb nightly
-# A full sync measures ~3 minutes (sync_run, 2026-07-16). 30m is a generous ceiling.
+# The wrapper runs `tb nightly` then publish-data.sh — publish runs even after a partial sync
+# (the export is still valid) and the unit fails if EITHER step failed, neither masking the
+# other. See docs/superpowers/specs/2026-07-19-publish-data-design.md (#146).
+ExecStart=%h/toronto-bids/deploy/tb-nightly-run.sh
+# A full sync measures ~3 minutes (sync_run, 2026-07-16); the upload adds a little. 30m ceiling.
 TimeoutStartSec=30m

--- a/docs/superpowers/specs/2026-07-19-publish-data-design.md
+++ b/docs/superpowers/specs/2026-07-19-publish-data-design.md
@@ -1,0 +1,106 @@
+# Publishing the nightly export (#146)
+
+**Date:** 2026-07-19
+**Status:** approved (derived from the frontend spec `2026-07-18-frontend-design.md`, approved
+2026-07-18), implemented.
+**Builds on:** [`2026-07-17-deployment-design.md`](2026-07-17-deployment-design.md), whose §1
+deliberately left the destination TBD ("the artifact lands on the server's disk and stops
+there"). This is that destination.
+
+## 1. What this is
+
+The nightly (`tb nightly`) writes `bids.json` to `~/tb-data/export/` on plexbox and stops. The
+frontend (`CivicTechTO/toronto-bids-frontend`) is a static site built from that artifact and
+needs it at a **stable public URL, refreshed nightly**. This adds the publish step that closes
+that gap — without touching anything behind the CLI, exactly as the deployment design wrapped
+the CLI without changing it.
+
+Publishing stays **outside** the `tb` CLI. It is a server-and-GitHub concern (a `gh` upload to a
+release), not archive logic, and the local-first goal still holds: `tb nightly` produces a valid
+local artifact with no cloud dependency, and the publish is a separate seam bolted on by the
+systemd unit. The dev laptop and CI never invoke it.
+
+## 2. Design
+
+### 2.1 Rolling `latest` release + monthly snapshots
+
+`deploy/publish-data.sh` uploads three assets to a **rolling `latest`** release on a new repo
+`CivicTechTO/toronto-bids-data`:
+
+- `bids.json` — the artifact
+- `bids.json.gz` — gzip for the frontend's fetch (bandwidth)
+- `bids.sqlite` — the queryable store (the frontend's Datasette-Lite link)
+
+```
+gh release upload latest bids.json bids.json.gz bids.sqlite --clobber -R CivicTechTO/toronto-bids-data
+```
+
+giving the stable URL `https://github.com/CivicTechTO/toronto-bids-data/releases/download/latest/bids.json`.
+GitHub serves release assets with `Access-Control-Allow-Origin: *`, which the frontend's
+browser-side Datasette-Lite link requires.
+
+On the **1st of each month** it also cuts a dated `snapshot-YYYY-MM-DD` release with the same
+assets — a point-in-time copy a researcher can cite, immune to the rolling overwrite.
+
+Then it triggers the site build:
+`gh workflow run deploy.yml -R CivicTechTO/toronto-bids-frontend`.
+
+### 2.2 Fatal vs. best-effort, deliberately
+
+- **Missing artifact, invalid JSON, missing DB, or a failed data upload → fatal** (non-zero
+  exit). Publishing the data IS the deliverable; a failure must be visible, not swallowed. This
+  is the opposite of the Slack webhook, which is a *notification* subordinate to the archive and
+  therefore optional.
+- **A missing `GH_TOKEN` → fatal**, for the same reason (unlike `TB_SLACK_WEBHOOK`, which
+  no-ops when unset).
+- **The frontend `workflow run` trigger → best-effort (warn, non-fatal).** The data is already
+  published — the acceptance `curl` passes — and letting a downstream trigger's failure report
+  the whole publish as failed would mask that success. A warning in the journal is the right
+  signal for "data is up, site rebuild didn't kick."
+
+### 2.3 Wiring: publish runs even after a partial sync, and neither step masks the other
+
+The unit's `ExecStart` becomes `deploy/tb-nightly-run.sh`, which:
+
+1. runs `tb nightly`, capturing its exit code;
+2. runs `publish-data.sh` **regardless** of that code — because the export is valid whenever any
+   rows exist, and a good artifact must not be withheld over one bad feed (the nightly's own
+   per-step isolation ethos, extended one level out);
+3. exits non-zero if **either** step failed.
+
+`&&` would be wrong twice over: `tb nightly` exits non-zero on a *partial* sync (any source
+failed), which must still publish; and a publish failure must not hide a nightly failure or vice
+versa. So both always run and the wrapper propagates the max.
+
+If the sync fails catastrophically (the DB never opens, no export written), `publish-data.sh`
+finds no `bids.json` and fails — correct: there is genuinely nothing to publish, and the unit is
+already failing on the nightly.
+
+### 2.4 The token is a credential; this repo is public
+
+`GH_TOKEN` lives beside the Slack webhook in `~/.config/toronto-bids/tb.env` (mode `0600`, never
+in git), pulled in by the unit's existing `EnvironmentFile=-`. It needs `repo` scope on
+`toronto-bids-data` (release write) and `workflow` scope on `toronto-bids-frontend` (dispatch).
+
+### 2.5 Offline self-test
+
+`TB_PUBLISH_DRY_RUN=1 deploy/publish-data.sh` prints every `gh` command instead of running it,
+after doing the real artifact/JSON checks and gzip — so the operator (and CI-free local dev) can
+confirm the logic against a real export without a token or the data repo existing. The snapshot
+day and date are overridable (`TB_PUBLISH_DAY`, `TB_PUBLISH_DATE`) so the 1st-of-month path is
+testable on any day. Repo names are overridable (`TB_DATA_REPO`, `TB_FRONTEND_REPO`) for a fork.
+
+## 3. Acceptance
+
+- After a nightly run, `curl -sIL .../releases/download/latest/bids.json` returns 200; the fetched
+  body carries a fresh `generated_at`.
+- A partial-sync night still publishes (the export is valid) and the unit still reports failure.
+- A publish failure (no network/token) does not mask a nightly failure, and vice versa — both run,
+  the wrapper propagates whichever failed.
+
+## 4. Out of scope / prerequisites the operator does once
+
+- **Creating `CivicTechTO/toronto-bids-data`** (a one-time GitHub action) and installing the `gh`
+  CLI on plexbox. Documented in `deploy/README.md`.
+- The frontend repo's `deploy.yml` — owned by the frontend project; until it exists the trigger
+  warns and the data still publishes.


### PR DESCRIPTION
Fixes #146.

The nightly writes `bids.json` to the server's disk and stops ("destination TBD"). The static frontend (`toronto-bids-frontend`) is built from that artifact and needs it at a **stable public URL, refreshed nightly**. This adds the publish step — outside the `tb` CLI (a server + GitHub concern, not archive logic; the local-first goal still holds), wired at the systemd level exactly as the deployment design wrapped the CLI without changing it.

Design: `docs/superpowers/specs/2026-07-19-publish-data-design.md`.

## What's built

- **`deploy/publish-data.sh`** — uploads `bids.json`, `bids.json.gz`, `bids.sqlite` to a rolling **`latest`** release on `CivicTechTO/toronto-bids-data`, giving `.../releases/download/latest/bids.json` (GitHub serves release assets with `Access-Control-Allow-Origin: *`, which the frontend's Datasette-Lite link needs). On the **1st of each month** it also cuts a dated `snapshot-YYYY-MM-DD` release (point-in-time citation), then triggers the frontend build (`gh workflow run deploy.yml`, best-effort).
- **`deploy/tb-nightly-run.sh`** — the new `ExecStart`. Runs `tb nightly`, then `publish-data.sh` **regardless of the nightly's exit**, and fails the unit if **either** step failed. `&&` would be wrong twice: a *partial* sync exits non-zero yet must still publish (the export is valid), and a publish failure must not hide a nightly failure or vice versa.
- **`GH_TOKEN`** — required (unlike the optional Slack webhook — publishing is the deliverable, so a missing token fails loudly). Lives beside the webhook in `~/.config/toronto-bids/tb.env` (mode `0600`, never in git).
- **`TB_PUBLISH_DRY_RUN=1`** — prints every `gh` command instead of running it (offline self-test), after the real artifact/JSON checks and gzip.

## Acceptance

- ✅ Rolling `latest` release gives a stable URL; the emitted upload command produces exactly `.../releases/download/latest/bids.json`.
- ✅ A partial-sync night still publishes (export is valid) **and** the unit still reports failure.
- ✅ A publish failure (no network/token) does not mask a nightly failure, and vice versa.

## Verification

Driven end-to-end against a **real** `tb export` in dry-run — this caught a bug a fixture wouldn't (`generated_at` is nested under `meta`, not top-level; fixed):

| Scenario | Result |
|---|---|
| happy path (normal day) | uploads `latest` + triggers frontend, exit 0; gzip valid |
| 1st-of-month | also cuts the snapshot release |
| missing artifact | fatal, exit 1 |
| no `GH_TOKEN` (real run) | fatal **before any `gh` call**, exit 1 |
| nightly ok + publish ok | wrapper exit 0 |
| **nightly fail + publish ok** | **publish ran, unit exit 1** |
| nightly ok + publish fail | exit 1 (not masked) |
| nightly fail + publish fail | exit 1 |

The live `curl → 200` is the operator's one-time step (needs the data repo + token + a server run); the dry-run prints the exact command that yields that URL.

## Operator one-time steps (documented in `deploy/README.md`)

- `sudo apt install -y gh`, create the public `CivicTechTO/toronto-bids-data` repo, add `GH_TOKEN` to `tb.env`.

Blocks frontend deploy (frontend plan Task 22); the frontend can be built/tested against a local export in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
