### PR TITLE
fix(deploy): publish accepts an existing gh login, not just GH_TOKEN (#146)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,18 +40,20 @@ chmod 600 ~/.config/toronto-bids/tb.env
 
 Unset the webhook and `tb nightly` still runs — it just posts nothing.
 
-The **`GH_TOKEN`** is what `deploy/publish-data.sh` uses to upload the nightly export (see
-**Publishing the export**, below). It
-needs `repo` scope on `CivicTechTO/toronto-bids-data` (release write) and `workflow` scope on
-`CivicTechTO/toronto-bids-frontend` (deploy dispatch). Append it to the same file:
+**Publishing** (see **Publishing the export**, below) needs `gh` to be **authenticated** with
+`repo` scope on `CivicTechTO/toronto-bids-data` (release write) and `workflow` scope on
+`CivicTechTO/toronto-bids-frontend` (deploy dispatch). Either works:
 
-```shell
-read -rs T && printf 'GH_TOKEN=%s\n' "$T" >> ~/.config/toronto-bids/tb.env
-chmod 600 ~/.config/toronto-bids/tb.env
-```
+- **A prior `gh auth login` on the box** (check with `gh auth status`) — nothing to add here; or
+- **A `GH_TOKEN`** appended to the same env file, for an unattended service token:
 
-Unlike the webhook, `GH_TOKEN` is **required** for publishing — the nightly's publish step fails
-loudly without it (publishing is the deliverable, not a notification).
+  ```shell
+  read -rs T && printf 'GH_TOKEN=%s\n' "$T" >> ~/.config/toronto-bids/tb.env
+  chmod 600 ~/.config/toronto-bids/tb.env
+  ```
+
+Unlike the webhook, authentication is **required** for publishing — the nightly's publish step
+fails loudly if `gh auth status` fails (publishing is the deliverable, not a notification).
 
 ## 4. Units
 

--- a/deploy/publish-data.sh
+++ b/deploy/publish-data.sh
@@ -56,9 +56,12 @@ GENERATED_AT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[
   || fail "export is not valid JSON with meta.generated_at: $JSON"
 echo "publish-data: export generated_at=$GENERATED_AT"
 
-# 3. A token is required — unlike the optional Slack webhook, publishing is the deliverable.
-if [ "$DRY_RUN" != 1 ] && [ -z "${GH_TOKEN:-}" ]; then
-  fail "GH_TOKEN is unset — cannot publish (add it to ~/.config/toronto-bids/tb.env)"
+# 3. gh must be authenticated — unlike the optional Slack webhook, publishing is the deliverable,
+#    so unauthenticated is a hard failure. Either a GH_TOKEN in the environment (an unattended
+#    service token) or a prior `gh auth login` on the box satisfies this; `gh auth status` covers
+#    both, so we don't force a duplicate credential onto a box where gh is already logged in.
+if [ "$DRY_RUN" != 1 ] && ! gh auth status >/dev/null 2>&1; then
+  fail "gh is not authenticated — set GH_TOKEN in ~/.config/toronto-bids/tb.env or run 'gh auth login'"
 fi
 
 # 4. Fresh gzip beside the json.

--- a/deploy/tb-nightly.service
+++ b/deploy/tb-nightly.service
@@ -11,8 +11,9 @@ WorkingDirectory=%h/toronto-bids/scrapers
 # live where a `git pull` cannot reach it.
 Environment=TB_DATA_DIR=%h/tb-data
 # The leading '-' makes this optional: no webhook file -> notify.post() no-ops and the run
-# still succeeds. The file holds credentials (TB_SLACK_WEBHOOK, GH_TOKEN) and is mode 0600;
-# it is never in git. GH_TOKEN, unlike the webhook, is required for the publish step (#146).
+# still succeeds. The file holds credentials (TB_SLACK_WEBHOOK, optional GH_TOKEN) and is mode
+# 0600; it is never in git. Publishing requires gh to be authenticated (a GH_TOKEN here OR a
+# prior `gh auth login` on the box) — the publish step fails loudly otherwise (#146).
 EnvironmentFile=-%h/.config/toronto-bids/tb.env
 # The wrapper runs `tb nightly` then publish-data.sh — publish runs even after a partial sync
 # (the export is still valid) and the unit fails if EITHER step failed, neither masking the

--- a/docs/superpowers/specs/2026-07-19-publish-data-design.md
+++ b/docs/superpowers/specs/2026-07-19-publish-data-design.md
@@ -51,8 +51,10 @@ Then it triggers the site build:
   exit). Publishing the data IS the deliverable; a failure must be visible, not swallowed. This
   is the opposite of the Slack webhook, which is a *notification* subordinate to the archive and
   therefore optional.
-- **A missing `GH_TOKEN` → fatal**, for the same reason (unlike `TB_SLACK_WEBHOOK`, which
-  no-ops when unset).
+- **Unauthenticated `gh` → fatal**, for the same reason (unlike `TB_SLACK_WEBHOOK`, which
+  no-ops when unset). The check is `gh auth status`, satisfied by either a `GH_TOKEN` in the
+  environment (an unattended service token) or a prior `gh auth login` on the box — so a box
+  where `gh` is already logged in needs no duplicate credential.
 - **The frontend `workflow run` trigger → best-effort (warn, non-fatal).** The data is already
   published — the acceptance `curl` passes — and letting a downstream trigger's failure report
   the whole publish as failed would mask that success. A warning in the journal is the right
@@ -76,11 +78,13 @@ If the sync fails catastrophically (the DB never opens, no export written), `pub
 finds no `bids.json` and fails — correct: there is genuinely nothing to publish, and the unit is
 already failing on the nightly.
 
-### 2.4 The token is a credential; this repo is public
+### 2.4 Authentication; this repo is public
 
-`GH_TOKEN` lives beside the Slack webhook in `~/.config/toronto-bids/tb.env` (mode `0600`, never
-in git), pulled in by the unit's existing `EnvironmentFile=-`. It needs `repo` scope on
-`toronto-bids-data` (release write) and `workflow` scope on `toronto-bids-frontend` (dispatch).
+Publishing needs `gh` authenticated with `repo` scope on `toronto-bids-data` (release write) and
+`workflow` scope on `toronto-bids-frontend` (dispatch). Either a prior `gh auth login` on the box
+or a `GH_TOKEN` satisfies it. A `GH_TOKEN`, if used, is a credential and lives beside the Slack
+webhook in `~/.config/toronto-bids/tb.env` (mode `0600`, never in git), pulled in by the unit's
+existing `EnvironmentFile=-`.
 
 ### 2.5 Offline self-test
 


### PR DESCRIPTION
Follow-up to #146/#149, surfaced while executing #150 on plexbox.

`publish-data.sh` hard-required `GH_TOKEN`, so it would fail on a host where `gh` is already authenticated via `gh auth login` — which is exactly the plexbox setup (org-admin login with `repo`+`workflow` scopes). That forced a duplicate credential into `tb.env` for no benefit.

**Fix:** replace the `[ -z "$GH_TOKEN" ]` check with `gh auth status`, satisfied by either a service token in the environment or a prior interactive login. README, unit comment, and design spec updated to say 'gh must be authenticated (GH_TOKEN or gh auth login)'.

**Verified on plexbox:** dry-run unchanged; the real path now passes the auth gate on the existing login and proceeds to the `gh` call (previously it died at `GH_TOKEN is unset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE