### PR TITLE
feat(nightly): expand the Slack report — per-step, per-source, growth & failures

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -144,6 +144,10 @@ https://github.com/CivicTechTO/toronto-bids-data/releases/download/latest/bids.j
 On the 1st of each month it also cuts a dated `snapshot-YYYY-MM-DD` release (point-in-time
 citation), then triggers the frontend build (`gh workflow run deploy.yml`, best-effort).
 
+The nightly posts two Slack messages: `tb nightly` posts the rich archive report first, then
+`publish-data.sh` posts a one-line publish result (✅ + release URL, or ❌ + reason). Both use
+`TB_SLACK_WEBHOOK` and both no-op silently when it is unset.
+
 **One-time prerequisites** (do these before the first publish):
 
 ```shell

--- a/deploy/publish-data.sh
+++ b/deploy/publish-data.sh
@@ -35,7 +35,22 @@ DAY="${TB_PUBLISH_DAY:-$(date +%d)}"
 SNAPSHOT_DATE="${TB_PUBLISH_DATE:-$(date +%F)}"
 DRY_RUN="${TB_PUBLISH_DRY_RUN:-0}"
 
-fail() { echo "publish-data: $*" >&2; exit 1; }
+# Post one line to Slack (best-effort). The webhook is a credential and this repo is public, so
+# it is passed ONLY as the curl URL — never echoed or logged. No webhook -> no-op; dry-run echoes.
+slack_notify() {
+  local msg="$1"
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "DRY-RUN slack: $msg"
+    return 0
+  fi
+  [ -n "${TB_SLACK_WEBHOOK:-}" ] || return 0
+  curl -s -o /dev/null --max-time 15 \
+    -H 'Content-Type: application/json' \
+    --data "$(printf '{"text": %s}' "$(printf '%s' "$msg" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")" \
+    "$TB_SLACK_WEBHOOK" || echo "publish-data: WARNING — slack post failed" >&2
+}
+
+fail() { slack_notify "❌ toronto-bids publish — $*"; echo "publish-data: $*" >&2; exit 1; }
 
 gh_run() {
   if [ "$DRY_RUN" = 1 ]; then
@@ -118,5 +133,7 @@ fi
 if ! gh_run workflow run deploy.yml -R "$FRONTEND_REPO"; then
   echo "publish-data: WARNING — could not trigger the frontend deploy on $FRONTEND_REPO (data is published)" >&2
 fi
+
+slack_notify "✅ toronto-bids publish — latest release updated · ${GENERATED_AT} · https://github.com/${DATA_REPO}/releases/tag/latest"
 
 echo "publish-data: done"

--- a/docs/superpowers/plans/2026-07-19-nightly-slack-report.md
+++ b/docs/superpowers/plans/2026-07-19-nightly-slack-report.md
@@ -1,0 +1,661 @@
+# Expanded Nightly Slack Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the nightly's one-line Slack notification with a multi-section mrkdwn report (Steps / Sources / Growth / Failures), and have `publish-data.sh` post a separate one-line publish result.
+
+**Architecture:** A pure `summarize(report: dict) -> str` renders the whole message and degrades gracefully over a partial `report` (missing sections just don't appear). `_cmd_nightly` assembles the `report` — first from data it already has (Task 2), then enriched with structured per-step records and this-run `sync_run` rows (Task 3). The publish line is a guarded bash `slack_notify` in `publish-data.sh` (Task 4). Delivering the formatter and the plumbing in that order keeps every task green and independently shippable.
+
+**Tech Stack:** Python 3.12, `uv`, pytest (offline, `monkeypatch`). Bash + `curl` for the publish line. Slack renders mrkdwn inside the `{"text": …}` payload — no Block Kit.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-19-nightly-slack-report-design.md`.
+- **No lint/format/typecheck exists** — the only check is `uv run pytest` from `scrapers/`. Don't invent tooling.
+- **`summarize` stays pure** (no I/O, no `db`/network) and total over a partial `report` — a missing key degrades to an omitted section, never a `KeyError`.
+- **The webhook is a credential and this repo is public.** Never log or echo `TB_SLACK_WEBHOOK`. `notify.post` already logs only status codes / exception *types*; the new bash `slack_notify` must pass the webhook only as the curl URL, never in an echoed/logged string.
+- **The exit-code contract is unchanged:** `_cmd_nightly` returns 1 iff there was any failure. The expansion changes *presentation only* — not what counts as a failure.
+- **Isolation preserved:** every nightly step stays wrapped so a raising step never stops later steps, the export, or the post.
+- **Every-run posting is retained** (the heartbeat: silence = the timer never fired).
+- Commit trailers on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
+  ```
+- Branch `feat-nightly-slack-report` (already checked out). Do not commit to `main`.
+
+## File Structure
+
+- `scrapers/toronto_bids/store/db.py` — add `sync_runs_since(conn, after_id)` (Task 1).
+- `scrapers/toronto_bids/notify.py` — rewrite `summarize` to `summarize(report: dict)` + section helpers (Task 2).
+- `scrapers/toronto_bids/cli.py` — `_cmd_nightly`: build `report` and call new `summarize` (Task 2); add `_run_step` + `steps`/`sources` bookkeeping (Task 3).
+- `scrapers/tests/test_notify.py` — rewrite for the report form (Task 2).
+- `scrapers/tests/test_nightly.py` — assert the new message sections (Tasks 2, 3).
+- `scrapers/tests/test_db.py` (or nearest existing db test file) — `sync_runs_since` (Task 1).
+- `deploy/publish-data.sh`, `deploy/README.md` — publish Slack line (Task 4).
+
+---
+
+## Task 1: `db.sync_runs_since` — this-run per-source rows
+
+**Files:**
+- Modify: `scrapers/toronto_bids/store/db.py` (near `finish_sync_run` ~line 277)
+- Test: `scrapers/tests/test_db.py` (create if absent; otherwise append)
+
+**Interfaces:**
+- Produces: `sync_runs_since(conn, after_id: int) -> list[dict]` — every `sync_run` row with `id > after_id`, ordered by `id`, each a dict with keys `source, status, rows_fetched, rows_upserted, error`.
+- Consumes: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create/append `scrapers/tests/test_db.py`:
+
+```python
+from toronto_bids.store import db
+
+
+def test_sync_runs_since_returns_only_newer_rows(conn):
+    r1 = db.start_sync_run(conn, "odata_solicitations")
+    db.finish_sync_run(conn, r1, status="ok", rows_fetched=7446, rows_upserted=12)
+    cutoff = r1
+    r2 = db.start_sync_run(conn, "ariba_discovery")
+    db.finish_sync_run(conn, r2, status="ok", rows_fetched=1670, rows_upserted=0)
+    r3 = db.start_sync_run(conn, "ckan_awarded")
+    db.finish_sync_run(conn, r3, status="failed", rows_fetched=0, rows_upserted=0, error="boom")
+
+    rows = db.sync_runs_since(conn, cutoff)
+    assert [r["source"] for r in rows] == ["ariba_discovery", "ckan_awarded"]
+    assert rows[0]["rows_fetched"] == 1670 and rows[0]["rows_upserted"] == 0
+    assert rows[1]["status"] == "failed" and rows[1]["error"] == "boom"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd scrapers && uv run pytest tests/test_db.py -v`
+Expected: FAIL — `db.sync_runs_since` does not exist.
+
+- [ ] **Step 3: Implement**
+
+In `db.py`, after `finish_sync_run`:
+
+```python
+def sync_runs_since(conn, after_id: int) -> list[dict]:
+    """Every sync_run row newer than after_id, oldest first — one nightly's per-source detail.
+
+    Capture MAX(id) before pipeline.sync, pass it here after, and you get exactly the rows that
+    run wrote (sync_run.id is autoincrement).
+    """
+    cur = conn.execute(
+        "SELECT source, status, rows_fetched, rows_upserted, error "
+        "FROM sync_run WHERE id > ? ORDER BY id", (after_id,))
+    cols = [c[0] for c in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd scrapers && uv run pytest tests/test_db.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `cd scrapers && uv run pytest -q` (expect all pass), then:
+
+```bash
+git add scrapers/toronto_bids/store/db.py scrapers/tests/test_db.py
+git commit -m "feat(db): sync_runs_since — a nightly's per-source rows for the report
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE"
+```
+
+---
+
+## Task 2: Rewrite `summarize` to the report form; wire `_cmd_nightly` to it
+
+**Files:**
+- Modify: `scrapers/toronto_bids/notify.py` (`summarize` ~line 40; keep `_count`, `_elapsed`, `_HEADLINE`)
+- Modify: `scrapers/toronto_bids/cli.py` (`_cmd_nightly` — the `text = notify.summarize(...)` call ~line 480, and assemble a `report` dict)
+- Test: `scrapers/tests/test_notify.py` (rewrite), `scrapers/tests/test_nightly.py` (adjust message assertions)
+
+**Interfaces:**
+- Produces: `summarize(report: dict) -> str`. `report` keys (all optional; summarize is total over partials): `ok: bool`, `steps: list[dict]`, `sources: list[dict]`, `before: dict`, `after: dict`, `failures: list[tuple[str,str]]`, `export_bytes: int|None`, `elapsed_s: float`. Step dict: `{name, status: "ok"|"fail"|"skip", detail: str, seconds: float, error: str|None}`. Source dict: `{source, status, rows_fetched, rows_upserted, error}`.
+- Consumes: nothing from other tasks (Task 3 fills `steps`/`sources`; this task leaves them `[]`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the body of `scrapers/tests/test_notify.py` (keep the existing `post`-related tests if any; replace the `summarize` tests) with report-based tests:
+
+```python
+from toronto_bids import notify
+
+
+def _counts(**kw):
+    base = {k: 0 for k in ("solicitation", "award", "bid", "supplier",
+                           "agency_award", "agency_bid", "ariba_attachment")}
+    base.update(kw)
+    return base
+
+
+def test_clean_run_header_and_growth():
+    report = {"ok": True, "before": _counts(solicitation=7434, bid=18605),
+              "after": _counts(solicitation=7446, bid=18632),
+              "failures": [], "export_bytes": 32_651_042, "elapsed_s": 3484.0}
+    text = notify.summarize(report)
+    assert text.startswith("*✅ toronto-bids nightly* · 58m04s")
+    assert "*Growth*" in text
+    assert "solicitations 7,446 (+12)" in text
+    assert "bids 18,632 (+27)" in text
+    assert "*Failures*" not in text
+
+
+def test_failed_run_header_and_failures_section():
+    report = {"ok": False, "before": _counts(), "after": _counts(),
+              "failures": [("ariba_attachments", "TimeoutError on Respond")],
+              "export_bytes": 1000, "elapsed_s": 61.0}
+    text = notify.summarize(report)
+    assert text.startswith("*❌ toronto-bids nightly*")
+    assert "*Failures (1)*" in text
+    assert "ariba_attachments: TimeoutError on Respond" in text
+
+
+def test_steps_section_renders_status_detail_and_skip():
+    report = {"ok": True, "before": _counts(), "after": _counts(), "failures": [],
+              "steps": [
+                  {"name": "sync", "status": "ok", "detail": "9/9 sources", "seconds": 192.0, "error": None},
+                  {"name": "council", "status": "skip", "detail": "not the 1st", "seconds": 0.0, "error": None},
+                  {"name": "ariba attachments", "status": "fail", "detail": "", "seconds": 2880.0, "error": "boom"},
+              ],
+              "export_bytes": 1000, "elapsed_s": 3600.0}
+    text = notify.summarize(report)
+    assert "*Steps*" in text
+    assert "✅ sync  9/9 sources · 3m12s" in text
+    assert "➖ council  not the 1st" in text
+    assert "❌ ariba attachments  boom · 48m0" in text[:1000] or "❌ ariba attachments  boom · 48m00s" in text
+
+
+def test_sources_section_flags_zero_fetch():
+    report = {"ok": True, "before": _counts(), "after": _counts(), "failures": [],
+              "sources": [
+                  {"source": "odata_solicitations", "status": "ok", "rows_fetched": 7446, "rows_upserted": 12, "error": None},
+                  {"source": "suspended_firms", "status": "ok", "rows_fetched": 0, "rows_upserted": 0, "error": None},
+              ],
+              "export_bytes": 1000, "elapsed_s": 60.0}
+    text = notify.summarize(report)
+    assert "*Sources* (fetched → new)" in text
+    assert "odata_solicitations 7,446 → +12" in text
+    assert "⚠ suspended_firms 0 fetched" in text
+
+
+def test_nothing_moved_omits_growth_and_empty_before_suppresses_deltas():
+    same = _counts(solicitation=10)
+    assert "*Growth*" not in notify.summarize(
+        {"ok": True, "before": same, "after": same, "failures": [], "export_bytes": 1, "elapsed_s": 1.0})
+    # empty before => before-count failed => no fabricated deltas
+    assert "*Growth*" not in notify.summarize(
+        {"ok": True, "before": {}, "after": _counts(bid=5), "failures": [], "export_bytes": 1, "elapsed_s": 1.0})
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_notify.py -v`
+Expected: FAIL — `summarize` has the old signature.
+
+- [ ] **Step 3: Rewrite `summarize` and add section helpers**
+
+In `notify.py`, keep `_elapsed` and `post`. Replace `_HEADLINE`/`_count`/`_seg`/`summarize` with:
+
+```python
+_STEP_ICON = {"ok": "✅", "fail": "❌", "skip": "➖"}
+
+# Nicer labels for the Growth section; unlisted tables fall back to the raw key.
+_LABELS = {
+    "solicitation": "solicitations", "award": "awards", "bid": "bids", "supplier": "suppliers",
+    "noncompetitive": "noncompetitive", "ariba_posting": "ariba postings",
+    "suspended_firm": "suspended firms", "capital_project": "capital projects",
+    "council_item": "council items", "background_pdf": "background pdfs",
+    "composite_award": "composite awards", "agency_solicitation": "agency solicitations",
+    "agency_award": "agency awards", "agency_bid": "agency bids",
+    "ariba_attachment": "ariba files",
+}
+# Housekeeping tables whose growth is noise in a report about the archive.
+_GROWTH_SKIP = {"sync_run", "buyer"}
+
+
+def _growth(before: dict, after: dict) -> list[str]:
+    """'solicitations 7,446 (+12)' for every table that grew. Empty `before` (the count step
+    failed) yields nothing — a delta against a zero nobody measured is a fabricated number."""
+    if not before:
+        return []
+    out = []
+    for key, now in after.items():
+        if key in _GROWTH_SKIP:
+            continue
+        delta = now - before.get(key, 0)
+        if delta:
+            out.append(f"{_LABELS.get(key, key)} {now:,} ({delta:+,})")
+    return out
+
+
+def summarize(report: dict) -> str:
+    """The nightly message — multi-section Slack mrkdwn. Pure and total over a partial report:
+    a missing/empty section is simply omitted, never a KeyError, because the report itself must
+    never be the thing that fails the run it exists to make visible.
+    """
+    before = report.get("before", {})
+    after = report.get("after", {})
+    failures = report.get("failures", [])
+    steps = report.get("steps", [])
+    sources = report.get("sources", [])
+    export_bytes = report.get("export_bytes")
+    elapsed_s = report.get("elapsed_s", 0.0)
+    ok = report.get("ok", not failures)
+
+    lines = [f"*{'✅' if ok else '❌'} toronto-bids nightly* · {_elapsed(elapsed_s)}"]
+
+    if steps:
+        lines += ["", "*Steps*"]
+        for s in steps:
+            icon = _STEP_ICON.get(s.get("status"), "•")
+            detail = s.get("detail") or s.get("error") or ""
+            dur = s.get("seconds") or 0.0
+            suffix = f" · {_elapsed(dur)}" if dur >= 1 else ""
+            lines.append(f"{icon} {s.get('name', '?')}  {detail}{suffix}".rstrip())
+
+    if sources:
+        lines += ["", "*Sources* (fetched → new)"]
+        ok_segs, warns = [], []
+        for r in sources:
+            fetched = r.get("rows_fetched", 0) or 0
+            new = r.get("rows_upserted", 0) or 0
+            if r.get("status") != "ok" or fetched == 0:
+                extra = "" if r.get("status") == "ok" else f" ({r.get('status')})"
+                warns.append(f"⚠ {r.get('source', '?')} {fetched:,} fetched{extra}")
+            else:
+                ok_segs.append(f"{r.get('source', '?')} {fetched:,} → +{new:,}")
+        if ok_segs:
+            lines.append(" · ".join(ok_segs))
+        lines += warns
+
+    growth = _growth(before, after)
+    if growth:
+        lines += ["", "*Growth*", " · ".join(growth)]
+
+    lines += ["", f"export {'FAILED' if export_bytes is None else f'{export_bytes / 1_048_576:.1f} MiB'}"]
+
+    if failures:
+        lines += ["", f"*Failures ({len(failures)})*"]
+        lines += [f"{name}: {error}" for name, error in failures]
+
+    return "\n".join(lines)
+```
+
+Note the test `test_steps_section_renders_status_detail_and_skip` expects `"❌ ariba attachments  boom · 48m00s"` — `_elapsed(2880.0)` is `48m00s`; the test's `or` accepts it. Confirm `_elapsed` renders `192.0 → "3m12s"` and `2880.0 → "48m00s"`.
+
+- [ ] **Step 4: Wire `_cmd_nightly` to build a `report` and call the new `summarize`**
+
+In `_cmd_nightly`, replace the final summarize/post block:
+
+```python
+    text = notify.summarize(before, after, failures, len(pipeline.default_sources()),
+                            export_bytes, time.monotonic() - started)
+    print(text)
+    for name, error in failures:
+        print(f"FAILED  {name}: {error}", file=sys.stderr)
+    notify.post(text, log=lambda m: print(m, file=sys.stderr))
+    return 1 if failures else 0
+```
+
+with:
+
+```python
+    report = {
+        "ok": not failures,
+        "steps": steps,            # populated in Task 3; [] here
+        "sources": sources,        # populated in Task 3; [] here
+        "before": before,
+        "after": after,
+        "failures": failures,
+        "export_bytes": export_bytes,
+        "elapsed_s": time.monotonic() - started,
+    }
+    text = notify.summarize(report)
+    print(text)
+    for name, error in failures:
+        print(f"FAILED  {name}: {error}", file=sys.stderr)
+    notify.post(text, log=lambda m: print(m, file=sys.stderr))
+    return 1 if failures else 0
+```
+
+And near the top of `_cmd_nightly` (with the other init vars `failures = []`, `before = {}`), add:
+
+```python
+    steps: list[dict] = []
+    sources: list[dict] = []
+```
+
+- [ ] **Step 5: Adjust `test_nightly.py` message assertions**
+
+Find any nightly test that asserts on the old one-line format (e.g. substrings like `"9/9 sources ok"` or `"toronto-bids —"`). Update them to the new header: a clean run's posted text starts with `"*✅ toronto-bids nightly*"`, a failed run with `"*❌ toronto-bids nightly*"`, and a failed step appears under `"*Failures"`. Do NOT weaken the exit-code assertions (still `== 0` / `== 1`). Run `grep -n "toronto-bids\|sources ok\|summarize" tests/test_nightly.py` to find them.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd scrapers && uv run pytest tests/test_notify.py tests/test_nightly.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Full suite + commit**
+
+Run: `cd scrapers && uv run pytest -q` (all pass), then:
+
+```bash
+git add scrapers/toronto_bids/notify.py scrapers/toronto_bids/cli.py scrapers/tests/test_notify.py scrapers/tests/test_nightly.py
+git commit -m "feat(nightly): multi-section Slack report (Growth + Failures sections)
+
+summarize now takes a report dict and renders multi-line mrkdwn, degrading
+gracefully over a partial report. _cmd_nightly assembles the report from the
+data it already has; steps/sources sections arrive next.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE"
+```
+
+---
+
+## Task 3: Structured per-step + per-source bookkeeping in `_cmd_nightly`
+
+**Files:**
+- Modify: `scrapers/toronto_bids/cli.py` (`_cmd_nightly`; add module-level `_run_step`)
+- Test: `scrapers/tests/test_nightly.py`
+
+**Interfaces:**
+- Consumes: `db.sync_runs_since` (Task 1); the `report` assembly + `steps`/`sources` vars (Task 2); `summarize` already renders these sections (Task 2).
+- Produces: `_run_step(steps, failures, name, fn) -> None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `scrapers/tests/test_nightly.py`:
+
+```python
+def test_report_has_a_steps_section_naming_each_step(nightly, monkeypatch):
+    posted = {}
+    from toronto_bids import notify
+    monkeypatch.setattr(notify, "post", lambda text, **k: posted.setdefault("text", text))
+    nightly()
+    t = posted["text"]
+    assert "*Steps*" in t
+    for name in ("sync", "award summaries", "ariba attachments", "agencies", "export"):
+        assert name in t
+
+
+def test_a_failed_step_appears_in_both_failures_and_steps(nightly, monkeypatch):
+    posted = {}
+    from toronto_bids import notify
+    monkeypatch.setattr(notify, "post", lambda text, **k: posted.setdefault("text", text))
+    from toronto_bids.sources import ariba_attachments
+    monkeypatch.setattr(ariba_attachments, "capture_attachments",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("browser died")))
+    assert nightly() == 1
+    t = posted["text"]
+    assert "*Failures (1)*" in t
+    assert "browser died" in t
+    assert "❌ ariba attachments" in t
+
+
+def test_run_step_records_ok_and_isolates_failure():
+    from toronto_bids import cli
+    steps, failures = [], []
+    cli._run_step(steps, failures, "demo", lambda: "+3 things")
+    assert steps[0]["status"] == "ok" and steps[0]["detail"] == "+3 things"
+    cli._run_step(steps, failures, "boom", lambda: (_ for _ in ()).throw(RuntimeError("x")))
+    assert steps[1]["status"] == "fail" and steps[1]["error"] == "x"
+    assert failures == [("boom", "x")]   # failure mirrored for the exit-code contract
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_nightly.py -k "steps or failed_step or run_step" -v`
+Expected: FAIL — `_run_step` doesn't exist; no Steps section yet.
+
+- [ ] **Step 3: Add `_run_step`**
+
+In `cli.py`, module-level (near `_is_first_of_month`):
+
+```python
+def _run_step(steps: list, failures: list, name: str, fn) -> None:
+    """Run one nightly step, timing it and recording a step record. On failure the error is
+    ALSO appended to `failures` — the authoritative list the exit code and the report's Failures
+    section read — so the exit-code contract is untouched while the Steps section gains status +
+    timing. `fn` returns a short detail string (or None)."""
+    import time
+    t = time.monotonic()
+    try:
+        detail = fn()
+        steps.append({"name": name, "status": "ok", "detail": detail or "",
+                      "seconds": time.monotonic() - t, "error": None})
+    except Exception as exc:  # isolation: never propagates
+        steps.append({"name": name, "status": "fail", "detail": "",
+                      "seconds": time.monotonic() - t, "error": str(exc)})
+        failures.append((name, str(exc)))
+```
+
+- [ ] **Step 4: Convert `_cmd_nightly`'s steps to `_run_step` + record sources**
+
+Rewrite the capture section of `_cmd_nightly`. Replace the inner `try: … finally: http.close()` block (the sync/award/portal/ariba/agencies/council sequence) so each step goes through `_run_step` and returns a detail string, and capture the sync_run cutoff around sync. Concretely:
+
+Before `pipeline.sync`, record the cutoff:
+```python
+            try:
+                sync_cutoff = conn.execute("SELECT COALESCE(MAX(id), 0) FROM sync_run").fetchone()[0]
+            except Exception:
+                sync_cutoff = 0
+```
+
+Sync step (special — pipeline.sync returns per-source failures, not an exception):
+```python
+                def _sync():
+                    src_failures = pipeline.sync(conn, http)
+                    failures.extend(src_failures)
+                    n = len(pipeline.default_sources())
+                    ok_n = n - len([f for f in src_failures if ":" not in f[0]])
+                    return f"{ok_n}/{n} sources"
+                _run_step(steps, failures, "sync", _sync)
+```
+(Note: `pipeline.sync` also runs linking passes whose failures land in `src_failures`; the `ok_n` count is a headline, not exact — the Sources section carries the precise per-source truth. Keep it simple: `return f"{n} sources"` is acceptable if the ok-count is awkward; the reviewer may simplify.)
+
+Then read this-run sources right after sync:
+```python
+                try:
+                    sources.extend(db.sync_runs_since(conn, sync_cutoff))
+                except Exception as exc:
+                    failures.append(("sync_detail", str(exc)))
+```
+
+Award summaries:
+```python
+                def _awards():
+                    download_award_summaries(conn, http, log=out)
+                    return f"{store_award_summary_bids(conn, log=out)} bids stored"
+                _run_step(steps, failures, "award summaries", _awards)
+```
+(Confirm `store_award_summary_bids` returns an int count; if it returns None, use `store_award_summary_bids(conn, log=out); return ""`.)
+
+Portal:
+```python
+                def _portal():
+                    from toronto_bids.sources.bids_tenders import run_portal_capture
+                    res = run_portal_capture(conn, log=out)
+                    for slug, v in res.items():
+                        if isinstance(v, str) and v.startswith("FAILED"):
+                            failures.append((f"portal:{slug}", v))
+                    total = sum(v for v in res.values() if isinstance(v, int))
+                    return f"{total} listings" if total else "no open bids"
+                _run_step(steps, failures, "portal", _portal)
+```
+
+Ariba attachments:
+```python
+                def _ariba():
+                    from toronto_bids.sources import ariba_attachments as aa
+                    n = aa.capture_attachments(conn, log=out, virtual_display=True)
+                    return f"+{n} bundles"
+                _run_step(steps, failures, "ariba attachments", _ariba)
+```
+
+Agencies (detail from the agency_* count delta around the step):
+```python
+                def _agencies():
+                    from toronto_bids.buyers import seed_buyers
+                    a0 = db.counts(conn)
+                    ids = seed_buyers(conn)
+                    failures.extend(_capture_agency_bodies(
+                        conn, ids, bodies=["trca", "zoo", "ep"],
+                        fetch=True, scrape=True, virtual_display=True, out=out))
+                    a1 = db.counts(conn)
+                    da = a1["agency_award"] - a0["agency_award"]
+                    db_ = a1["agency_bid"] - a0["agency_bid"]
+                    return f"+{da} awards, +{db_} bids"
+                _run_step(steps, failures, "agencies", _agencies)
+```
+
+Council (skip records a step; run records via `_run_step`):
+```python
+                if _is_first_of_month():
+                    def _council():
+                        from functools import partial
+                        from toronto_bids.sources.council import enrich_council, fetch_agenda_item
+                        n = enrich_council(conn, http, fetch=partial(fetch_agenda_item, virtual_display=True))
+                        return f"{n} items"
+                    _run_step(steps, failures, "council", _council)
+                else:
+                    steps.append({"name": "council", "status": "skip",
+                                  "detail": "not the 1st", "seconds": 0.0, "error": None})
+```
+
+Keep the `finally: http.close()` (still recording `http_close` failures into `failures` — that can stay a plain try/except; it is not a user-facing step).
+
+Supplier rebuild and export become steps too (they run after `http.close()`):
+```python
+        def _supplier():
+            from toronto_bids.linking.supplier import build_supplier_dimension
+            return f"{build_supplier_dimension(conn)} suppliers"
+        _run_step(steps, failures, "supplier rebuild", _supplier)
+
+        def _export():
+            nonlocal export_bytes
+            written = export_json(conn, Path(config.DATA_DIR) / "export" / "bids.json")
+            export_bytes = written.stat().st_size
+            return f"{export_bytes / 1_048_576:.1f} MiB"
+        _run_step(steps, failures, "export", _export)
+```
+(`export_bytes` must be declared `nonlocal`-able — it's a local of `_cmd_nightly`; since `_export` is a nested function, `nonlocal export_bytes` works. Keep the existing `after = db.counts(conn)` and `conn.close()` blocks as they are.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd scrapers && uv run pytest tests/test_nightly.py -v`
+Expected: PASS (new step/source tests green; existing isolation + exit-code tests still green — a raising step still yields exit 1 and the export still runs).
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `cd scrapers && uv run pytest -q` (all pass), then:
+
+```bash
+git add scrapers/toronto_bids/cli.py scrapers/tests/test_nightly.py
+git commit -m "feat(nightly): per-step + per-source detail in the Slack report
+
+_run_step times and records each step (status/detail/seconds), sync_runs_since
+supplies per-source fetched/new, and the report's Steps/Sources sections light
+up. Failures still mirrored to the authoritative list — exit-code contract
+unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE"
+```
+
+---
+
+## Task 4: `publish-data.sh` posts a one-line publish result
+
+**Files:**
+- Modify: `deploy/publish-data.sh`
+- Modify: `deploy/README.md` (note the two-message design)
+
+**Interfaces:** none (deploy-only).
+
+- [ ] **Step 1: Add a guarded `slack_notify` helper**
+
+In `deploy/publish-data.sh`, after the `gh_run()` definition, add:
+
+```bash
+# Post one line to Slack (best-effort). The webhook is a credential and this repo is public, so
+# it is passed ONLY as the curl URL — never echoed or logged. No webhook -> no-op; dry-run echoes.
+slack_notify() {
+  local msg="$1"
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "DRY-RUN slack: $msg"
+    return 0
+  fi
+  [ -n "${TB_SLACK_WEBHOOK:-}" ] || return 0
+  curl -s -o /dev/null --max-time 15 \
+    -H 'Content-Type: application/json' \
+    --data "$(printf '{"text": %s}' "$(printf '%s' "$msg" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")" \
+    "$TB_SLACK_WEBHOOK" || echo "publish-data: WARNING — slack post failed" >&2
+}
+```
+
+- [ ] **Step 2: Make `fail` post before exiting**
+
+Change the existing `fail()` to notify then exit:
+
+```bash
+fail() { slack_notify "❌ toronto-bids publish — $*"; echo "publish-data: $*" >&2; exit 1; }
+```
+(`slack_notify` is defined above `fail` — confirm ordering; if `fail` is defined before `gh_run`/`slack_notify`, move `slack_notify` up so it precedes `fail`.)
+
+- [ ] **Step 3: Post success at the very end**
+
+Just before the final `echo "publish-data: done"`, add:
+
+```bash
+slack_notify "✅ toronto-bids publish — latest release updated · ${GENERATED_AT} · https://github.com/${DATA_REPO}/releases/tag/latest"
+```
+
+- [ ] **Step 4: Verify syntax + dry-run (plexbox)**
+
+Run:
+```bash
+bash -n deploy/publish-data.sh && echo OK
+cd /home/alex/toronto-bids && TB_PUBLISH_DRY_RUN=1 TB_DATA_DIR="$HOME/tb-data" TB_PUBLISH_DAY=15 deploy/publish-data.sh 2>&1 | grep -iE "DRY-RUN slack|generated_at|done"
+```
+Expected: `OK`; and the dry-run shows a `DRY-RUN slack: ✅ toronto-bids publish — latest release updated · …` line and `publish-data: done`, exit 0. Paste the output into your report. Do NOT run a real publish.
+
+- [ ] **Step 5: Document in `deploy/README.md`**
+
+In the "Publishing the export" section, add a sentence: the nightly posts two Slack messages — the rich archive report from `tb nightly`, then a one-line publish result from `publish-data.sh` (both use `TB_SLACK_WEBHOOK`; both no-op when it is unset).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/publish-data.sh deploy/README.md
+git commit -m "feat(deploy): publish-data.sh posts a one-line Slack publish result
+
+Second of the two nightly messages: tb nightly posts the archive report,
+publish-data.sh posts publish success (+release URL) or failure. Best-effort,
+credential-safe (webhook only as the curl URL), no-op without a webhook.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE"
+```
+
+---
+
+## Post-implementation: live verification on plexbox
+
+Not a code task — after merge: run one real nightly (`systemctl --user start tb-nightly.service`), confirm the multi-section archive report renders in Slack and the separate publish line follows.
+
+## Self-Review
+
+**Spec coverage:** two-message design → Tasks 2/3 (report) + Task 4 (publish line) ✓; Steps section → Task 3 ✓; Sources + `⚠` zero-fetch → Tasks 1+3 ✓; Growth all-deltas → Task 2 ✓; Failures section + timing → Tasks 2/3 ✓; pure/total summarize → Task 2 ✓; heartbeat + exit-code unchanged → Task 2 (`ok`/return) + Task 3 (`_run_step` mirrors to `failures`) ✓; credential safety → Task 4 (`slack_notify` webhook-as-URL) ✓; degrade over partial report → Task 2 `summarize` `.get` everywhere ✓.
+
+**Placeholder scan:** No TBD/TODO. Each code step carries full code. The one soft edge — the sync step's `ok_n` count — is called out with an acceptable fallback (`f"{n} sources"`), not left vague.
+
+**Type consistency:** `report` dict keys and step/source dict shapes are identical between Task 2 (`summarize` reads them) and Task 3 (`_cmd_nightly` writes them). `_run_step(steps, failures, name, fn)` defined and used consistently. `sync_runs_since(conn, after_id) -> list[dict]` with keys `source/status/rows_fetched/rows_upserted/error` matches what the Sources renderer reads.

--- a/docs/superpowers/specs/2026-07-19-nightly-slack-report-design.md
+++ b/docs/superpowers/specs/2026-07-19-nightly-slack-report-design.md
@@ -1,0 +1,177 @@
+# Expanded nightly Slack report
+
+**Date:** 2026-07-19
+**Status:** approved, not yet implemented
+**Amends:** [`2026-07-17-deployment-design.md`](2026-07-17-deployment-design.md) §3.4 (the
+one-line summary) and [`2026-07-19-unified-nightly-capture-design.md`](2026-07-19-unified-nightly-capture-design.md)
+§3 ("Slack summary extended"). The nightly now runs ~8 steps (sync, award summaries, portal,
+Ariba attachments, agency board reports, monthly council, supplier rebuild, export); one line
+hides almost all of it, and the richest signal — `sync_run`'s per-source
+`rows_fetched`/`rows_upserted`/status — is never surfaced.
+
+## 1. Goal
+
+Turn the single-line nightly notification into a scannable multi-section report that answers,
+from Slack alone, "what ran, what each step did, what moved, and what broke" — so a bad night is
+diagnosable without SSHing to read the journal. Keep the every-run heartbeat (silence = the timer
+never fired) and the pure, offline-tested formatter.
+
+## 2. The two-message design (decided)
+
+Publishing happens in the `tb-nightly-run.sh` wrapper *after* `tb nightly` (which posts Slack)
+returns, so a single message cannot natively report the publish outcome. Two messages, each tool
+owning its own line:
+
+1. **`tb nightly`** posts the **rich archive report** (sync → export) — the bulk of this spec.
+2. **`publish-data.sh`** posts a **one-line publish result** (✅ + release URL, or ❌ + reason)
+   after it runs.
+
+Both read `TB_SLACK_WEBHOOK` from the same environment (the unit's `EnvironmentFile`), and both
+no-op when it is unset (dev/CI stay silent with no separate code path). A failed post never fails
+the run.
+
+## 3. The rich report (`tb nightly`)
+
+### 3.1 Structured bookkeeping in `_cmd_nightly`
+
+Today `_cmd_nightly` records only `failures: list[(name, error)]`. Replace that with structured
+per-step records so the report can show status, detail, and timing per step.
+
+- A `steps: list[dict]` where each entry is `{"name": str, "status": "ok"|"fail"|"skip",
+  "detail": str, "seconds": float, "error": str | None}`.
+- A helper `_run_step(steps, name, fn)` that times `fn`, appends an `"ok"` record with
+  `detail=fn()` (a short string the step returns, e.g. `"+48 bundles"`), or a `"fail"` record with
+  `error=str(exc)` on exception — preserving today's isolation (a raising step never stops the
+  ones behind it or the export). A skip is recorded explicitly (council when not the 1st) as
+  `status="skip"`.
+- Each capture step's `fn` returns its own short detail where it cheaply can (award summaries:
+  bids added; Ariba attachments: bundles captured; supplier rebuild: dimension size; export:
+  size). Where a step has no natural scalar (agencies), detail is derived from the relevant count
+  delta snapshotted around that step (a couple of `COUNT(*)` reads), or left blank — the **Growth**
+  section (§3.4) carries the full delta story regardless.
+
+The overall run is **ok** iff no step failed and no source failed; `_cmd_nightly` still exits
+non-zero otherwise (systemd marks the unit failed).
+
+### 3.2 Per-source sync detail
+
+`sync_run.id` is autoincrement. Capture `SELECT MAX(id) FROM sync_run` **before** `pipeline.sync`,
+then after read every row with `id > that_max` — this run's per-source records
+(`source, status, rows_fetched, rows_upserted, error`). Add a small read helper
+`db.sync_runs_since(conn, after_id) -> list[dict]`. A source that ran with `rows_fetched == 0`, or
+`status != "ok"`, is flagged `⚠` — the silent-upstream-break signal the current "9/9 ok" hides.
+
+### 3.3 Counts
+
+Full `db.counts` before and after the run (as today) drives the Growth section — every table whose
+count moved, not just the four headline ones.
+
+### 3.4 Message layout (multi-line Slack mrkdwn)
+
+`post` is unchanged — it still sends `{"text": …}`; Slack renders mrkdwn in the `text` field, so no
+Block Kit is needed. A pure `summarize(report) -> str` builds:
+
+```
+*✅ toronto-bids nightly* · 58m04s
+
+*Steps*
+✅ sync              9/9 sources · 3m12s
+✅ award summaries   +12 bids
+✅ portal            no open bids
+❌ ariba attachments TimeoutError on Respond · 48m
+✅ agencies          +7 awards, +15 bids · 6m
+➖ council           skipped (not the 1st)
+✅ supplier rebuild  8,022 suppliers
+✅ export            31.1 MiB
+
+*Sources* (fetched → new)
+odata_solicitations 7,446 → +12 · ckan_awarded 14,165 → +8 · ariba_discovery 1,670 → +0
+⚠ suspended_firms 0 fetched
+
+*Growth*
+solicitations +12 · awards +8 · bids +27 · ariba files +111 · agency awards +7 · agency bids +15
+
+*Failures (1)*
+ariba_attachments: TimeoutError on Respond
+```
+
+Rules:
+- **Header** stays `✅/❌ toronto-bids nightly` + total elapsed, so the at-a-glance heartbeat and
+  the failed/ok signal survive the expansion. `❌` when the run is not ok.
+- **Steps** — one line per step in run order, `✅` ok / `❌` fail / `➖` skip, the step's detail,
+  and its duration when ≥ a small threshold (skip sub-second noise).
+- **Sources** — this-run `sync_run` rows, compact, `fetched → +new`; a `⚠`-flagged line for any
+  source that fetched 0 or whose status isn't ok.
+- **Growth** — every non-zero count delta (reuses the existing `_seg`/`_count` delta style and
+  `,`-thousands formatting). Omitted entirely if nothing moved.
+- **Failures** — present only when there are failures; lists each failed step/source with its
+  error. Errors are the same strings `_cmd_nightly` already records — no new leakage surface (the
+  webhook-credential care in `post` is unchanged).
+- An empty `before` (the before-count step itself failed) still suppresses fabricated deltas, as
+  today.
+
+The message can run ~15-25 lines; that is the point, and Slack handles it. Every-run posting is
+retained (heartbeat).
+
+### 3.5 Signature change
+
+`summarize` moves from `summarize(before, after, failures, n_sources, export_bytes, elapsed_s)` to
+`summarize(report: dict) -> str`, where `report = {"ok", "steps", "sources", "before", "after",
+"export_bytes", "elapsed_s"}`. `_cmd_nightly` assembles `report` and passes it. This is a breaking
+signature change to a purely-internal function — all callers are `_cmd_nightly` and the tests.
+
+## 4. The publish line (`publish-data.sh`)
+
+Add a guarded `slack_notify` bash helper and post once at the end:
+
+- On success: `✅ toronto-bids publish — latest release updated · <generated_at> · <release URL>`.
+- On failure (each existing `fail` path): `❌ toronto-bids publish — <reason>` before exiting.
+- `slack_notify` no-ops when `TB_SLACK_WEBHOOK` is unset; under `TB_PUBLISH_DRY_RUN=1` it echoes
+  instead of curling (mirrors `gh_run`). Posting uses `curl -s -o /dev/null --data-urlencode`
+  style with the webhook as the URL only (never echoed/logged), so the credential does not leak —
+  the same discipline `notify.post` follows.
+- A failed Slack post never changes the publish exit code (the release upload is the deliverable).
+- The agenda-archive best-effort warnings (§ from the unified-nightly work) are not publish
+  failures and do not post.
+
+## 5. Error handling
+
+- The report is assembled defensively: if `db.counts` or `sync_runs_since` raises, that is recorded
+  as a step failure and the report still posts with what it has (the summary must never be the
+  thing that fails the run — its whole reason for existing is to make failure visible).
+- `_run_step` catches every step exception (isolation preserved); `summarize` is pure and total
+  over a partial `report` (missing keys degrade to omitted sections, never a `KeyError`).
+- `post` and `slack_notify` swallow their own errors and log a type/status only, as `notify.post`
+  already does.
+
+## 6. Testing
+
+- **`summarize` is pure and fully offline-tested** against fixture `report` dicts: a clean run
+  (all sections), a run with a failed step (❌ header + Failures section), a run with a skipped
+  council, a run with a `⚠` zero-fetch source, a run where nothing moved (no Growth section), and a
+  run with an empty `before` (no fabricated deltas). Assert exact substrings, as the current
+  `test_notify.py` does.
+- **`sync_runs_since`** tested against an in-memory DB: seed two runs, assert only the newer run's
+  rows return.
+- **`_run_step`** tested: an ok step records ok+detail+seconds; a raising step records fail+error
+  and does not propagate.
+- **`_cmd_nightly`** existing isolation tests updated for the new `report`/`steps` plumbing (the
+  `nightly` fixture already stubs the capture calls); assert the posted text contains the Steps
+  header and a failed step surfaces in Failures.
+- **`publish-data.sh`** `slack_notify`: dry-run shows the echoed post line on success; no webhook →
+  no post. (Bash, verified by dry-run + inspection, as with the rest of the script.)
+- **Live**, after merge on plexbox: one real nightly, confirm the multi-section message renders in
+  Slack and the separate publish line follows.
+
+## 7. Out of scope
+
+- Slack Block Kit / attachments / threading — plain mrkdwn `text` only.
+- Per-step timing precision beyond `Xm`/`Xs` (the existing `_elapsed` granularity).
+- Posting anything about the frontend build trigger (that stays a `publish-data.sh` stderr warning;
+  it is not archive state).
+- Changing what counts as a failure or the exit-code contract — only the *presentation* expands.
+
+## 8. Recording
+
+On completion, note in the deployment design's lineage that §3.4's one-liner is superseded by the
+multi-section report, and update `deploy/README.md`'s description of what the nightly posts.

--- a/scrapers/tests/test_db.py
+++ b/scrapers/tests/test_db.py
@@ -193,3 +193,18 @@ def test_init_db_adds_missing_column_to_pre_p5a_table():
     row = c.execute("SELECT supplier_id FROM suspended_firm WHERE supplier_name_raw = 'Acme'").fetchone()
     assert row["supplier_id"] == 7
     c.close()
+
+
+def test_sync_runs_since_returns_only_newer_rows(conn):
+    r1 = db.start_sync_run(conn, "odata_solicitations")
+    db.finish_sync_run(conn, r1, status="ok", rows_fetched=7446, rows_upserted=12)
+    cutoff = r1
+    r2 = db.start_sync_run(conn, "ariba_discovery")
+    db.finish_sync_run(conn, r2, status="ok", rows_fetched=1670, rows_upserted=0)
+    r3 = db.start_sync_run(conn, "ckan_awarded")
+    db.finish_sync_run(conn, r3, status="failed", rows_fetched=0, rows_upserted=0, error="boom")
+
+    rows = db.sync_runs_since(conn, cutoff)
+    assert [r["source"] for r in rows] == ["ariba_discovery", "ckan_awarded"]
+    assert rows[0]["rows_fetched"] == 1670 and rows[0]["rows_upserted"] == 0
+    assert rows[1]["status"] == "failed" and rows[1]["error"] == "boom"

--- a/scrapers/tests/test_nightly.py
+++ b/scrapers/tests/test_nightly.py
@@ -210,6 +210,41 @@ def test_an_agency_body_failure_is_recorded_but_export_still_runs(nightly, monke
     assert (tmp_path / "export" / "bids.json").exists()
 
 
+def test_report_has_a_steps_section_naming_each_step(nightly, monkeypatch):
+    posted = {}
+    from toronto_bids import notify
+    monkeypatch.setattr(notify, "post", lambda text, **k: posted.setdefault("text", text))
+    nightly()
+    t = posted["text"]
+    assert "*Steps*" in t
+    for name in ("sync", "award summaries", "ariba attachments", "agencies", "export"):
+        assert name in t
+
+
+def test_a_failed_step_appears_in_both_failures_and_steps(nightly, monkeypatch):
+    posted = {}
+    from toronto_bids import notify
+    monkeypatch.setattr(notify, "post", lambda text, **k: posted.setdefault("text", text))
+    from toronto_bids.sources import ariba_attachments
+    monkeypatch.setattr(ariba_attachments, "capture_attachments",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("browser died")))
+    assert nightly() == 1
+    t = posted["text"]
+    assert "*Failures (1)*" in t
+    assert "browser died" in t
+    assert "❌ ariba attachments" in t
+
+
+def test_run_step_records_ok_and_isolates_failure():
+    from toronto_bids import cli
+    steps, failures = [], []
+    cli._run_step(steps, failures, "demo", lambda: "+3 things")
+    assert steps[0]["status"] == "ok" and steps[0]["detail"] == "+3 things"
+    cli._run_step(steps, failures, "boom", lambda: (_ for _ in ()).throw(RuntimeError("x")))
+    assert steps[1]["status"] == "fail" and steps[1]["error"] == "x"
+    assert failures == [("boom", "x")]   # failure mirrored for the exit-code contract
+
+
 def test_council_runs_only_on_the_first_of_the_month(nightly, monkeypatch):
     calls = []
     from toronto_bids.sources import council as council_src

--- a/scrapers/tests/test_nightly.py
+++ b/scrapers/tests/test_nightly.py
@@ -96,7 +96,7 @@ def test_the_summary_is_posted(nightly, monkeypatch):
     monkeypatch.setattr(notify, "post", lambda text, **k: posted.append(text) or True)
     assert nightly() == 0
     assert len(posted) == 1
-    assert posted[0].startswith("✅ toronto-bids")
+    assert posted[0].startswith("*✅ toronto-bids nightly*")
 
 
 def test_a_failing_run_posts_the_failure(nightly, monkeypatch):
@@ -104,7 +104,8 @@ def test_a_failing_run_posts_the_failure(nightly, monkeypatch):
     monkeypatch.setattr(notify, "post", lambda text, **k: posted.append(text) or True)
     monkeypatch.setattr(cli.pipeline, "sync", lambda *a, **k: [("ariba_discovery", "boom")])
     assert nightly() == 1
-    assert posted[0].startswith("❌ toronto-bids")
+    assert posted[0].startswith("*❌ toronto-bids nightly*")
+    assert "*Failures" in posted[0]
     assert "ariba_discovery" in posted[0]
 
 
@@ -118,7 +119,7 @@ def test_a_broken_database_still_reports_to_slack(nightly, monkeypatch):
         raise sqlite3.OperationalError("unable to open database file")
     monkeypatch.setattr(cli, "_open_db", boom)
     assert nightly() == 1
-    assert posted and posted[0].startswith("❌ toronto-bids")
+    assert posted and posted[0].startswith("*❌ toronto-bids nightly*")
     assert "unable to open database file" in posted[0]
 
 
@@ -129,7 +130,7 @@ def test_counting_the_archive_failing_still_reports_to_slack(nightly, monkeypatc
         raise sqlite3.DatabaseError("database disk image is malformed")
     monkeypatch.setattr(cli.db, "counts", boom)
     assert nightly() == 1
-    assert posted and posted[0].startswith("❌ toronto-bids")
+    assert posted and posted[0].startswith("*❌ toronto-bids nightly*")
 
 
 def test_a_failure_building_the_http_client_does_not_cost_us_the_export(nightly, monkeypatch,
@@ -185,7 +186,7 @@ def test_a_failure_closing_the_database_does_not_swallow_the_summary(nightly, mo
 
     monkeypatch.setattr(cli, "_open_db", lambda: _CloseFails())
     assert nightly() == 1
-    assert posted and posted[0].startswith("❌ toronto-bids")
+    assert posted and posted[0].startswith("*❌ toronto-bids nightly*")
 
 
 def test_a_raising_ariba_attachment_step_does_not_stop_the_export(nightly, monkeypatch, tmp_path):

--- a/scrapers/tests/test_notify.py
+++ b/scrapers/tests/test_notify.py
@@ -4,82 +4,71 @@
 """
 from toronto_bids import notify
 
-BEFORE = {"solicitation": 7641, "award": 14157, "bid": 18627, "supplier": 6738}
-AFTER = {"solicitation": 7653, "award": 14165, "bid": 18632, "supplier": 6738}
-
 
 def _counts(**kw):
-    base = {k: 0 for k in ("solicitation", "award", "bid", "agency_award",
-                           "agency_bid", "ariba_attachment")}
+    base = {k: 0 for k in ("solicitation", "award", "bid", "supplier",
+                           "agency_award", "agency_bid", "ariba_attachment")}
     base.update(kw)
     return base
 
 
-def test_summary_shows_agency_and_attachment_growth():
-    before = _counts(agency_award=100, agency_bid=200, ariba_attachment=1000)
-    after = _counts(agency_award=107, agency_bid=215, ariba_attachment=1111)
-    text = notify.summarize(before, after, [], 9, 31_000_000, 12.0)
-    assert "agency awards 107 (+7)" in text
-    assert "agency bids 215 (+15)" in text
-    assert "ariba files 1,111 (+111)" in text
+def test_clean_run_header_and_growth():
+    report = {"ok": True, "before": _counts(solicitation=7434, bid=18605),
+              "after": _counts(solicitation=7446, bid=18632),
+              "failures": [], "export_bytes": 32_651_042, "elapsed_s": 3484.0}
+    text = notify.summarize(report)
+    assert text.startswith("*✅ toronto-bids nightly* · 58m04s")
+    assert "*Growth*" in text
+    assert "solicitations 7,446 (+12)" in text
+    assert "bids 18,632 (+27)" in text
+    assert "*Failures*" not in text
 
 
-def test_summary_omits_zero_growth_agency_and_attachment_lines():
-    c = _counts(solicitation=10)
-    text = notify.summarize(c, c, [], 9, 1000, 1.0)
-    assert "agency awards" not in text  # nothing captured -> no noise
+def test_failed_run_header_and_failures_section():
+    report = {"ok": False, "before": _counts(), "after": _counts(),
+              "failures": [("ariba_attachments", "TimeoutError on Respond")],
+              "export_bytes": 1000, "elapsed_s": 61.0}
+    text = notify.summarize(report)
+    assert text.startswith("*❌ toronto-bids nightly*")
+    assert "*Failures (1)*" in text
+    assert "ariba_attachments: TimeoutError on Respond" in text
 
 
-def test_a_healthy_run_leads_with_success_and_the_counts():
-    text = notify.summarize(BEFORE, AFTER, [], 9, 30_800_000, 192.0)
-    assert text.startswith("✅ toronto-bids")
-    assert "9/9 sources ok" in text
-    assert "solicitations 7,653 (+12)" in text
-    assert "awards 14,165 (+8)" in text
-    assert "bids 18,632 (+5)" in text
+def test_steps_section_renders_status_detail_and_skip():
+    report = {"ok": True, "before": _counts(), "after": _counts(), "failures": [],
+              "steps": [
+                  {"name": "sync", "status": "ok", "detail": "9/9 sources", "seconds": 192.0, "error": None},
+                  {"name": "council", "status": "skip", "detail": "not the 1st", "seconds": 0.0, "error": None},
+                  {"name": "ariba attachments", "status": "fail", "detail": "", "seconds": 2880.0, "error": "boom"},
+              ],
+              "export_bytes": 1000, "elapsed_s": 3600.0}
+    text = notify.summarize(report)
+    assert "*Steps*" in text
+    assert "✅ sync  9/9 sources · 3m12s" in text
+    assert "➖ council  not the 1st" in text
+    assert "❌ ariba attachments  boom · 48m0" in text[:1000] or "❌ ariba attachments  boom · 48m00s" in text
 
 
-def test_an_unchanged_count_shows_no_delta():
-    """(+0) on every quiet table is noise; a delta appears only when something moved."""
-    text = notify.summarize(BEFORE, AFTER, [], 9, 1, 1.0)
-    assert "suppliers 6,738" in text
-    assert "6,738 (+0)" not in text
+def test_sources_section_flags_zero_fetch():
+    report = {"ok": True, "before": _counts(), "after": _counts(), "failures": [],
+              "sources": [
+                  {"source": "odata_solicitations", "status": "ok", "rows_fetched": 7446, "rows_upserted": 12, "error": None},
+                  {"source": "suspended_firms", "status": "ok", "rows_fetched": 0, "rows_upserted": 0, "error": None},
+              ],
+              "export_bytes": 1000, "elapsed_s": 60.0}
+    text = notify.summarize(report)
+    assert "*Sources* (fetched → new)" in text
+    assert "odata_solicitations 7,446 → +12" in text
+    assert "⚠ suspended_firms 0 fetched" in text
 
 
-def test_a_failure_leads_with_it_and_names_the_source_and_error():
-    """The whole point of posting: a failure must be legible without opening a terminal."""
-    text = notify.summarize(BEFORE, AFTER, [("ariba_discovery", "HTTPError 500")], 9,
-                            30_800_000, 192.0)
-    assert text.startswith("❌ toronto-bids")
-    assert "1 failed" in text
-    assert "ariba_discovery: HTTPError 500" in text
-
-
-def test_a_failed_step_is_not_reported_as_a_failed_source():
-    """`failures` carries whole-step failures (sync, award_summary, export) alongside the
-    per-source ones pipeline.sync returns. 'N/9 sources FAILED' would call a dead disk a
-    failed City feed."""
-    text = notify.summarize(BEFORE, AFTER, [("export", "disk full")], 9, None, 5.0)
-    assert "sources" not in text
-    assert "export: disk full" in text
-
-
-def test_a_failure_still_reports_the_export():
-    """Export runs even after a partial sync — the message must say so, or a reader assumes
-    the run produced nothing."""
-    text = notify.summarize(BEFORE, AFTER, [("ariba_discovery", "boom")], 9, 30_800_000, 5.0)
-    assert "export 29.4 MiB" in text
-
-
-def test_a_missing_export_is_reported_as_missing_not_as_zero():
-    text = notify.summarize(BEFORE, AFTER, [("export", "disk full")], 9, None, 5.0)
-    assert "export FAILED" in text
-    assert "0.0 MiB" not in text
-
-
-def test_elapsed_is_human_readable():
-    assert "3m12s" in notify.summarize(BEFORE, AFTER, [], 9, 1, 192.0)
-    assert "45s" in notify.summarize(BEFORE, AFTER, [], 9, 1, 45.0)
+def test_nothing_moved_omits_growth_and_empty_before_suppresses_deltas():
+    same = _counts(solicitation=10)
+    assert "*Growth*" not in notify.summarize(
+        {"ok": True, "before": same, "after": same, "failures": [], "export_bytes": 1, "elapsed_s": 1.0})
+    # empty before => before-count failed => no fabricated deltas
+    assert "*Growth*" not in notify.summarize(
+        {"ok": True, "before": {}, "after": _counts(bid=5), "failures": [], "export_bytes": 1, "elapsed_s": 1.0})
 
 
 def test_post_without_a_webhook_is_a_no_op_and_makes_no_request(monkeypatch):
@@ -156,15 +145,6 @@ def test_a_successful_post_returns_true(monkeypatch):
         status_code = 200
     monkeypatch.setattr(notify.httpx, "post", lambda url, **kw: Resp())
     assert notify.post("hi", webhook="https://hooks.slack.test/x") is True
-
-
-def test_a_failed_before_count_shows_no_delta_rather_than_a_fabricated_one():
-    """When the `before` count raised, the caller passes before={}. Rendering (+18,632) against
-    a zero it never actually measured is a fabricated number in the exact mechanism the summary
-    exists for. Show the absolute count, no delta."""
-    text = notify.summarize({}, AFTER, [("counts", "locked")], 9, 30_800_000, 5.0)
-    assert "bids 18,632" in text
-    assert "(+" not in text
 
 
 def test_a_malformed_webhook_exception_never_leaks_the_url_into_the_log(monkeypatch):

--- a/scrapers/tests/test_notify.py
+++ b/scrapers/tests/test_notify.py
@@ -71,6 +71,23 @@ def test_nothing_moved_omits_growth_and_empty_before_suppresses_deltas():
         {"ok": True, "before": {}, "after": _counts(bid=5), "failures": [], "export_bytes": 1, "elapsed_s": 1.0})
 
 
+def test_missing_export_is_reported_as_failed():
+    report = {"ok": False, "before": _counts(), "after": _counts(), "failures": [],
+              "export_bytes": None, "elapsed_s": 60.0}
+    text = notify.summarize(report)
+    assert "export FAILED" in text
+
+
+def test_growth_labels_agency_and_ariba():
+    before = _counts(agency_award=100, agency_bid=200, ariba_attachment=1000)
+    after = _counts(agency_award=107, agency_bid=215, ariba_attachment=1111)
+    text = notify.summarize({"ok": True, "before": before, "after": after,
+                             "failures": [], "export_bytes": 1, "elapsed_s": 1.0})
+    assert "agency awards 107 (+7)" in text
+    assert "agency bids 215 (+15)" in text
+    assert "ariba files 1,111 (+111)" in text
+
+
 def test_post_without_a_webhook_is_a_no_op_and_makes_no_request(monkeypatch):
     """Absence of the credential degrades gracefully — this Mac and CI stay silent with no
     separate code path, the same way the rewrite design's goal 3 asks of auth-optional parts."""

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -549,8 +549,8 @@ def _cmd_nightly(args) -> int:
 
     report = {
         "ok": not failures,
-        "steps": steps,            # populated in Task 3; [] here
-        "sources": sources,        # populated in Task 3; [] here
+        "steps": steps,
+        "sources": sources,
         "before": before,
         "after": after,
         "failures": failures,

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -412,6 +412,8 @@ def _cmd_nightly(args) -> int:
     after: dict = {}
     export_bytes = None
     conn = None
+    steps: list[dict] = []
+    sources: list[dict] = []
 
     try:
         conn = _open_db()
@@ -505,8 +507,17 @@ def _cmd_nightly(args) -> int:
         except Exception as exc:
             failures.append(("conn_close", str(exc)))
 
-    text = notify.summarize(before, after, failures, len(pipeline.default_sources()),
-                            export_bytes, time.monotonic() - started)
+    report = {
+        "ok": not failures,
+        "steps": steps,            # populated in Task 3; [] here
+        "sources": sources,        # populated in Task 3; [] here
+        "before": before,
+        "after": after,
+        "failures": failures,
+        "export_bytes": export_bytes,
+        "elapsed_s": time.monotonic() - started,
+    }
+    text = notify.summarize(report)
     print(text)
     for name, error in failures:
         print(f"FAILED  {name}: {error}", file=sys.stderr)

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -113,6 +113,23 @@ def _is_first_of_month() -> bool:
     return date.today().day == 1
 
 
+def _run_step(steps: list, failures: list, name: str, fn) -> None:
+    """Run one nightly step, timing it and recording a step record. On failure the error is
+    ALSO appended to `failures` — the authoritative list the exit code and the report's Failures
+    section read — so the exit-code contract is untouched while the Steps section gains status +
+    timing. `fn` returns a short detail string (or None)."""
+    import time
+    t = time.monotonic()
+    try:
+        detail = fn()
+        steps.append({"name": name, "status": "ok", "detail": detail or "",
+                      "seconds": time.monotonic() - t, "error": None})
+    except Exception as exc:  # isolation: never propagates
+        steps.append({"name": name, "status": "fail", "detail": "",
+                      "seconds": time.monotonic() - t, "error": str(exc)})
+        failures.append((name, str(exc)))
+
+
 def _open_db():
     config.DATA_DIR.mkdir(parents=True, exist_ok=True)
     conn = db.connect(config.DB_PATH)
@@ -439,63 +456,86 @@ def _cmd_nightly(args) -> int:
         if http is not None:
             try:
                 try:
-                    failures.extend(pipeline.sync(conn, http))
-                except Exception as exc:
-                    failures.append(("sync", str(exc)))
+                    sync_cutoff = conn.execute(
+                        "SELECT COALESCE(MAX(id), 0) FROM sync_run").fetchone()[0]
+                except Exception:
+                    sync_cutoff = 0
+
+                def _sync():
+                    src_failures = pipeline.sync(conn, http)
+                    failures.extend(src_failures)
+                    n = len(pipeline.default_sources())
+                    return f"{n} sources"
+                _run_step(steps, failures, "sync", _sync)
+
                 try:
+                    sources.extend(db.sync_runs_since(conn, sync_cutoff))
+                except Exception as exc:
+                    failures.append(("sync_detail", str(exc)))
+
+                def _awards():
                     download_award_summaries(conn, http, log=out)
-                    store_award_summary_bids(conn, log=out)
-                except Exception as exc:
-                    failures.append(("award_summary", str(exc)))
-                try:
+                    return f"{store_award_summary_bids(conn, log=out)} bids stored"
+                _run_step(steps, failures, "award summaries", _awards)
+
+                def _portal():
                     from toronto_bids.sources.bids_tenders import run_portal_capture
                     res = run_portal_capture(conn, log=out)
                     for slug, v in res.items():
                         if isinstance(v, str) and v.startswith("FAILED"):
                             failures.append((f"portal:{slug}", v))
-                except Exception as exc:
-                    failures.append(("portal", str(exc)))
-                try:
+                    total = sum(v for v in res.values() if isinstance(v, int))
+                    return f"{total} listings" if total else "no open bids"
+                _run_step(steps, failures, "portal", _portal)
+
+                def _ariba():
                     from toronto_bids.sources import ariba_attachments as aa
                     n = aa.capture_attachments(conn, log=out, virtual_display=True)
-                    print(f"  ariba attachments    : {n} bundles captured")
-                except Exception as exc:
-                    failures.append(("ariba_attachments", str(exc)))
-                try:
+                    return f"+{n} bundles"
+                _run_step(steps, failures, "ariba attachments", _ariba)
+
+                def _agencies():
                     from toronto_bids.buyers import seed_buyers
+                    a0 = db.counts(conn)
                     ids = seed_buyers(conn)
                     failures.extend(_capture_agency_bodies(
                         conn, ids, bodies=["trca", "zoo", "ep"],
                         fetch=True, scrape=True, virtual_display=True, out=out))
-                except Exception as exc:
-                    failures.append(("agencies", str(exc)))
+                    a1 = db.counts(conn)
+                    da = a1["agency_award"] - a0["agency_award"]
+                    db_ = a1["agency_bid"] - a0["agency_bid"]
+                    return f"+{da} awards, +{db_} bids"
+                _run_step(steps, failures, "agencies", _agencies)
+
                 if _is_first_of_month():
-                    try:
+                    def _council():
                         from functools import partial
                         from toronto_bids.sources.council import (
                             enrich_council, fetch_agenda_item)
                         fetch = partial(fetch_agenda_item, virtual_display=True)
-                        print(f"  council enriched     : "
-                              f"{enrich_council(conn, http, fetch=fetch)}")
-                    except Exception as exc:
-                        failures.append(("council", str(exc)))
+                        n = enrich_council(conn, http, fetch=fetch)
+                        return f"{n} items"
+                    _run_step(steps, failures, "council", _council)
+                else:
+                    steps.append({"name": "council", "status": "skip",
+                                  "detail": "not the 1st", "seconds": 0.0, "error": None})
             finally:
                 try:
                     http.close()
                 except Exception as exc:
                     failures.append(("http_close", str(exc)))
 
-        try:
+        def _supplier():
             from toronto_bids.linking.supplier import build_supplier_dimension
-            print(f"  suppliers            : {build_supplier_dimension(conn)}")
-        except Exception as exc:
-            failures.append(("supplier_linking", str(exc)))
+            return f"{build_supplier_dimension(conn)} suppliers"
+        _run_step(steps, failures, "supplier rebuild", _supplier)
 
-        try:
+        def _export():
+            nonlocal export_bytes
             written = export_json(conn, Path(config.DATA_DIR) / "export" / "bids.json")
             export_bytes = written.stat().st_size
-        except Exception as exc:
-            failures.append(("export", str(exc)))
+            return f"{export_bytes / 1_048_576:.1f} MiB"
+        _run_step(steps, failures, "export", _export)
 
         try:
             after = db.counts(conn)

--- a/scrapers/toronto_bids/notify.py
+++ b/scrapers/toronto_bids/notify.py
@@ -10,26 +10,7 @@ import os
 
 import httpx
 
-# Tables worth a line in a one-line summary. The full set is in `tb status`; this is the
-# headline: what the archive is FOR (solicitations, awards, bids) plus the dimension the bids
-# feed. Everything else is either derived or quiet.
-_HEADLINE = (("solicitation", "solicitations"), ("award", "awards"),
-             ("bid", "bids"), ("supplier", "suppliers"))
 _SLACK_TIMEOUT = 15.0
-
-
-def _count(before: dict, after: dict, key: str, label: str) -> str:
-    """'solicitations 7,653 (+12)', or without the delta when nothing moved.
-
-    An empty `before` means the before-count did not run (the caller passes {} on that
-    failure) — showing a delta against it would render a fake number against a zero nobody
-    measured, so it is omitted entirely rather than computed against 0.
-    """
-    now = after.get(key, 0)
-    if not before:
-        return f"{label} {now:,}"
-    delta = now - before.get(key, 0)
-    return f"{label} {now:,}" + (f" ({delta:+,})" if delta else "")
 
 
 def _elapsed(seconds: float) -> str:
@@ -37,35 +18,88 @@ def _elapsed(seconds: float) -> str:
     return f"{m}m{s:02d}s" if m else f"{s}s"
 
 
-def summarize(before: dict, after: dict, failures: list, n_sources: int,
-              export_bytes: int | None, elapsed_s: float) -> str:
-    """The one-line message. Pure — `export_bytes` is passed in, never stat'ed here.
+_STEP_ICON = {"ok": "✅", "fail": "❌", "skip": "➖"}
 
-    Posted on EVERY run, not only on failure, and that is the design: the failure mode a
-    failures-only alert cannot catch is the timer never firing at all, where silence and health
-    look identical. A nightly line makes silence itself the signal.
+# Nicer labels for the Growth section; unlisted tables fall back to the raw key.
+_LABELS = {
+    "solicitation": "solicitations", "award": "awards", "bid": "bids", "supplier": "suppliers",
+    "noncompetitive": "noncompetitive", "ariba_posting": "ariba postings",
+    "suspended_firm": "suspended firms", "capital_project": "capital projects",
+    "council_item": "council items", "background_pdf": "background pdfs",
+    "composite_award": "composite awards", "agency_solicitation": "agency solicitations",
+    "agency_award": "agency awards", "agency_bid": "agency bids",
+    "ariba_attachment": "ariba files",
+}
+# Housekeeping tables whose growth is noise in a report about the archive.
+_GROWTH_SKIP = {"sync_run", "buyer"}
+
+
+def _growth(before: dict, after: dict) -> list[str]:
+    """'solicitations 7,446 (+12)' for every table that grew. Empty `before` (the count step
+    failed) yields nothing — a delta against a zero nobody measured is a fabricated number."""
+    if not before:
+        return []
+    out = []
+    for key, now in after.items():
+        if key in _GROWTH_SKIP:
+            continue
+        delta = now - before.get(key, 0)
+        if delta:
+            out.append(f"{_LABELS.get(key, key)} {now:,} ({delta:+,})")
+    return out
+
+
+def summarize(report: dict) -> str:
+    """The nightly message — multi-section Slack mrkdwn. Pure and total over a partial report:
+    a missing/empty section is simply omitted, never a KeyError, because the report itself must
+    never be the thing that fails the run it exists to make visible.
     """
-    def _seg(label, key):
-        a = after.get(key)
-        if not a:
-            return None
-        d = a - before.get(key, 0)
-        return f"{label} {a:,} (+{d:,})" if d else None
+    before = report.get("before", {})
+    after = report.get("after", {})
+    failures = report.get("failures", [])
+    steps = report.get("steps", [])
+    sources = report.get("sources", [])
+    export_bytes = report.get("export_bytes")
+    elapsed_s = report.get("elapsed_s", 0.0)
+    ok = report.get("ok", not failures)
 
-    parts = [_count(before, after, key, label) for key, label in _HEADLINE]
-    parts.extend(s for s in (_seg("agency awards", "agency_award"),
-                             _seg("agency bids", "agency_bid"),
-                             _seg("ariba files", "ariba_attachment")) if s)
-    parts.append(f"export {export_bytes / 1_048_576:.1f} MiB" if export_bytes is not None  # binary MiB, matching ls -lh
-                 else "export FAILED")
-    parts.append(_elapsed(elapsed_s))
-    if not failures:
-        return f"✅ toronto-bids — {n_sources}/{n_sources} sources ok · " + " · ".join(parts)
-    # NOT "N/{n_sources} sources FAILED": `failures` mixes per-source failures from
-    # pipeline.sync with whole-step failures (sync, award_summary, export), and calling a
-    # dead disk a failed City feed would send someone to the wrong system at 06:00.
-    named = ", ".join(f"{name}: {error}" for name, error in failures)
-    return f"❌ toronto-bids — {len(failures)} failed · {named} · " + " · ".join(parts)
+    lines = [f"*{'✅' if ok else '❌'} toronto-bids nightly* · {_elapsed(elapsed_s)}"]
+
+    if steps:
+        lines += ["", "*Steps*"]
+        for s in steps:
+            icon = _STEP_ICON.get(s.get("status"), "•")
+            detail = s.get("detail") or s.get("error") or ""
+            dur = s.get("seconds") or 0.0
+            suffix = f" · {_elapsed(dur)}" if dur >= 1 else ""
+            lines.append(f"{icon} {s.get('name', '?')}  {detail}{suffix}".rstrip())
+
+    if sources:
+        lines += ["", "*Sources* (fetched → new)"]
+        ok_segs, warns = [], []
+        for r in sources:
+            fetched = r.get("rows_fetched", 0) or 0
+            new = r.get("rows_upserted", 0) or 0
+            if r.get("status") != "ok" or fetched == 0:
+                extra = "" if r.get("status") == "ok" else f" ({r.get('status')})"
+                warns.append(f"⚠ {r.get('source', '?')} {fetched:,} fetched{extra}")
+            else:
+                ok_segs.append(f"{r.get('source', '?')} {fetched:,} → +{new:,}")
+        if ok_segs:
+            lines.append(" · ".join(ok_segs))
+        lines += warns
+
+    growth = _growth(before, after)
+    if growth:
+        lines += ["", "*Growth*", " · ".join(growth)]
+
+    lines += ["", f"export {'FAILED' if export_bytes is None else f'{export_bytes / 1_048_576:.1f} MiB'}"]
+
+    if failures:
+        lines += ["", f"*Failures ({len(failures)})*"]
+        lines += [f"{name}: {error}" for name, error in failures]
+
+    return "\n".join(lines)
 
 
 def post(text: str, webhook: str | None = None, log=lambda _m: None) -> bool:

--- a/scrapers/toronto_bids/store/db.py
+++ b/scrapers/toronto_bids/store/db.py
@@ -281,3 +281,16 @@ def finish_sync_run(conn, run_id, *, status, rows_fetched=0, rows_upserted=0, er
         (status, rows_fetched, rows_upserted, error, run_id),
     )
     conn.commit()
+
+
+def sync_runs_since(conn, after_id: int) -> list[dict]:
+    """Every sync_run row newer than after_id, oldest first — one nightly's per-source detail.
+
+    Capture MAX(id) before pipeline.sync, pass it here after, and you get exactly the rows that
+    run wrote (sync_run.id is autoincrement).
+    """
+    cur = conn.execute(
+        "SELECT source, status, rows_fetched, rows_upserted, error "
+        "FROM sync_run WHERE id > ? ORDER BY id", (after_id,))
+    cols = [c[0] for c in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]


### PR DESCRIPTION
Expands the nightly's Slack feedback from a single line into a **multi-section report**, so a bad night is diagnosable from Slack alone. Design: `docs/superpowers/specs/2026-07-19-nightly-slack-report-design.md`.

## Why

The unified nightly now runs ~8 steps (sync, award summaries, portal, Ariba attachments, Zoo/TRCA/EP board reports, monthly council, supplier rebuild, export). One line hid almost all of it, and the richest signal — `sync_run`'s per-source `rows_fetched`/`rows_upserted`/status — was never surfaced.

## What the report now looks like

```
*✅ toronto-bids nightly* · 58m04s

*Steps*
✅ sync              9/9 sources · 3m12s
✅ award summaries   +12 bids stored
➖ council           not the 1st
❌ ariba attachments browser died · 48m00s
✅ agencies          +7 awards, +15 bids · 6m
✅ export            31.1 MiB

*Sources* (fetched → new)
odata_solicitations 7,446 → +12 · ckan_awarded 14,165 → +8
⚠ suspended_firms 0 fetched

*Growth*
solicitations 7,446 (+12) · bids 18,632 (+27) · ariba files 1,111 (+111) · ...

*Failures (1)*
ariba_attachments: browser died
```

The `⚠` flags a source that fetched **0 rows** — the silent-upstream-break the old "9/9 ok" hid.

## Two-message design (chosen)

Publishing happens in the wrapper *after* `tb nightly` posts, so one message can't include the publish outcome. `tb nightly` posts the archive report; **`publish-data.sh` posts a one-line publish result** (✅ + release URL / ❌ + reason), credential-safe and best-effort.

## How it's built (4 reviewed tasks)

1. **`db.sync_runs_since`** — this-run per-source rows (`sync_run.id > cutoff`).
2. **`summarize(report: dict)`** — pure and **total over a partial report** (a missing section is omitted, never a `KeyError` — the report must never be the thing that fails the run it exists to make visible).
3. **`_run_step`** — times each step, records status/detail, and **mirrors failures into the authoritative list** so the exit-code contract is untouched and isolation is preserved (a raising browser step still lets the export and post run).
4. **`slack_notify`** in `publish-data.sh` — webhook passed only as the curl URL (repo is public), `--max-time` bounded, never changes the publish exit code.

## Testing / review

- **569 tests pass** (offline). New coverage: `sync_runs_since`, the report renderer across clean/failed/skip/zero-fetch/nothing-moved/empty-before cases, `_run_step` isolation + failure-mirroring, and the Steps/Sources/Failures sections in a real nightly.
- Each task spec+quality reviewed (one caught a dropped export-FAILED test → restored). Whole-branch review on the most capable model — **all load-bearing guarantees HOLD**, no Critical/Important; isolation explicitly traced ("no step exception reaches past its handler before export/post").
- Heartbeat (every-run post) and the exit-code contract are unchanged — only the presentation expanded.

Post-merge: one live nightly on plexbox to confirm the multi-section message renders and the publish line follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
