### PR TITLE
fix(nightly): Sources report shows only real feeds with honest fetched counts

### DIFF
--- a/scrapers/tests/test_nightly.py
+++ b/scrapers/tests/test_nightly.py
@@ -210,6 +210,23 @@ def test_an_agency_body_failure_is_recorded_but_export_still_runs(nightly, monke
     assert (tmp_path / "export" / "bids.json").exists()
 
 
+def test_report_sources_excludes_linking_passes_and_validator(conn):
+    # sync_run records the linking passes and the schema-drift validator too; they are not
+    # fetch sources (a pass touching 0 rows is normal), so the Sources list must drop them —
+    # otherwise every night falsely ⚠-flags title_cleanup/ariba_bridge/schema_check as broken.
+    from toronto_bids import cli
+    from toronto_bids.store import db as _db
+    for src, fetched in (("schema_check", 0), ("odata_solicitations", 7446),
+                         ("supplier_dimension", 8020), ("title_cleanup", 0)):
+        rid = _db.start_sync_run(conn, src)
+        _db.finish_sync_run(conn, rid, status="ok", rows_fetched=fetched, rows_upserted=fetched)
+    names = [r["source"] for r in cli._report_sources(conn, 0)]
+    assert "odata_solicitations" in names
+    assert "schema_check" not in names          # validator, fetches 0 by nature
+    assert "supplier_dimension" not in names     # linking pass, not a fetch
+    assert "title_cleanup" not in names          # linking pass, not a fetch
+
+
 def test_report_has_a_steps_section_naming_each_step(nightly, monkeypatch):
     posted = {}
     from toronto_bids import notify

--- a/scrapers/tests/test_notify.py
+++ b/scrapers/tests/test_notify.py
@@ -57,8 +57,9 @@ def test_sources_section_flags_zero_fetch():
               ],
               "export_bytes": 1000, "elapsed_s": 60.0}
     text = notify.summarize(report)
-    assert "*Sources* (fetched → new)" in text
-    assert "odata_solicitations 7,446 → +12" in text
+    assert "*Sources* (fetched)" in text
+    assert "odata_solicitations 7,446" in text
+    assert "→ +" not in text   # rows_upserted is written-rows, NOT "new" — Growth owns new-record counts
     assert "⚠ suspended_firms 0 fetched" in text
 
 

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -130,6 +130,20 @@ def _run_step(steps: list, failures: list, name: str, fn) -> None:
         failures.append((name, str(exc)))
 
 
+def _report_sources(conn, after_id: int) -> list:
+    """This-run sync_run rows for the DATA fetch sources only — the report's Sources section.
+
+    sync_run also records the schema-drift validator (`schema_check`, which writes 0 rows by
+    nature) and the post-source linking passes (`title_cleanup`, `ariba_bridge`,
+    `amount_backfill`, `amount_labels`, `supplier_dimension`). Those are not fetches — a pass
+    touching 0 rows is normal — so including them would falsely ⚠-flag them as broken every
+    single night. Keep only the real City feeds; a genuine `schema_check` failure still surfaces
+    in the Failures section via pipeline.sync's return.
+    """
+    names = {s.name for s in pipeline.default_sources()} - {"schema_check"}
+    return [r for r in db.sync_runs_since(conn, after_id) if r["source"] in names]
+
+
 def _open_db():
     config.DATA_DIR.mkdir(parents=True, exist_ok=True)
     conn = db.connect(config.DB_PATH)
@@ -469,7 +483,7 @@ def _cmd_nightly(args) -> int:
                 _run_step(steps, failures, "sync", _sync)
 
                 try:
-                    sources.extend(db.sync_runs_since(conn, sync_cutoff))
+                    sources.extend(_report_sources(conn, sync_cutoff))
                 except Exception as exc:
                     failures.append(("sync_detail", str(exc)))
 

--- a/scrapers/toronto_bids/notify.py
+++ b/scrapers/toronto_bids/notify.py
@@ -75,16 +75,18 @@ def summarize(report: dict) -> str:
             lines.append(f"{icon} {s.get('name', '?')}  {detail}{suffix}".rstrip())
 
     if sources:
-        lines += ["", "*Sources* (fetched → new)"]
+        # Fetched rows per data source — did each City feed respond, and with how much. NOT
+        # rows_upserted: that is written-rows (a COALESCE upsert, one record → many rows), which
+        # exceeds fetched and is not "new". The Growth section owns the real new-record counts.
+        lines += ["", "*Sources* (fetched)"]
         ok_segs, warns = [], []
         for r in sources:
             fetched = r.get("rows_fetched", 0) or 0
-            new = r.get("rows_upserted", 0) or 0
             if r.get("status") != "ok" or fetched == 0:
                 extra = "" if r.get("status") == "ok" else f" ({r.get('status')})"
                 warns.append(f"⚠ {r.get('source', '?')} {fetched:,} fetched{extra}")
             else:
-                ok_segs.append(f"{r.get('source', '?')} {fetched:,} → +{new:,}")
+                ok_segs.append(f"{r.get('source', '?')} {fetched:,}")
         if ok_segs:
             lines.append(" · ".join(ok_segs))
         lines += warns


### PR DESCRIPTION
Follow-up to #157, surfaced by the **live verification** on plexbox (the check the offline fixtures structurally couldn't do — they used clean synthetic `sync_run` rows).

## What the live render exposed

Rendering the new report against the real DB showed the Sources section was wrong two ways:

1. **False `⚠` every night.** `sync_run` records not just City feeds but also the schema-drift validator (`schema_check`) and the five post-source linking passes (`title_cleanup`, `ariba_bridge`, `amount_backfill`, `amount_labels`, `supplier_dimension`). Those touch 0 rows by nature, so they rendered as `⚠ … 0 fetched` — 4-5 false alarms per run, which trains the reader to ignore `⚠` (defeating the one signal the section exists for).
2. **`rows_upserted` mislabeled as `→ +new`.** It's *written* rows (a COALESCE upsert, one record → many rows), so it exceeds fetched: `odata_solicitations 7,657 → +15,134` is meaningless as "new." The real new-record counts are already the Growth section.

## Fix

- New `cli._report_sources(conn, after_id)` filters Sources to the real data feeds (`pipeline.default_sources()` minus `schema_check`), dropping the linking passes. A genuine `schema_check` failure still surfaces in **Failures** (via `pipeline.sync`'s return), so nothing is lost.
- Sources now shows **fetched only** (`odata_solicitations 7,657`), with `⚠` reserved for a real feed that fetched 0 or failed — a genuine upstream break. Growth owns "what's new."

## Before → after (live render)

```
before:  ⚠ schema_check 0 fetched · ⚠ title_cleanup 0 fetched · odata_solicitations 7,657 → +15,134 · ...
after:   odata_solicitations 7,657 · odata_noncompetitive 2,956 · ckan_awarded 7,574 · ... · suspended_firms 3
```

## Testing

- **570 tests pass.** Updated the Sources rendering test (fetched-only, no `→ +`), added `test_report_sources_excludes_linking_passes_and_validator` (seeds a validator + a pass + a feed, asserts only the feed survives).
- Re-verified by rendering against the live plexbox DB — Sources now lists exactly the 8 City feeds, cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE