### PR TITLE
feat(deploy): mirror bids.sqlite to a CORS-enabled R2 bucket (#155)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -183,6 +183,36 @@ unzip -q -o /tmp/agendas/council-agendas.zip -d ~/tb-data/council/agendas
 cd ~/toronto-bids/scrapers && TB_DATA_DIR=~/tb-data uv run tb enrich-titles   # offline, no browser
 ```
 
+### R2 mirror of bids.sqlite — for browser-side Datasette-Lite (#155)
+
+GitHub release assets no longer send `Access-Control-Allow-Origin`, so the frontend's in-browser
+SQL page cannot load `bids.sqlite` from the release. `publish-data.sh` therefore also mirrors
+`bids.sqlite` each night to a **CORS-enabled Cloudflare R2 bucket** (overwriting the same object,
+so the URL is stable), reusing `CLOUDFLARE_API_TOKEN` via `wrangler`. The step is **best-effort**
+(a failed push warns; the GitHub release is the deliverable) and **skips cleanly** when
+`CLOUDFLARE_API_TOKEN` is unset.
+
+Public URL: `https://pub-99a890c186c743c19ef7bcd00024dca8.r2.dev/bids.sqlite`
+(Datasette-Lite: `https://lite.datasette.io/?url=<that URL>`).
+
+**One-time R2 setup** (already done for the current deployment):
+
+```shell
+# 1. Enable R2 in the Cloudflare dashboard (accept terms; free tier covers this).
+# 2. Create a scoped API token (Workers R2 Storage: Edit) + note the Account ID; add to tb.env:
+#      CLOUDFLARE_API_TOKEN=...      (0600, gitignored — same file as the Slack webhook)
+#      CLOUDFLARE_ACCOUNT_ID=...
+# 3. Provision the bucket (wrangler runs via npx — no global install):
+wr() { ( set -a; . ~/.config/toronto-bids/tb.env; set +a; npx -y wrangler@latest "$@" ); }
+wr r2 bucket create toronto-bids-data
+wr r2 bucket dev-url enable toronto-bids-data          # -> the public pub-*.r2.dev URL
+# CORS must allow '*' (NOT the frontend origin — Datasette-Lite fetches from lite.datasette.io):
+printf '{"rules":[{"allowed":{"origins":["*"],"methods":["GET","HEAD"],"headers":["*"]},"maxAgeSeconds":3600}]}' > /tmp/r2-cors.json
+wr r2 bucket cors set toronto-bids-data --file /tmp/r2-cors.json
+```
+
+`TB_R2_BUCKET` overrides the bucket name (default `toronto-bids-data`).
+
 ## What does NOT run here
 
 `enrich-council` needs a **headed** Chromium (TMMIS is Akamai-gated and blocks headless), but

--- a/deploy/publish-data.sh
+++ b/deploy/publish-data.sh
@@ -113,6 +113,32 @@ else
   echo "publish-data: WARNING — no cached agendas at $AGENDAS_DIR to archive" >&2
 fi
 
+# 5c. Mirror bids.sqlite to the CORS-enabled R2 bucket for browser-side Datasette-Lite (#155).
+#     GitHub release assets no longer send CORS, so the in-browser SQL page loads the DB from R2
+#     instead. Reuses CLOUDFLARE_API_TOKEN (already in tb.env for provisioning) via wrangler —
+#     overwrite the same object each night so the URL is stable. Best-effort: the GitHub release
+#     is the deliverable; a failed R2 push leaves last night's copy and only warns. Skips cleanly
+#     when R2 is not configured (dev/CI, or before the account is set up).
+R2_BUCKET="${TB_R2_BUCKET:-toronto-bids-data}"
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  echo "publish-data: R2 not configured (no CLOUDFLARE_API_TOKEN) — skipping the bucket mirror"
+elif [ "$DRY_RUN" = 1 ]; then
+  echo "DRY-RUN wrangler r2 object put $R2_BUCKET/bids.sqlite --file $SQLITE --remote"
+else
+  # systemd's PATH is minimal; make node/npx findable, preferring the newest nvm node.
+  if ! command -v npx >/dev/null 2>&1; then
+    _node_bin="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
+    [ -n "$_node_bin" ] && PATH="$_node_bin:$PATH"
+  fi
+  # Pinned version so a warm npx cache is reused (no nightly re-resolve of "latest").
+  if npx -y wrangler@4.112.0 r2 object put "$R2_BUCKET/bids.sqlite" \
+        --file "$SQLITE" --remote --content-type application/x-sqlite3 >/dev/null 2>&1; then
+    echo "publish-data: mirrored bids.sqlite to R2 bucket $R2_BUCKET"
+  else
+    echo "publish-data: WARNING — R2 upload of bids.sqlite failed (release is published)" >&2
+  fi
+fi
+
 # 6. On the 1st, cut a dated snapshot for citation (idempotent — skip if it already exists).
 if [ "$DAY" = 01 ]; then
   TAG="snapshot-$SNAPSHOT_DATE"


### PR DESCRIPTION
Fixes #155. The publisher-side companion to `CivicTechTO/toronto-bids-frontend#2`.

GitHub release assets no longer send `Access-Control-Allow-Origin`, so the frontend's in-browser SQL page (Datasette-Lite) can't load `bids.sqlite` from the release. This mirrors `bids.sqlite` each night to a **CORS-enabled Cloudflare R2 bucket**.

## What's built

`publish-data.sh` gains a `5c` step: `wrangler r2 object put toronto-bids-data/bids.sqlite …`, reusing the `CLOUDFLARE_API_TOKEN` already in `tb.env` (no new credential, no global install — wrangler runs via `npx`; systemd's minimal PATH is handled by resolving the newest nvm node). Overwrites the same object nightly → stable URL.

- **Best-effort**: a failed push warns; the GitHub release is the deliverable. **Skips cleanly** when `CLOUDFLARE_API_TOKEN` is unset (dev/CI).
- Bucket name via `TB_R2_BUCKET` (default `toronto-bids-data`).
- README documents the one-time R2 setup (enable R2, scoped token, `bucket create` / `dev-url enable` / `cors set`), including the CORS trap: allow `*`, **not** the frontend origin (Datasette-Lite fetches from `lite.datasette.io`).

## Provisioned + verified live (plexbox)

Bucket created, dev-url enabled, CORS set to `*` / GET,HEAD, and a real upload verified against **all three acceptance criteria**:

- `curl -H "Origin: https://lite.datasette.io" .../bids.sqlite` → `200` + `access-control-allow-origin: *`
- OPTIONS preflight → `204` + ACAO `*` + `Allow-Methods: GET, HEAD`
- **range request** (206) → ACAO `*` + `Accept-Ranges: bytes` (Datasette-Lite's real access pattern); bytes are a valid SQLite file
- the script's exact nightly command uploads and serves fresh

Public URL: `https://pub-99a890c186c743c19ef7bcd00024dca8.r2.dev/bids.sqlite`

## Testing

`bash -n` clean; dry-run shows the R2 command with a token and skips cleanly without one; the real upload path verified end-to-end. No Python touched (569 tests unaffected).

## Frontend follow-up (tracked on `toronto-bids-frontend#2`)

Point the Datasette-Lite `?url=` at the R2 URL above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE