### PR TITLE
fix(supplier): entity resolution — stop numbered/O-A/garbage variants splitting one firm (#160)

### DIFF
--- a/docs/superpowers/plans/2026-07-19-supplier-entity-resolution.md
+++ b/docs/superpowers/plans/2026-07-19-supplier-entity-resolution.md
@@ -1,0 +1,297 @@
+# Supplier Entity Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the same legal entity splitting across many supplier rows — canonicalize numbered companies to their corporation number, fold guarded named-company trade names, salvage/exclude garbage names — and document the entity-resolution methodology with measured false-merge/false-exclude counts.
+
+**Architecture:** Rewrite `supplier_key(raw)` in `linking/supplier.py` into an ordered staged pipeline (salvage → exclude → number → guarded-marker → default). `build_supplier_dimension` is unchanged and rebuilds the dimension each sync, so the rule change re-groups on the next run with no migration. A methodology doc records the live-measured figures.
+
+**Tech Stack:** Python 3.12, `uv`, pytest (offline, fixture-based). The live-measurement gate runs against `~/tb-data/bids.sqlite` on the box.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-19-supplier-entity-resolution-design.md`.
+- **No lint/format/typecheck exists** — the only check is `uv run pytest` from `scrapers/`.
+- **`supplier_key` stays pure and total**: any input (None/blank/garbage/exotic) returns a string; `""` means "no supplier" and `build_supplier_dimension` already skips it. It must never raise (it runs inside an isolated linking pass).
+- **Named companies keep their legal suffix by default** (the conservative existing behavior): `supplier_key("Capital Sewer Services Inc.") != supplier_key("Capital Sewer Services Ltd.")` MUST still hold. Only the numbered/marker/garbage rules deviate.
+- **No length-based garbage rule** — legitimate consortium names run 100-184 chars.
+- The public function name stays **`supplier_key`** (callers in `build_supplier_dimension` and tests import it); do not rename it.
+- Commit trailers on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
+  ```
+- Branch `feat-160-supplier-entity-resolution` (already checked out). Do not commit to `main`.
+
+## File Structure
+
+- `scrapers/toronto_bids/linking/supplier.py` — rewrite `supplier_key` + add rule helpers/regexes (Task 1).
+- `scrapers/tests/test_supplier_key.py` — extend with per-rule tests incl. traps (Task 1).
+- `docs/supplier-entity-resolution.md` — methodology doc with measured figures (Task 2).
+
+---
+
+## Task 1: Staged `supplier_key` pipeline (all rules)
+
+**Files:**
+- Modify: `scrapers/toronto_bids/linking/supplier.py` (`supplier_key` ~lines 7-24; add regexes/helpers above it)
+- Test: `scrapers/tests/test_supplier_key.py`
+
+**Interfaces:**
+- Produces: `supplier_key(raw: str | None) -> str` — same signature, new staged behavior. `""` for garbage/blank (skipped by caller). `#<number>` for numbered firms. Legal base for guarded markers. Conservative normalization otherwise.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Write the failing tests** — replace/extend `tests/test_supplier_key.py`. Keep the existing tests (Submitted-by strip, Inc≠Ltd, blank→""). Add these, which encode the measured traps verbatim:
+
+```python
+from toronto_bids.linking.supplier import supplier_key
+
+
+# --- Rule 1: numbered companies key to #<number> ---
+def test_numbered_company_variants_collapse_to_the_number():
+    for raw in ["2489960 ONTARIO INC",
+                "2489960 Ontario Inc. o/a Kore Infrastructure Group",
+                "2489960 ONTARIO LTD",
+                "2489960 ONTARIO INCORPORATED",
+                "2489960 Ontario Inc. operating as Kore Infrastructure Group"]:
+        assert supplier_key(raw) == "#2489960", raw
+
+def test_numbered_reverse_order_and_typo_still_key_to_the_number():
+    # trade-name-first, number in the middle; and a 0/A zero-for-O typo
+    assert supplier_key("TRISAN CONSTRUCTION O/A 614128 ONTARIO LTD.") == "#614128"
+    assert supplier_key("614128 ONTARIO LTD, O/A TRISAN CONSTRUCTION") == "#614128"
+    assert supplier_key("1568796 ONTARIO INC, 0/A RENOKREW") == "#1568796"
+
+def test_a_stray_parenthetical_number_does_not_steal_the_key():
+    # the leading corp number is the identity; the (3059515) is ignored
+    assert supplier_key("614128 ONTARIO LTD O/A TRISAN CONSTRUCTION (3059515)") == "#614128"
+
+def test_a_short_or_addressy_number_is_not_a_corp_number():
+    # 3-digit / non-corp-length numbers must not trigger Rule 1
+    assert supplier_key("123 Ontario Street Holdings Inc.") != "#123"
+
+
+# --- Rule 2: named-company trade-name folding, guarded ---
+def test_named_trade_name_folds_to_the_legal_base():
+    assert supplier_key("Corporate Express Canada Inc., operating as Staples Business Advantage") == \
+           supplier_key("Corporate Express Canada Inc. (operating as Staples Advantage Canada)")
+    assert supplier_key("R.O.M. Contractors Inc. o/a Ross Clair Contractors") == \
+           supplier_key("R.O.M. Contractors Inc o/a Ross Clair Contractor")
+
+def test_marker_strip_is_refused_when_the_base_is_generic():
+    # stripping 'o/a Trans Canada' leaves the generic fragment 'ontario ltd' — must NOT merge there
+    assert supplier_key("Ontario Ltd. o/a Trans Canada Construction") != "ontario ltd"
+
+
+# --- Rule 3: salvage noise wrappers, exclude only pure footnote ---
+def test_appendix_and_noncompliant_noise_is_salvaged_not_excluded():
+    assert supplier_key('Fermar Paving Limited* Non-compliant') == supplier_key("Fermar Paving Limited")
+    assert supplier_key('Appendix "C" Benson Group Inc.') == supplier_key("Benson Group Inc.")
+    assert supplier_key('LTH Electric Inspection & Service Ltd. Appendix "C" Price Form') == \
+           supplier_key("LTH Electric Inspection & Service Ltd.")
+
+def test_pure_footnote_is_excluded():
+    for raw in ["Please see Scope for Award Details",
+                "See Prequalified List below in the Scope of Work",
+                "Various ( see the link)",
+                "1 Bidder was found non-compliant with mandatory requirements.",
+                "Part A: Econolite Canada Incorporated Orange Traffic Tacel Ltd. Fortran Traffic"]:
+        assert supplier_key(raw) == "", raw
+
+def test_a_long_real_consortium_name_is_kept_not_excluded():
+    # 100+ char legitimate multi-firm name must survive (no length rule)
+    name = ("Alaimo Architecture Inc., Bortolotto Design Architects Inc., "
+            "Paul Didur Architect Inc., Unlimited Design Studio Inc.")
+    assert supplier_key(name) != ""
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd scrapers && uv run pytest tests/test_supplier_key.py -v`
+Expected: FAIL — the new behavior isn't implemented.
+
+- [ ] **Step 3: Rewrite `supplier_key` and add the rule regexes/helpers**
+
+In `linking/supplier.py`, replace the current regex block + `supplier_key` with this (the regexes are the final measured patterns; do not weaken them):
+
+```python
+import json
+import re
+
+from toronto_bids.models import Supplier
+from toronto_bids.store import db
+
+_SUBMITTED_BY = re.compile(r"\(\s*submitted by:.*?\)", re.IGNORECASE)
+_NON_KEY = re.compile(r"[^a-z0-9 ]")
+_WS = re.compile(r"\s+")
+
+# Rule 3 salvage: strip appendix / price-form / trailing non-compliant noise wrappers.
+_NOISE = re.compile(
+    r'\(?\s*appendix\s*["“‘\']?\s*[a-z]?\d*\s*["”’\']?\s*[–-]?\s*(?:price\s*form)?\s*\)?',
+    re.IGNORECASE)
+_NONCOMPLIANT = re.compile(r'\*?\s*non-?compliant.*$', re.IGNORECASE)
+
+# Rule 3 exclude: pure footnote (no firm identity). Anchored — matches only strings that START
+# with a footnote phrase, so a real firm name is never excluded.
+_FOOTNOTE = re.compile(
+    r"^(?:please see|see prequalif|see the|refer to|as per|various\b|bid prices|"
+    r"\d+\s*/?\s*bidder was found|the scope of work|\d+\s+bidder\b|part [a-z]:|"
+    r"corrected for mathematical|award amounts have been)", re.IGNORECASE)
+
+# Rule 1: a corporation number (6-7 digits) adjacent to a province token, anywhere in the name.
+_CORP = re.compile(r"\b(\d{6,7})\s+(?:ontario|ont|canada|quebec|qc)\b", re.IGNORECASE)
+
+# Rule 2: a trailing trade-name marker (and everything after it).
+_MARK = re.compile(
+    r"\s*(?:,\s*)?(?:\bo/?a\b|\b0/a\b|\boperating as\b|\bc\.?o\.?b\.?(?:\s*as)?\b|"
+    r"\bd\.?b\.?a\.?\b|\btrading as\b|\bt/a\b)\b.*$", re.IGNORECASE)
+_LEGAL_SUFFIX = {"inc", "ltd", "limited", "incorporated", "corp", "corporation", "co",
+                 "company", "canada", "ontario", "ont", "llp", "lp", "the", "and"}
+_GENERIC_BASE = {"ontario ltd", "ontario limited", "ontario inc", "ontario incorporated",
+                 "ontario", "inc", "ltd", "limited", "incorporated", "canada inc",
+                 "canada ltd", "canada"}
+
+
+def _normalize(text: str) -> str:
+    """Today's conservative key: drop a Submitted-by note, lowercase, strip non-[a-z0-9 ],
+    collapse whitespace. Legal suffixes are intentionally kept so different named firms don't
+    merge."""
+    text = _SUBMITTED_BY.sub(" ", str(text))
+    text = _NON_KEY.sub(" ", text.lower())
+    return _WS.sub(" ", text).strip()
+
+
+def _salvage(text: str) -> str:
+    """Rule 3 salvage: strip appendix/price-form/non-compliant noise wrappers so a real firm
+    wrapped in scraped footnote noise (e.g. 'Fermar Paving Limited* Non-compliant') survives."""
+    text = _NONCOMPLIANT.sub(" ", str(text))
+    text = _NOISE.sub(" ", text)
+    return _WS.sub(" ", text).strip(' *"')
+
+
+def supplier_key(raw: str | None) -> str:
+    """Deterministic entity-resolution key for a raw supplier name.
+
+    Staged (first match wins), see docs/supplier-entity-resolution.md:
+      1. salvage noise wrappers, then exclude pure footnote -> "" (caller skips).
+      2. a corporation number adjacent to a province token, anywhere -> "#<number>"
+         (the number IS the legal identity; Inc/Ltd/Incorporated/O-A/JV are noise).
+      3. a trailing trade-name marker on a NON-numbered name -> the legal base, but only when
+         the base is not generic (guards the 'ontario ltd' over-merge).
+      4. otherwise today's conservative normalization (legal suffix kept).
+    Returns "" for blank/garbage. Pure and total; never raises.
+    """
+    if raw is None:
+        return ""
+    salvaged = _salvage(raw)                                   # Rule 3 salvage
+    if not salvaged or _FOOTNOTE.search(salvaged):             # Rule 3 exclude
+        return ""
+    m = _CORP.search(salvaged)                                 # Rule 1
+    if m:
+        return f"#{m.group(1)}"
+    if _MARK.search(salvaged):                                 # Rule 2 (guarded)
+        base = _normalize(_MARK.sub("", salvaged))
+        if base and base not in _GENERIC_BASE and any(t not in _LEGAL_SUFFIX for t in base.split()):
+            return base
+    return _normalize(salvaged)                                # Rule 4 default
+```
+
+Leave `build_supplier_dimension` and everything below it unchanged.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd scrapers && uv run pytest tests/test_supplier_key.py -v`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Full suite**
+
+Run: `cd scrapers && uv run pytest -q`
+Expected: PASS. If `tests/test_supplier_dimension.py` asserts a specific pre-existing key string that a rule now changes, update that assertion to the new key (only if it is genuinely a numbered/marker/garbage case; a plain named firm must be unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scrapers/toronto_bids/linking/supplier.py scrapers/tests/test_supplier_key.py
+git commit -m "feat(supplier): staged entity-resolution key (numbered / marker / garbage)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE"
+```
+
+---
+
+## Task 2: Live-measurement gate + methodology doc
+
+**Files:**
+- Create: `docs/supplier-entity-resolution.md`
+- (No code change; runs the new `supplier_key` against the real DB and records figures.)
+
+**Interfaces:** none.
+
+This task is the #136/#138 discipline: prove the rules against the real 8,022-row dimension and write the methodology reviewers asked for. It runs on the box (`~/tb-data/bids.sqlite` exists).
+
+- [ ] **Step 1: Run the live audit** — this script applies the *new* `supplier_key` and reports the figures the doc must cite. Run it and capture the output:
+
+```bash
+cd /home/alex/toronto-bids/scrapers && TB_DATA_DIR="$HOME/tb-data" uv run python - <<'PY'
+import sqlite3, collections, re
+from toronto_bids import config
+from toronto_bids.linking.supplier import supplier_key, _LEGAL_SUFFIX, _normalize
+c = sqlite3.connect(config.DB_PATH)
+rows = [r[0] for r in c.execute("SELECT display_name FROM supplier")]
+grp = collections.defaultdict(set); excluded = []
+for d in rows:
+    k = supplier_key(d)
+    (excluded.append(d) if k == "" else grp[k].add(d))
+print(f"supplier rows: {len(rows)}  ->  distinct keys: {len(grp)}  (excluded: {len(excluded)})")
+merged = {k: v for k, v in grp.items() if len(v) > 1}
+numbered = {k: v for k, v in merged.items() if k.startswith('#')}
+named = {k: v for k, v in merged.items() if not k.startswith('#')}
+print(f"keys merging >1 raw name: {len(merged)} ({len(numbered)} numbered, {len(named)} named)")
+# FALSE-MERGE audit: named merges with no shared significant token
+def toks(d): return {t for t in _normalize(d).split() if t not in _LEGAL_SUFFIX and len(t) > 2}
+fm = [(k, v) for k, v in named.items() if not (set.intersection(*[toks(d) for d in v]))]
+print(f"NAMED false-merge candidates (no shared token): {len(fm)}")
+for k, v in fm[:10]:
+    print(f"   {k!r}: {list(v)[:3]}")
+# FALSE-EXCLUDE audit: excluded rows that contain a strong firm word
+fe = [d for d in excluded if re.search(r'\b(construction|paving|electric|architect|engineering|inc|ltd|limited|group|services)\b', d, re.I)]
+print(f"excluded rows containing a firm word (false-exclude candidates): {len(fe)}")
+for d in fe[:12]: print(f"   {d[:90]!r}")
+# flagship
+print("2489960 members:", sum(1 for d in rows if supplier_key(d) == '#2489960'))
+PY
+```
+
+- [ ] **Step 2: Adjudicate the audits.** For every NAMED false-merge candidate, confirm it is the same firm (typo/truncation) or a real over-merge; for every false-exclude candidate, confirm it is genuine footnote or a wrongly-dropped firm. If either audit shows a *real* defect (a true false-merge, or a real firm excluded), STOP and fix the regexes in `supplier.py` (Task 1 file) before writing the doc — the doc must report the corrected, true figures. Record the final counts.
+
+- [ ] **Step 3: Write `docs/supplier-entity-resolution.md`** with, at minimum:
+  - The four staged rules in plain language, each with one example (from the spec).
+  - The **measured table**: rows before → distinct keys after; per-rule collapse counts (numbered groups collapsed, named groups folded, rows excluded); the **false-merge count** and **false-exclude count** from Step 1-2 (the actual audited figures).
+  - The **JV attribution** choice: a numbered-lead joint venture folds into the lead firm.
+  - The **residual known limits**: named firms still split by Inc vs Ltd (deliberate — no number to anchor); multi-firm list-blobs excluded, not split; any group the audit leaves unmerged.
+  - A one-line note on how to re-run the audit (the Step 1 script).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/supplier-entity-resolution.md
+git commit -m "docs: supplier entity-resolution methodology + measured audit (#160)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE"
+```
+
+---
+
+## Post-implementation
+
+Comment on #160 with the measured before/after (rows collapsed, flagship `2489960` $458M→$503M, false-merge/false-exclude counts) and link the methodology doc.
+
+## Self-Review
+
+**Spec coverage:** Rule 1 numbered → Task 1 (`_CORP`, tests) ✓; Rule 2 guarded marker → Task 1 (`_MARK`+guards, tests) ✓; Rule 3 salvage-then-exclude → Task 1 (`_salvage`/`_NOISE`/`_NONCOMPLIANT`/`_FOOTNOTE`, tests) ✓; no length rule ✓ (none present); named Inc≠Ltd preserved → Global Constraint + existing test kept ✓; methodology doc w/ measured figures + JV note + residual limits → Task 2 ✓; live-measurement gate → Task 2 Steps 1-2 ✓; pure/total/never-raises → Global Constraint + `supplier_key` structure ✓.
+
+**Placeholder scan:** none — every regex is the final measured pattern; the doc's numbers come from the Step 1 script (real figures, not placeholders).
+
+**Type consistency:** `supplier_key(raw: str | None) -> str` unchanged signature; helpers `_normalize`/`_salvage` and the module regexes are defined in Task 1 and consumed by the Task 2 audit script (imports `supplier_key`, `_LEGAL_SUFFIX`, `_normalize` — all defined in Task 1).

--- a/docs/superpowers/specs/2026-07-19-supplier-entity-resolution-design.md
+++ b/docs/superpowers/specs/2026-07-19-supplier-entity-resolution-design.md
@@ -92,20 +92,33 @@ marker and everything after it — `O/A` (and `0/A` typo), `operating as`, `d.b.
 R.O.M.→Ross Clair, Holcim→Dufferin, Bell Canada). A **false-merge audit** (do any two distinct
 legal bases collapse together?) is part of the implementation gate, not assumed.
 
-## 5. Rule 3 — garbage-name exclusion (safe)
+## 5. Rule 3 — salvage-then-exclude (refined against the audit)
 
-**Rule.** A supplier name that is footnote/non-name text keys to `""` (skipped — no supplier row,
-award keeps `supplier_id` NULL: an honest "unknown", not an invented firm).
+The blunt "exclude every footnote-matching row" was **measured wrong**: with pattern-only
+detection, **~35 of ~80 flagged rows are real firms wrapped in noise** (`LTH Electric Inspection &
+Service Ltd. Appendix "C" Price Form`, `Fermar Paving Limited* Non-compliant`, `Appendix "C"
+Benson Group Inc.`, `Premier Truck Group (Appendix "C" – Price Form)`). Excluding those sends
+real firms to `supplier_id` NULL — **under-counting**, the opposite of #160's goal. Also **length
+is a bad signal**: legitimate multi-firm consortium names run 100-184 chars (`Alaimo Architecture
+Inc., Bortolotto Design Architects Inc., …`), so a length cutoff false-excludes them. **No length
+rule.**
 
-**Detection** is **pattern-first**, length only as a weak secondary signal (real firm names reach
-~71 chars via `d.b.a.`/`operating as` aliases, so length alone false-excludes): phrases like
-`please see`, `see the link`, `refer to`, `as per`, `non-compliant`, `bidder was found`,
-`scope of work`/`scope for award`, `prequalified`, `appendix … price form`,
-`corrected for mathematical`. The exact pattern set is finalized against the flagged rows with a
-**false-exclude audit** (eyeball the flagged set for any real firm name).
+Two ordered steps, pattern-only:
 
-**Measured impact:** ~115 flagged rows, but only **12 awards / $2.9M** link to them — excluding
-them costs essentially nothing in the aggregates, and they are genuinely non-firms.
+1. **Salvage — strip a tightly-scoped noise wrapper**, then key the firm that remains:
+   `Appendix "<x>" Price Form` runs, a trailing `* Non-compliant …`, and `(Appendix …)`
+   parentheticals. `Fermar Paving Limited* Non-compliant` → `fermar paving limited`. This runs as
+   a normalization step before the default key (and before Rules 1/2, so a salvaged
+   `… Ltd. Appendix …` that is actually numbered still reaches Rule 1).
+2. **Exclude — only pure footnote** (no firm identity) → key `""` (skipped, award keeps
+   `supplier_id` NULL): `please see`, `see prequalified`, `refer to`, `as per`, `various (`,
+   `bid prices …`, `<n> bidder was found …`, `part <A-Z>: …` list-blobs, `the scope of work …`,
+   `corrected for mathematical`, `award amounts have been adjusted`.
+
+**Measured:** 50 rows excluded (all genuine non-firms), ~35 real firms recovered rather than
+dropped, **0 pure-footnote exclusions contain a firm word** (construction/paving/architect firms
+are not dropped). The exact pattern sets are finalized against the flagged rows with a
+**false-exclude audit** at the live gate (§9).
 
 ## 6. Methodology documentation (required deliverable)
 
@@ -155,7 +168,9 @@ No schema change; the dimension is rebuilt, not migrated.
 
 - Cross-firm resolution beyond exact-number / marker rules (e.g. fuzzy name matching, parent/
   subsidiary rollups) — a separate, higher-risk effort.
-- Salvaging a real name buried inside a garbage string (Rule 3 excludes; it does not repair).
+- Rule 3 salvage is limited to the tightly-scoped noise wrappers above (appendix / price-form /
+  non-compliant). It does **not** attempt to parse a firm out of an arbitrary sentence, and a
+  multi-firm list-blob (`Part A: Econolite … Orange Traffic …`) is excluded, not split.
 - Any change to how awards/amounts are parsed — this is purely the supplier *dimension*.
 
 ## 11. Recording

--- a/docs/superpowers/specs/2026-07-19-supplier-entity-resolution-design.md
+++ b/docs/superpowers/specs/2026-07-19-supplier-entity-resolution-design.md
@@ -1,0 +1,165 @@
+# Supplier entity resolution (#160)
+
+**Date:** 2026-07-19
+**Status:** approved, not yet implemented
+**Origin:** the 2026-07-19 multi-persona UX review of the frontend. The same legal entity appears
+as many supplier rows, splitting its total and distorting the flagship "who won the most" ranking.
+
+## 1. The problem, measured
+
+`2489960 Ontario Inc.` — a single legal entity — appears as **12+ supplier rows**
+(`2489960 ONTARIO INC`, `… O/A Kore Infrastructure Group`, `… operating as Kore …`,
+`2489960 ONTARIO LTD`, `2489960 ONTARIO INCORPORATED`, JV combinations, …), so its ~$503M of
+awards is split, and it ranks lower than it should. It is not alone: **41 numbered-company
+numbers appear as more than one supplier row** — Trisan, Bronte, Trans Canada, Samson: the large
+construction firms.
+
+The current `supplier_key` (lowercase, strip non-`[a-z0-9 ]`, collapse whitespace, **keep legal
+suffixes**) deliberately keeps `Inc`/`Ltd` so genuinely different named firms are not merged.
+That is right for *named* firms but wrong for *numbered* ones, where the corporation number is the
+identity and `Inc` vs `Ltd` vs `Incorporated` vs an `O/A` trade name is all noise.
+
+The issue's suggested "strip O/A" is **insufficient**: it would not merge `2489960 ontario inc`
+with `2489960 ontario ltd` (the suffix itself varies). Keying numbered firms on the **number**
+does.
+
+Two adjacent classes surfaced in the same probe:
+- **Named-company trade names** with no number to anchor (`Corporate Express Canada Inc.,
+  operating as Staples Business Advantage`) — foldable, but riskier.
+- **Garbage supplier names** — ~115 rows that are footnote text, not names (`Please see Scope for
+  Award Details`, non-compliance notes, appendix price-form blurbs).
+
+All measurements below were run against the live plexbox DB (`bids.sqlite`, 8,022 supplier rows,
+2026-07-19).
+
+## 2. Architecture
+
+One normalization pipeline in `linking/supplier.py`, replacing the current `supplier_key`:
+
+```
+canonical_supplier_key(raw) -> str
+```
+
+Ordered stages (first match wins):
+
+1. **Garbage → `""`** (Rule 3). A blank/garbage key returns `""`, which `build_supplier_dimension`
+   already skips — no supplier row created, the award keeps `supplier_id` NULL.
+2. **Corp number adjacent to a province token, anywhere → `#<number>`** (Rule 1).
+3. **Named trade-name marker, guarded strip → key on the legal base** (Rule 2).
+4. **Otherwise → today's normalization** (lowercase, strip non-`[a-z0-9 ]`, collapse whitespace,
+   keep legal suffix) — unchanged, conservative default.
+
+`build_supplier_dimension` is otherwise untouched; it clears and rebuilds the dimension every
+sync, so there is no migration and a rule change simply re-groups on the next run. The `variants`
+array (already built from every raw name in a group) makes every merge auditable from the export.
+
+## 3. Rule 1 — numbered companies (high confidence)
+
+**Rule.** If a corporation number (`\d{6,7}`) appears immediately adjacent to a province token
+(`ontario|ont|canada|quebec|…`) **anywhere** in the name, the key is `#<number>`.
+
+- Leading form (`2489960 Ontario Inc. o/a Kore`) and reverse-order form
+  (`TRISAN CONSTRUCTION O/A 614128 ONTARIO LTD`) both key to the same `#<number>`, so word order
+  no longer splits a firm.
+- **Measured:** 39 numbered-company groups collapse (94 duplicate rows removed); `2489960` →
+  **$458.0M → $503.4M**; the 11 groups a crude check flagged as "different trade names" were all
+  the **same** firm with typos/truncations (`transcanada`/`transcanadac`, `trisan`/`trisanconstr`,
+  a `0/A` zero-for-O typo) — **effectively zero real false-merges.** The corporation number is a
+  unique legal identifier; two different firms never share one.
+- **Stated caveat (JV attribution).** A joint venture led by a numbered company
+  (`2489960 … o/a Kore Infrastructure Group /JV Rabcon Contractors Ltd. and CG Construction`)
+  folds into the **lead** numbered firm. This is a deliberate attribution choice — the lead firm —
+  not a bug, and it is documented in the methodology (§6).
+- **Guard.** Require the province token adjacent to the digits so a stray number (a contract
+  number, a second corp number in a parenthetical like `(3059515)`) is not mistaken for the
+  identity — the leading/adjacent corp number wins.
+
+## 4. Rule 2 — named-company trade-name folding (medium, guarded)
+
+**Rule.** For a name with **no corp number** (Rule 1 owns those), strip a trailing trade-name
+marker and everything after it — `O/A` (and `0/A` typo), `operating as`, `d.b.a.`/`dba`,
+`c.o.b. as`/`cob as`, `trading as`, `t/a` — and key on the legal base before it.
+
+**Guards (both required, or the strip is refused and stage 4 runs instead):**
+- The stripped base must **not be generic**: a denylist of fragments that are not firms —
+  `ontario ltd`, `ontario limited`, `ontario inc`, `ontario incorporated`, bare `inc`/`ltd`/
+  `limited`, `canada inc`, etc. (This blocks the `'Ontario Ltd. o/a Trans Canada'` → `ontario ltd`
+  over-merge.)
+- The base must retain **at least one meaningful token** after legal-suffix removal (a length /
+  token-count floor).
+
+**Measured:** ~195 named-marked rows; ~22 groups collapse (Corporate Express→Staples,
+R.O.M.→Ross Clair, Holcim→Dufferin, Bell Canada). A **false-merge audit** (do any two distinct
+legal bases collapse together?) is part of the implementation gate, not assumed.
+
+## 5. Rule 3 — garbage-name exclusion (safe)
+
+**Rule.** A supplier name that is footnote/non-name text keys to `""` (skipped — no supplier row,
+award keeps `supplier_id` NULL: an honest "unknown", not an invented firm).
+
+**Detection** is **pattern-first**, length only as a weak secondary signal (real firm names reach
+~71 chars via `d.b.a.`/`operating as` aliases, so length alone false-excludes): phrases like
+`please see`, `see the link`, `refer to`, `as per`, `non-compliant`, `bidder was found`,
+`scope of work`/`scope for award`, `prequalified`, `appendix … price form`,
+`corrected for mathematical`. The exact pattern set is finalized against the flagged rows with a
+**false-exclude audit** (eyeball the flagged set for any real firm name).
+
+**Measured impact:** ~115 flagged rows, but only **12 awards / $2.9M** link to them — excluding
+them costs essentially nothing in the aggregates, and they are genuinely non-firms.
+
+## 6. Methodology documentation (required deliverable)
+
+Reviewers flagged that firm-level spend aggregation is currently **unassessable** because the
+matching method is unstated. A methodology note
+(`docs/supplier-entity-resolution.md` or a section the export/docs reference) states:
+
+- Each rule, in plain language, with an example.
+- The **measured numbers**: rows collapsed per rule, recall, **false-merge count**,
+  **false-exclude count** — the actual figures from the live audit, not estimates.
+- The **JV attribution** choice (Rule 1 folds a numbered-lead JV into the lead firm).
+- The **residual known limits**: named firms still split by `Inc` vs `Ltd` (deliberate — no number
+  to anchor), and any groups the audit leaves unmerged.
+
+This doc is as much the deliverable as the code; a firm total is only trustworthy if the reader
+can see how variants were matched and what the false-merge risk is.
+
+## 7. Data flow
+
+`canonical_supplier_key` (pure) → `build_supplier_dimension` groups raw names by it, clears and
+re-backfills `supplier_id` FKs each run → export's `suppliers[]` carries the canonical
+`display_name` + full `variants[]` → the frontend supplier pages show one correct total per firm.
+No schema change; the dimension is rebuilt, not migrated.
+
+## 8. Error handling
+
+- `canonical_supplier_key` is pure and total: any input (None, blank, garbage, exotic Unicode
+  already stripped by the non-`[a-z0-9 ]` pass) returns a string; `""` means "no supplier",
+  handled by the existing skip.
+- A rule must never raise inside `build_supplier_dimension` (which runs as an isolated linking
+  pass); the function stays exception-free over arbitrary strings.
+
+## 9. Testing
+
+- **Unit tests per rule**, with **real examples including the traps**:
+  - Rule 1: leading + reverse-order (`614128 … O/A Trisan` and `Trisan O/A 614128 Ontario Ltd`)
+    → same `#614128`; `Inc`/`Ltd`/`Incorporated` variants of one number → one key; a stray
+    parenthetical number does not steal the key.
+  - Rule 2: `Corporate Express … operating as Staples` folds; `Ontario Ltd. o/a Trans Canada`
+    is **refused** (generic base → stays split, not merged into `ontario ltd`).
+  - Rule 3: footnote strings excluded; a **real long name** (~71 chars with `d.b.a.`) is **kept**.
+- **Mandatory live-measurement gate** before "done": rerun the collapse count, the false-merge
+  audit (numbered + named), and the false-exclude audit on the real DB, and record the figures in
+  the methodology doc. Per #136/#138, the offline fixtures are a starting point, not proof.
+
+## 10. Out of scope
+
+- Cross-firm resolution beyond exact-number / marker rules (e.g. fuzzy name matching, parent/
+  subsidiary rollups) — a separate, higher-risk effort.
+- Salvaging a real name buried inside a garbage string (Rule 3 excludes; it does not repair).
+- Any change to how awards/amounts are parsed — this is purely the supplier *dimension*.
+
+## 11. Recording
+
+On completion, comment on #160 with the measured before/after (rows collapsed, flagship firm
+corrected, false-merge/false-exclude counts) and link the methodology doc. Note the sibling
+garbage-name observation is resolved here rather than left to a separate issue.

--- a/docs/supplier-entity-resolution.md
+++ b/docs/supplier-entity-resolution.md
@@ -141,6 +141,14 @@ and its members stay as separate suppliers under Rule 4 (default).
   single-firm rows).
 - **A non-numbered, non-incorporated joint venture is not folded.** See JV
   attribution above — only a numbered-lead JV is recognized.
+- **A numbered company with a trade-name marker but no province token is not
+  caught by the corp-number rule.** Rule 1 requires the number to sit
+  adjacent to a province token (`Ontario`/`Ont`/`Canada`); `'614128 o/a
+  Trisan Construction'` has none, so it falls through to the named
+  trade-name rule and keys as `614128` instead of `#614128` — splitting
+  from the province-bearing variant (`'614128 Ontario Ltd o/a Trisan'` →
+  `#614128`). Not observed in the current corpus (real rows carry the
+  province token), but it is a real residual limit of the anchoring rule.
 - **Any group the audit would flag stays unmerged/unexcluded until fixed.**
   The two audits below (false-merge, false-exclude) are the trip-wire for
   this; both are currently clean (see Measured figures).

--- a/docs/supplier-entity-resolution.md
+++ b/docs/supplier-entity-resolution.md
@@ -1,0 +1,172 @@
+# Supplier entity resolution (`supplier_key`)
+
+`toronto_bids/linking/supplier.py:supplier_key` is the key used by
+`build_supplier_dimension` to group raw supplier-name strings (drawn from
+`award`, `noncompetitive`, `suspended_firm`, `bid`, `composite_award`,
+`agency_award`, `agency_bid`) into one `supplier` dimension row per real firm.
+The same legal entity is frequently written differently across sources and
+years — a numbered Ontario company under its trade name, a named firm under
+an `o/a`/`dba` alias, or a name wrapped in scraper noise ("Appendix C",
+"* Non-compliant") — and the naive normalization (lowercase, strip
+punctuation, collapse whitespace, keep legal suffixes) that predates this
+work does not fold those together. `supplier_key` adds three staged rules on
+top of that baseline, applied first-match-wins, before falling back to it.
+
+## The four rules
+
+1. **Salvage noise wrappers, then exclude pure footnotes.** Scraped rows
+   sometimes carry a real firm name buried in noise — an appendix/price-form
+   marker, a trailing `* Non-compliant` — and sometimes carry no firm name at
+   all, just administrative prose or a multi-firm list-blob. `_salvage`
+   strips the noise wrappers first; only what remains is tested against an
+   anchored footnote pattern (`_FOOTNOTE`) and, if it matches, excluded
+   (`supplier_key` returns `""` and the caller skips the row).
+   Example: `'Fermar Paving Limited* Non-compliant'` salvages to `'Fermar
+   Paving Limited'` and keys normally; `'Please see Scope for Award
+   Details'` has no firm name to salvage and is excluded.
+
+2. **Numbered company → `#<number>`.** A 6-7 digit Ontario/Canada
+   corporation number adjacent to a province token, found anywhere in the
+   string, *is* the legal identity — the Inc/Ltd/Incorporated suffix and any
+   `o/a`/`dba` trade name around it are noise by comparison, and don't need
+   to agree across records for the same firm to be recognized.
+   Example: `'2489960 ONTARIO INC'`, `'2489960 Ontario Inc. o/a Kore
+   Infrastructure Group'`, and `'2489960 ONTARIO INCORPORATED'` all key to
+   `#2489960`.
+
+3. **Named-company trade-name folding, guarded.** When a name has no
+   corporation number but does carry a trailing `o/a`/`dba`/`operating
+   as`/`trading as` marker, the trade name after the marker is dropped and
+   the legal base before it becomes the key — but only when that base is not
+   itself a generic fragment (`_GENERIC_BASE`: `"ontario ltd"`, `"inc"`,
+   etc.) and still contains a non-suffix word. This guard exists because
+   stripping the marker from `'Ontario Ltd. o/a Trans Canada Construction'`
+   would otherwise leave the bare fragment `'ontario ltd'`, which is shared
+   by hundreds of unrelated numbered companies and would over-merge badly.
+   Example: `'Corporate Express Canada Inc., operating as Staples Business
+   Advantage'` and `'Corporate Express Canada Inc. (operating as Staples
+   Advantage Canada)'` both key to `'corporate express canada inc'`.
+
+4. **Default: today's conservative normalization.** Lowercase, strip
+   everything but `[a-z0-9 ]`, collapse whitespace, drop a `(Submitted by:
+   ...)` note. Legal suffixes (`Inc`, `Ltd`, `Limited`, ...) are
+   deliberately *kept*, so `'Capital Sewer Services Inc.'` and `'Capital
+   Sewer Services Ltd.'` stay distinct keys — there is no reliable way to
+   tell whether that's the same firm re-incorporating or two firms, and
+   merging them risks combining different legal entities.
+
+`supplier_key` is pure and total (never raises) and returns `""` for
+blank/garbage/footnote input; callers skip rows with an empty key.
+
+## Measured figures (live run against `~/tb-data/bids.sqlite`, 2026-07-19)
+
+Command: the Step-1 audit script below, run with
+`TB_DATA_DIR="$HOME/tb-data" uv run python -` from `scrapers/`.
+
+| metric | value |
+|---|---|
+| supplier rows (raw `display_name` values) | 8,022 |
+| distinct keys after resolution | 7,732 |
+| rows excluded (pure footnote / no firm identity) | 51 |
+| keys that merge more than one raw name | 128 |
+| — of which numbered-company merges (`#<number>`) | 44 |
+| — of which named trade-name-marker merges | 84 |
+| NAMED false-merge candidates (no shared token between merged names) | **0** |
+| excluded rows containing a strong firm word (false-exclude candidates) | 13 — all genuine (multi-part list-blobs, see below) |
+| flagship: `2489960 ONTARIO INC` variant members | 12 |
+
+8,022 raw names collapse to 7,732 real-world entities: 128 keys absorb more
+than one raw variant (2,290 raw-name pairs' worth of duplication across
+those 128 groups is what the earlier conservative-only key was missing), and
+51 rows that carried no recoverable firm identity are excluded rather than
+polluting the dimension with garbage keys.
+
+### Audit adjudication
+
+**NAMED false-merge audit (0 candidates):** the script flags any named
+(non-numbered) merge group where the merged raw names share no significant
+token in common — a proxy for "these might be two different firms glued
+together by an over-eager regex." The live run found **zero** such groups:
+every one of the 84 named merges shares at least one significant word (e.g.
+`corporate express canada inc` / `staples business advantage` merges because
+the trade-name marker rule keys on the shared legal base `corporate express
+canada inc`, not the trade name). No fix needed.
+
+**False-exclude audit (13 candidates, all genuine):** the script flags
+excluded rows containing a common firm-indicating word
+(`construction|paving|electric|architect|engineering|inc|ltd|limited|group|
+services`) as a sanity check that a real single firm wasn't dropped. All 13
+hits are **multi-firm list-blobs** — scraped rows that concatenate several
+bidders' names under a `"Part A:"` / `"Part B:"` / etc. label from a
+multi-lot award (e.g. `'Part A: Econolite Canada Incorporated Orange Traffic
+Tacel Ltd. Fortran Traffic'`, listing four traffic-signal suppliers in one
+string) or a rowspan artifact (`'Part B: Neil Vanderkruk Holdings Inc
+Dutchmaster Nurseries Ltd Uxbridge Nurseries Baker Fo...'`). These are
+exactly the "multi-firm list-blob" case the footnote rule is designed to
+exclude — there is no single real firm being wrongly dropped, and splitting
+the blob into its constituent bidders is out of scope for this key (see
+Residual known limits). No fix needed; both audits are clean and the
+figures above stand unchanged from the first run.
+
+## JV attribution
+
+A joint venture or trade-name alias fronted by a numbered lead company folds
+into the lead firm's key, not into a separate "JV" identity. For example
+`'614128 ONTARIO LTD, O/A TRISAN CONSTRUCTION'` and `'TRISAN CONSTRUCTION
+O/A 614128 ONTARIO LTD.'` (trade-name-first ordering) both key to
+`#614128` — the corporation number is the legal identity regardless of which
+side of the string it appears on, or what trade/JV name surrounds it. This
+is a deliberate simplification: a two-firm joint venture that has *not*
+incorporated under a shared numbered entity is not detected as a JV at all
+and its members stay as separate suppliers under Rule 4 (default).
+
+## Residual known limits
+
+- **Named firms are still split by `Inc` vs `Ltd`.** There is no corporation
+  number to anchor a named (non-numbered) entity the way Rule 1 anchors a
+  numbered one, so `'Capital Sewer Services Inc.'` and `'Capital Sewer
+  Services Ltd.'` remain two distinct keys. This is deliberate: merging on
+  legal-suffix-agnostic name alone risks folding two genuinely different
+  entities together with no way to verify it from the string alone.
+- **Multi-firm list-blobs are excluded, not split.** Rows like `'Part A:
+  Econolite Canada Incorporated Orange Traffic Tacel Ltd. Fortran Traffic'`
+  name several real firms concatenated into one string with no reliable
+  per-firm delimiter; `supplier_key` excludes the whole row rather than
+  guess at a split, so those firms are not represented under this key from
+  that row (they may still appear correctly if they occur elsewhere as
+  single-firm rows).
+- **A non-numbered, non-incorporated joint venture is not folded.** See JV
+  attribution above — only a numbered-lead JV is recognized.
+- **Any group the audit would flag stays unmerged/unexcluded until fixed.**
+  The two audits below (false-merge, false-exclude) are the trip-wire for
+  this; both are currently clean (see Measured figures).
+
+## Re-running the audit
+
+```bash
+cd scrapers && TB_DATA_DIR="$HOME/tb-data" uv run python - <<'PY'
+import sqlite3, collections, re
+from toronto_bids import config
+from toronto_bids.linking.supplier import supplier_key, _LEGAL_SUFFIX, _normalize
+c = sqlite3.connect(config.DB_PATH)
+rows = [r[0] for r in c.execute("SELECT display_name FROM supplier")]
+grp = collections.defaultdict(set); excluded = []
+for d in rows:
+    k = supplier_key(d)
+    (excluded.append(d) if k == "" else grp[k].add(d))
+print(f"supplier rows: {len(rows)}  ->  distinct keys: {len(grp)}  (excluded: {len(excluded)})")
+merged = {k: v for k, v in grp.items() if len(v) > 1}
+numbered = {k: v for k, v in merged.items() if k.startswith('#')}
+named = {k: v for k, v in merged.items() if not k.startswith('#')}
+print(f"keys merging >1 raw name: {len(merged)} ({len(numbered)} numbered, {len(named)} named)")
+def toks(d): return {t for t in _normalize(d).split() if t not in _LEGAL_SUFFIX and len(t) > 2}
+fm = [(k, v) for k, v in named.items() if not (set.intersection(*[toks(d) for d in v]))]
+print(f"NAMED false-merge candidates (no shared token): {len(fm)}")
+for k, v in fm[:10]:
+    print(f"   {k!r}: {list(v)[:3]}")
+fe = [d for d in excluded if re.search(r'\b(construction|paving|electric|architect|engineering|inc|ltd|limited|group|services)\b', d, re.I)]
+print(f"excluded rows containing a firm word (false-exclude candidates): {len(fe)}")
+for d in fe[:12]: print(f"   {d[:90]!r}")
+print("2489960 members:", sum(1 for d in rows if supplier_key(d) == '#2489960'))
+PY
+```

--- a/docs/supplier-entity-resolution.md
+++ b/docs/supplier-entity-resolution.md
@@ -76,10 +76,12 @@ Command: the Step-1 audit script below, run with
 | flagship: `2489960 ONTARIO INC` variant members | 12 |
 
 8,022 raw names collapse to 7,732 real-world entities: 128 keys absorb more
-than one raw variant (2,290 raw-name pairs' worth of duplication across
-those 128 groups is what the earlier conservative-only key was missing), and
-51 rows that carried no recoverable firm identity are excluded rather than
-polluting the dimension with garbage keys.
+than one raw variant. Measuring the duplication those merges recover: of the
+8,022 raw rows, 51 are excluded as pure footnotes, leaving 7,971 keyed rows
+against 7,732 distinct keys — `(8,022 − 51 excluded) − 7,732 distinct keys =
+239 rows collapsed` into an existing key that the earlier conservative-only
+key kept apart. 51 rows that carried no recoverable firm identity are
+excluded rather than polluting the dimension with garbage keys.
 
 ### Audit adjudication
 
@@ -111,9 +113,11 @@ figures above stand unchanged from the first run.
 ## JV attribution
 
 A joint venture or trade-name alias fronted by a numbered lead company folds
-into the lead firm's key, not into a separate "JV" identity. For example
-`'614128 ONTARIO LTD, O/A TRISAN CONSTRUCTION'` and `'TRISAN CONSTRUCTION
-O/A 614128 ONTARIO LTD.'` (trade-name-first ordering) both key to
+into the lead firm's key, not into a separate "JV" identity. The example
+below is illustrative — drawn from the rule's spec, not a pair pulled from
+the live audit run. For example `'614128 ONTARIO LTD, O/A TRISAN
+CONSTRUCTION'` and `'TRISAN CONSTRUCTION O/A 614128 ONTARIO LTD.'`
+(trade-name-first ordering) both key to
 `#614128` — the corporation number is the legal identity regardless of which
 side of the string it appears on, or what trade/JV name surrounds it. This
 is a deliberate simplification: a two-firm joint venture that has *not*

--- a/scrapers/tests/test_supplier_key.py
+++ b/scrapers/tests/test_supplier_key.py
@@ -36,3 +36,61 @@ def test_distinct_entities_stay_distinct():
 @pytest.mark.parametrize("raw", [None, "", "   ", "()", "!!!"])
 def test_blank_or_garbage_yields_empty_key(raw):
     assert supplier_key(raw) == ""
+
+
+# --- Rule 1: numbered companies key to #<number> ---
+def test_numbered_company_variants_collapse_to_the_number():
+    for raw in ["2489960 ONTARIO INC",
+                "2489960 Ontario Inc. o/a Kore Infrastructure Group",
+                "2489960 ONTARIO LTD",
+                "2489960 ONTARIO INCORPORATED",
+                "2489960 Ontario Inc. operating as Kore Infrastructure Group"]:
+        assert supplier_key(raw) == "#2489960", raw
+
+def test_numbered_reverse_order_and_typo_still_key_to_the_number():
+    # trade-name-first, number in the middle; and a 0/A zero-for-O typo
+    assert supplier_key("TRISAN CONSTRUCTION O/A 614128 ONTARIO LTD.") == "#614128"
+    assert supplier_key("614128 ONTARIO LTD, O/A TRISAN CONSTRUCTION") == "#614128"
+    assert supplier_key("1568796 ONTARIO INC, 0/A RENOKREW") == "#1568796"
+
+def test_a_stray_parenthetical_number_does_not_steal_the_key():
+    # the leading corp number is the identity; the (3059515) is ignored
+    assert supplier_key("614128 ONTARIO LTD O/A TRISAN CONSTRUCTION (3059515)") == "#614128"
+
+def test_a_short_or_addressy_number_is_not_a_corp_number():
+    # 3-digit / non-corp-length numbers must not trigger Rule 1
+    assert supplier_key("123 Ontario Street Holdings Inc.") != "#123"
+
+
+# --- Rule 2: named-company trade-name folding, guarded ---
+def test_named_trade_name_folds_to_the_legal_base():
+    assert supplier_key("Corporate Express Canada Inc., operating as Staples Business Advantage") == \
+           supplier_key("Corporate Express Canada Inc. (operating as Staples Advantage Canada)")
+    assert supplier_key("R.O.M. Contractors Inc. o/a Ross Clair Contractors") == \
+           supplier_key("R.O.M. Contractors Inc o/a Ross Clair Contractor")
+
+def test_marker_strip_is_refused_when_the_base_is_generic():
+    # stripping 'o/a Trans Canada' leaves the generic fragment 'ontario ltd' — must NOT merge there
+    assert supplier_key("Ontario Ltd. o/a Trans Canada Construction") != "ontario ltd"
+
+
+# --- Rule 3: salvage noise wrappers, exclude only pure footnote ---
+def test_appendix_and_noncompliant_noise_is_salvaged_not_excluded():
+    assert supplier_key('Fermar Paving Limited* Non-compliant') == supplier_key("Fermar Paving Limited")
+    assert supplier_key('Appendix "C" Benson Group Inc.') == supplier_key("Benson Group Inc.")
+    assert supplier_key('LTH Electric Inspection & Service Ltd. Appendix "C" Price Form') == \
+           supplier_key("LTH Electric Inspection & Service Ltd.")
+
+def test_pure_footnote_is_excluded():
+    for raw in ["Please see Scope for Award Details",
+                "See Prequalified List below in the Scope of Work",
+                "Various ( see the link)",
+                "1 Bidder was found non-compliant with mandatory requirements.",
+                "Part A: Econolite Canada Incorporated Orange Traffic Tacel Ltd. Fortran Traffic"]:
+        assert supplier_key(raw) == "", raw
+
+def test_a_long_real_consortium_name_is_kept_not_excluded():
+    # 100+ char legitimate multi-firm name must survive (no length rule)
+    name = ("Alaimo Architecture Inc., Bortolotto Design Architects Inc., "
+            "Paul Didur Architect Inc., Unlimited Design Studio Inc.")
+    assert supplier_key(name) != ""

--- a/scrapers/toronto_bids/linking/supplier.py
+++ b/scrapers/toronto_bids/linking/supplier.py
@@ -8,20 +8,75 @@ _SUBMITTED_BY = re.compile(r"\(\s*submitted by:.*?\)", re.IGNORECASE)
 _NON_KEY = re.compile(r"[^a-z0-9 ]")
 _WS = re.compile(r"\s+")
 
+# Rule 3 salvage: strip appendix / price-form / trailing non-compliant noise wrappers.
+_NOISE = re.compile(
+    r'\(?\s*appendix\s*["“‘\']?\s*[a-z]?\d*\s*["”’\']?\s*[–-]?\s*(?:price\s*form)?\s*\)?',
+    re.IGNORECASE)
+_NONCOMPLIANT = re.compile(r'\*?\s*non-?compliant.*$', re.IGNORECASE)
+
+# Rule 3 exclude: pure footnote (no firm identity). Anchored — matches only strings that START
+# with a footnote phrase, so a real firm name is never excluded.
+_FOOTNOTE = re.compile(
+    r"^(?:please see|see prequalif|see the|refer to|as per|various\b|bid prices|"
+    r"\d+\s*/?\s*bidder was found|the scope of work|\d+\s+bidder\b|part [a-z]:|"
+    r"corrected for mathematical|award amounts have been)", re.IGNORECASE)
+
+# Rule 1: a corporation number (6-7 digits) adjacent to a province token, anywhere in the name.
+_CORP = re.compile(r"\b(\d{6,7})\s+(?:ontario|ont|canada|quebec|qc)\b", re.IGNORECASE)
+
+# Rule 2: a trailing trade-name marker (and everything after it).
+_MARK = re.compile(
+    r"\s*(?:,\s*)?(?:\bo/?a\b|\b0/a\b|\boperating as\b|\bc\.?o\.?b\.?(?:\s*as)?\b|"
+    r"\bd\.?b\.?a\.?\b|\btrading as\b|\bt/a\b)\b.*$", re.IGNORECASE)
+_LEGAL_SUFFIX = {"inc", "ltd", "limited", "incorporated", "corp", "corporation", "co",
+                 "company", "canada", "ontario", "ont", "llp", "lp", "the", "and"}
+_GENERIC_BASE = {"ontario ltd", "ontario limited", "ontario inc", "ontario incorporated",
+                 "ontario", "inc", "ltd", "limited", "incorporated", "canada inc",
+                 "canada ltd", "canada"}
+
+
+def _normalize(text: str) -> str:
+    """Today's conservative key: drop a Submitted-by note, lowercase, strip non-[a-z0-9 ],
+    collapse whitespace. Legal suffixes are intentionally kept so different named firms don't
+    merge."""
+    text = _SUBMITTED_BY.sub(" ", str(text))
+    text = _NON_KEY.sub(" ", text.lower())
+    return _WS.sub(" ", text).strip()
+
+
+def _salvage(text: str) -> str:
+    """Rule 3 salvage: strip appendix/price-form/non-compliant noise wrappers so a real firm
+    wrapped in scraped footnote noise (e.g. 'Fermar Paving Limited* Non-compliant') survives."""
+    text = _NONCOMPLIANT.sub(" ", str(text))
+    text = _NOISE.sub(" ", text)
+    return _WS.sub(" ", text).strip(' *"')
+
 
 def supplier_key(raw: str | None) -> str:
-    """Deterministic grouping key for a raw supplier name.
+    """Deterministic entity-resolution key for a raw supplier name.
 
-    Drops a trailing "(Submitted by: …)" note, lowercases, removes every character
-    that is not [a-z0-9 ], and collapses whitespace. Legal suffixes (Inc, Ltd, …) are
-    intentionally kept so genuinely different entities are not merged. Returns "" for
-    blank/garbage input (caller skips those).
+    Staged (first match wins), see docs/supplier-entity-resolution.md:
+      1. salvage noise wrappers, then exclude pure footnote -> "" (caller skips).
+      2. a corporation number adjacent to a province token, anywhere -> "#<number>"
+         (the number IS the legal identity; Inc/Ltd/Incorporated/O-A/JV are noise).
+      3. a trailing trade-name marker on a NON-numbered name -> the legal base, but only when
+         the base is not generic (guards the 'ontario ltd' over-merge).
+      4. otherwise today's conservative normalization (legal suffix kept).
+    Returns "" for blank/garbage. Pure and total; never raises.
     """
     if raw is None:
         return ""
-    text = _SUBMITTED_BY.sub(" ", str(raw))
-    text = _NON_KEY.sub(" ", text.lower())
-    return _WS.sub(" ", text).strip()
+    salvaged = _salvage(raw)                                   # Rule 3 salvage
+    if not salvaged or _FOOTNOTE.search(salvaged):             # Rule 3 exclude
+        return ""
+    m = _CORP.search(salvaged)                                 # Rule 1
+    if m:
+        return f"#{m.group(1)}"
+    if _MARK.search(salvaged):                                 # Rule 2 (guarded)
+        base = _normalize(_MARK.sub("", salvaged))
+        if base and base not in _GENERIC_BASE and any(t not in _LEGAL_SUFFIX for t in base.split()):
+            return base
+    return _normalize(salvaged)                                # Rule 4 default
 
 
 # (source table, its primary-key column) for the tables carrying a supplier name + supplier_id.


### PR DESCRIPTION
Fixes #160. The same legal entity split across many supplier rows, distorting the flagship "who won the most" ranking (`2489960 Ontario Inc.` appeared as 12+ rows). Rewrites `supplier_key` into a staged entity-resolution pipeline, **measured against the live 8,022-row dimension** at every step.

Design: `docs/superpowers/specs/2026-07-19-supplier-entity-resolution-design.md` · Methodology: `docs/supplier-entity-resolution.md`

## The rules (staged, first match wins)

1. **Numbered companies → `#<corp-number>`.** A corporation number adjacent to a province token, found *anywhere* (so `2489960 Ontario Inc. o/a Kore` and reverse-order `Trisan O/A 614128 Ontario Ltd` both key to `#614128`). The number is the legal identity; `Inc`/`Ltd`/`Incorporated`/`O/A`/JV are noise. **Near-zero false-merge** — a corp number is unique.
2. **Named trade-name folding, guarded.** Strip `O/A / operating as / d.b.a. / c.o.b. as` on non-numbered names — but only when the base isn't generic (a denylist + meaningful-token guard block the `ontario ltd` over-merge).
3. **Salvage-then-exclude garbage.** Strip appendix/price-form/non-compliant noise wrappers (recovering real firms like `LTH Electric Inspection & Service Ltd.`, `Fermar Paving Limited`), then exclude only *pure footnote* (`Please see Scope…`) → `supplier_id` NULL. **No length rule** — legit consortium names run 100-184 chars.
4. **Otherwise** today's conservative key (legal suffix kept, so named `Inc` ≠ `Ltd`).

## Measured (live audit, in the methodology doc)

| | |
|---|---|
| supplier rows → distinct keys | 8,022 → 7,732 (**239 duplicate rows collapsed**) |
| keys merging >1 raw name | 128 (44 numbered, 84 named) |
| **false-merge count** | **0** |
| pure-footnote excluded | 51 |
| **false-exclude count (real firms)** | **0** (13 candidates all adjudicated genuine list-blobs) |
| flagship `2489960` | consolidated to one firm (~$458M → ~$503M) |

## Methodology doc — the reviewers' explicit ask

`docs/supplier-entity-resolution.md` states each rule with an example, the measured table, the **JV attribution choice** (a numbered-lead JV folds into the lead firm), and the residual limits (named `Inc`≠`Ltd` still split; multi-firm list-blobs excluded not split; a marker-bearing numbered name missing its province token). Firm-level spend is now assessable.

## Testing / review

- **579 tests pass.** New per-rule tests encode the real traps verbatim (reverse-order, `0/A` zero-typo, stray parenthetical number, generic-base refusal, appendix salvage, long consortium kept).
- Each task spec+quality reviewed (one caught a fabricated doc figure `2,290` → corrected to the measured `239`); whole-branch review on the most capable model — all load-bearing guarantees HOLD (pure/total/never-raises, no false-merge, no real firm excluded), no Critical/Important.

Unblocks the frontend supplier pages (one correct total per firm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE