### PR TITLE
feat(export): Parquet + CSV bulk exports (#161)

### DIFF
--- a/deploy/publish-data.sh
+++ b/deploy/publish-data.sh
@@ -7,8 +7,9 @@
 # partial sync — the export is valid whenever any rows exist, and a good artifact must not be
 # withheld over one bad feed (the nightly's own per-step isolation ethos, extended one level out).
 #
-# Uploads bids.json, bids.json.gz, bids.sqlite, schema.json, manifest.json to a rolling `latest`
-# release (schema.json + manifest.json added in #168), giving the static
+# Uploads bids.json, bids.json.gz, bids.sqlite, schema.json, manifest.json, bids-csv.zip and the
+# per-table *.parquet files to a rolling `latest` release (schema.json + manifest.json added in
+# #168; the Parquet + CSV bulk formats in #161), giving the static
 # frontend a stable URL. On the 1st of the month it also cuts a dated snapshot-YYYY-MM-DD release
 # (point-in-time citation). Then it triggers the frontend deploy (best-effort).
 #
@@ -34,6 +35,7 @@ GZ="$EXPORT_DIR/bids.json.gz"
 SQLITE="$DATA_DIR/bids.sqlite"
 SCHEMA="$EXPORT_DIR/schema.json"       # written beside bids.json by the nightly `tb export` (#168)
 MANIFEST="$EXPORT_DIR/manifest.json"   # generated here from the actual uploaded bytes
+CSV_ZIP="$EXPORT_DIR/bids-csv.zip"     # bundled per-table CSVs (#161); per-table *.parquet sit beside it
 
 DATA_REPO="${TB_DATA_REPO:-CivicTechTO/toronto-bids-data}"
 FRONTEND_REPO="${TB_FRONTEND_REPO:-CivicTechTO/toronto-bids-frontend}"
@@ -93,13 +95,20 @@ gzip -9 -c "$JSON" > "$GZ" || fail "gzip failed"
 #     missing dictionary is a publish gap the frontend /data/ page depends on.
 [ -f "$SCHEMA" ] || fail "no schema.json at $SCHEMA — did 'tb export' run?"
 
-# 4c. Generate manifest.json from the ACTUAL bytes about to be uploaded, so the stated sizes can
+# 4c. The bulk exports (#161) ride the nightly `tb export` too. Require them — a missing bulk
+#     artifact is a publish gap. The parquet files are per-table; glob and confirm at least one.
+[ -f "$CSV_ZIP" ] || fail "no bids-csv.zip at $CSV_ZIP — did 'tb export' run?"
+PARQUET_FILES=("$EXPORT_DIR"/*.parquet)
+[ -e "${PARQUET_FILES[0]}" ] || fail "no *.parquet in $EXPORT_DIR — did 'tb export' run?"
+
+# 4d. Generate manifest.json from the ACTUAL bytes about to be uploaded, so the stated sizes can
 #     never drift from the assets. Runs for real even in dry-run (like the gzip above) so the
 #     asset list is complete. Row counts live only in schema.json — one generated source.
-"$UV" run --project "$SCRAPERS" tb manifest "$JSON" "$GZ" "$SQLITE" --out "$MANIFEST" \
+"$UV" run --project "$SCRAPERS" tb manifest \
+  "$JSON" "$GZ" "$SQLITE" "$CSV_ZIP" "${PARQUET_FILES[@]}" --out "$MANIFEST" \
   || fail "could not generate manifest.json"
 
-ASSETS=("$JSON" "$GZ" "$SQLITE" "$SCHEMA" "$MANIFEST")
+ASSETS=("$JSON" "$GZ" "$SQLITE" "$SCHEMA" "$MANIFEST" "$CSV_ZIP" "${PARQUET_FILES[@]}")
 
 # 5. Ensure the rolling `latest` release exists, then clobber its assets.
 if ! gh_run release view latest -R "$DATA_REPO" >/dev/null 2>&1; then

--- a/docs/superpowers/plans/2026-07-20-parquet-csv-bulk-export.md
+++ b/docs/superpowers/plans/2026-07-20-parquet-csv-bulk-export.md
@@ -1,0 +1,513 @@
+# Parquet + CSV Bulk Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish per-table Parquet files (HTTP-queryable columnar data) and a `bids-csv.zip` bundle to the `toronto-bids-data` release beside `bids.json`, with their sizes folded into the existing `manifest.json` (#161).
+
+**Architecture:** A new `export/tabular_export.py` dumps the 18 flat store tables (reusing `db.EXPORT_TABLES` from #168) to per-table `<table>.parquet` (pyarrow) and a `bids-csv.zip` (stdlib csv+zipfile), excluding two giant blob columns and server paths. `tb export`/nightly emit them; `publish-data.sh` uploads them and extends the manifest.
+
+**Tech Stack:** Python 3.12, `pyarrow` (new core dep), stdlib `csv`/`zipfile`/`sqlite3`, pytest.
+
+## Global Constraints
+
+- The table set is `db.EXPORT_TABLES` (the #168 shared constant) — no drift from `schema.json`/`counts()`.
+- Excluded columns: `ariba_posting.raw_json`, `background_pdf.text` (giant blobs), and any column named `local_path` (server filesystem path). Everything else — ids, keys, checksums, `odata_id` — is kept.
+- Deterministic content: each table read `ORDER BY 1` (first kept column).
+- Rows read as plain tuples (`tuple(r)`), never sqlite3.Row, so csv and pyarrow both consume them cleanly.
+- `pyarrow` is a core dependency (nightly/publish needs it); `uv.lock` must be re-locked and committed (CI runs `uv sync --locked`).
+- Tests are offline/fixture-based; pyarrow is a core dep so tests import it directly (no skip guard).
+- `bids.json`'s shape is untouched.
+
+---
+
+### Task 1: Add pyarrow dependency and re-lock
+
+**Files:**
+- Modify: `scrapers/pyproject.toml`
+- Modify: `scrapers/uv.lock` (regenerated)
+
+**Interfaces:**
+- Produces: `pyarrow` importable in the project environment.
+
+- [ ] **Step 1: Add pyarrow to core dependencies**
+
+In `scrapers/pyproject.toml`, add `pyarrow` to `[project].dependencies`:
+
+```toml
+dependencies = [
+    "httpx",
+    "lxml>=6.1.1",
+    "pdfplumber>=0.11.10",
+    "pyarrow>=17",
+]
+```
+
+- [ ] **Step 2: Re-lock and sync**
+
+Run:
+```bash
+cd scrapers && uv sync
+```
+Expected: resolves and installs pyarrow; `uv.lock` is updated.
+
+- [ ] **Step 3: Verify the locked env is consistent and pyarrow imports**
+
+Run:
+```bash
+cd scrapers && uv sync --locked && uv run python -c "import pyarrow, pyarrow.parquet; print('pyarrow', pyarrow.__version__)"
+```
+Expected: `uv sync --locked` succeeds (no "lockfile out of date"), and the version prints.
+
+- [ ] **Step 4: Confirm the existing suite still passes under the new env**
+
+Run: `cd scrapers && uv run pytest -q`
+Expected: all tests pass (baseline unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/pyproject.toml scrapers/uv.lock
+git commit -m "build: add pyarrow core dependency for Parquet bulk export (#161)"
+```
+
+---
+
+### Task 2: `_read_table` + `write_csv_zip`
+
+**Files:**
+- Create: `scrapers/toronto_bids/export/tabular_export.py`
+- Test: `scrapers/tests/test_tabular_export.py`
+
+**Interfaces:**
+- Consumes: `db.EXPORT_TABLES`.
+- Produces:
+  - `tabular_export._EXCLUDE_COLUMNS: set[tuple[str, str]]`
+  - `tabular_export._read_table(conn, table) -> tuple[list[str], list[tuple]]`
+  - `tabular_export.write_csv_zip(conn, out_path) -> Path`
+
+- [ ] **Step 1: Write the failing csv tests**
+
+Create `scrapers/tests/test_tabular_export.py`:
+
+```python
+import csv
+import io
+import zipfile
+
+from toronto_bids.export.tabular_export import _read_table, write_csv_zip
+from toronto_bids.models import AribaPosting, Award, Solicitation
+from toronto_bids.store import db
+
+
+def test_read_table_excludes_blob_and_path_columns(conn):
+    cols, _ = _read_table(conn, "ariba_posting")
+    assert "raw_json" not in cols          # giant blob excluded
+    assert "rfx_id" in cols                # keys kept
+    cols_pdf, _ = _read_table(conn, "background_pdf")
+    assert "text" not in cols_pdf          # giant blob excluded
+    assert "local_path" not in cols_pdf    # server path excluded
+    assert "url" in cols_pdf
+
+
+def test_read_table_orders_by_first_column(conn):
+    db.upsert_row(conn, Solicitation(document_number="2000000002", source="odata"), overwrite=True)
+    db.upsert_row(conn, Solicitation(document_number="1000000001", source="odata"), overwrite=True)
+    conn.commit()
+    cols, rows = _read_table(conn, "solicitation")
+    assert cols[0] == "document_number"
+    assert [r[0] for r in rows] == ["1000000001", "2000000002"]
+
+
+def test_write_csv_zip_has_one_csv_per_table(conn, tmp_path):
+    out = write_csv_zip(conn, tmp_path / "bids-csv.zip")
+    assert out == tmp_path / "bids-csv.zip"
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+    assert names == {f"{t}.csv" for t in db.EXPORT_TABLES}
+
+
+def test_csv_has_header_and_null_is_empty(conn, tmp_path):
+    db.upsert_row(conn, Award(document_number="1000000001", supplier_name_raw="Acme",
+                              award_amount="1000", source="odata"), overwrite=True)
+    conn.commit()
+    out = write_csv_zip(conn, tmp_path / "bids-csv.zip")
+    with zipfile.ZipFile(out) as zf:
+        text = zf.read("award.csv").decode("utf-8")
+    reader = list(csv.reader(io.StringIO(text)))
+    header = reader[0]
+    assert "supplier_name_raw" in header
+    row = reader[1]
+    # award_date was never set -> empty field, not the string "None"
+    assert row[header.index("award_date")] == ""
+    assert row[header.index("supplier_name_raw")] == "Acme"
+
+
+def test_excluded_column_absent_from_csv_header(conn, tmp_path):
+    out = write_csv_zip(conn, tmp_path / "bids-csv.zip")
+    with zipfile.ZipFile(out) as zf:
+        header = zf.read("ariba_posting.csv").decode("utf-8").splitlines()[0]
+    assert "raw_json" not in header
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_tabular_export.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'toronto_bids.export.tabular_export'`.
+
+- [ ] **Step 3: Implement `_read_table` + `write_csv_zip`**
+
+Create `scrapers/toronto_bids/export/tabular_export.py`:
+
+```python
+import csv
+import io
+import zipfile
+from pathlib import Path
+
+from toronto_bids.store import db
+
+# Columns dropped from the bulk tabular export. The two blobs would dominate file size and are
+# not analytical (the nested JSON export drops them too); `local_path` is a server filesystem
+# path. Everything else — ids, keys, checksums, City identifiers — is kept as a join key.
+_EXCLUDE_COLUMNS = {
+    ("ariba_posting", "raw_json"),
+    ("background_pdf", "text"),
+}
+
+
+def _kept_columns(conn, table: str) -> list[str]:
+    return [
+        row[1]
+        for row in conn.execute(f"PRAGMA table_info({table})")
+        if (table, row[1]) not in _EXCLUDE_COLUMNS and row[1] != "local_path"
+    ]
+
+
+def _read_table(conn, table: str) -> tuple[list[str], list[tuple]]:
+    """The kept columns and rows of one table, ORDER BY the first column (deterministic).
+
+    Rows are plain tuples so both csv.writer and pyarrow consume them without sqlite3.Row quirks.
+    """
+    cols = _kept_columns(conn, table)
+    col_list = ", ".join(cols)
+    rows = [tuple(r) for r in conn.execute(f"SELECT {col_list} FROM {table} ORDER BY 1")]
+    return cols, rows
+
+
+def write_csv_zip(conn, out_path) -> Path:
+    """One `<table>.csv` per EXPORT_TABLES, bundled into a single zip. NULL renders as an empty
+    field (csv default). For the non-technical / Excel audience (#161)."""
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for table in db.EXPORT_TABLES:
+            cols, rows = _read_table(conn, table)
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(cols)
+            writer.writerows(rows)
+            zf.writestr(f"{table}.csv", buf.getvalue())
+    return out_path
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scrapers && uv run pytest tests/test_tabular_export.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/export/tabular_export.py scrapers/tests/test_tabular_export.py
+git commit -m "feat(export): flat-table reader + bids-csv.zip bundle (#161)"
+```
+
+---
+
+### Task 3: `write_parquet_files`
+
+**Files:**
+- Modify: `scrapers/toronto_bids/export/tabular_export.py`
+- Test: `scrapers/tests/test_tabular_export.py`
+
+**Interfaces:**
+- Consumes: `_read_table` (Task 2); `pyarrow` (Task 1).
+- Produces: `tabular_export.write_parquet_files(conn, out_dir) -> list[Path]`.
+
+- [ ] **Step 1: Write the failing parquet tests**
+
+Append to `scrapers/tests/test_tabular_export.py`:
+
+```python
+import pyarrow.parquet as pq
+
+from toronto_bids.export.tabular_export import write_parquet_files
+
+
+def test_write_parquet_one_file_per_table(conn, tmp_path):
+    paths = write_parquet_files(conn, tmp_path)
+    names = {p.name for p in paths}
+    assert names == {f"{t}.parquet" for t in db.EXPORT_TABLES}
+    for p in paths:
+        assert p.exists()
+
+
+def test_parquet_roundtrips_rows_and_types(conn, tmp_path):
+    # A REAL-with-NULL column (award_amount_numeric) and a TEXT column round-trip.
+    db.upsert_row(conn, Award(document_number="1000000001", supplier_name_raw="Acme",
+                              award_amount="1000", award_amount_numeric=1000.0,
+                              source="odata"), overwrite=True)
+    db.upsert_row(conn, Award(document_number="1000000002", supplier_name_raw="Beta",
+                              award_amount="kj", source="odata"), overwrite=True)  # numeric NULL
+    conn.commit()
+    write_parquet_files(conn, tmp_path)
+    table = pq.read_table(tmp_path / "award.parquet").to_pylist()
+    by_supplier = {r["supplier_name_raw"]: r for r in table}
+    assert by_supplier["Acme"]["award_amount_numeric"] == 1000.0
+    assert by_supplier["Beta"]["award_amount_numeric"] is None
+
+
+def test_parquet_omits_excluded_columns(conn, tmp_path):
+    write_parquet_files(conn, tmp_path)
+    ap = pq.read_table(tmp_path / "ariba_posting.parquet")
+    assert "raw_json" not in ap.column_names
+    bp = pq.read_table(tmp_path / "background_pdf.parquet")
+    assert "text" not in bp.column_names
+    assert "local_path" not in bp.column_names
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scrapers && uv run pytest tests/test_tabular_export.py -k parquet -v`
+Expected: FAIL — `ImportError: cannot import name 'write_parquet_files'`.
+
+- [ ] **Step 3: Implement `write_parquet_files`**
+
+In `scrapers/toronto_bids/export/tabular_export.py`, add the imports at the top:
+
+```python
+import pyarrow as pa
+import pyarrow.parquet as pq
+```
+
+and the function:
+
+```python
+def write_parquet_files(conn, out_dir) -> list[Path]:
+    """One `<table>.parquet` per EXPORT_TABLES in out_dir. Arrow infers each column's type from
+    its values (an all-NULL column becomes Arrow null type, which Parquet stores fine). For the
+    DuckDB/pandas/Polars audience — the files are individually HTTP-queryable (#161)."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written = []
+    for table in db.EXPORT_TABLES:
+        cols, rows = _read_table(conn, table)
+        data = {col: [row[i] for row in rows] for i, col in enumerate(cols)}
+        arrow_table = pa.table(data)
+        path = out_dir / f"{table}.parquet"
+        pq.write_table(arrow_table, path)
+        written.append(path)
+    return written
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scrapers && uv run pytest tests/test_tabular_export.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/export/tabular_export.py scrapers/tests/test_tabular_export.py
+git commit -m "feat(export): per-table Parquet files via pyarrow (#161)"
+```
+
+---
+
+### Task 4: Wire `tb export` and nightly `_export`
+
+**Files:**
+- Modify: `scrapers/toronto_bids/cli.py`
+- Test: `scrapers/tests/test_cli.py`, `scrapers/tests/test_nightly.py`
+
+**Interfaces:**
+- Consumes: `write_parquet_files`, `write_csv_zip` (Tasks 2-3).
+- Produces: `tb export` and the nightly export step write the parquet files + `bids-csv.zip` into the export dir.
+
+- [ ] **Step 1: Extend `_cmd_export` to emit the bulk formats**
+
+In `scrapers/toronto_bids/cli.py`, add the import near the top (beside the other export imports, line ~5):
+
+```python
+from toronto_bids.export.tabular_export import write_csv_zip, write_parquet_files
+```
+
+In `_cmd_export`, after the `export_schema(...)` line, add:
+
+```python
+        write_parquet_files(conn, out_path.parent)
+        write_csv_zip(conn, out_path.parent / "bids-csv.zip")
+        print(f"Wrote Parquet + CSV bulk exports to {out_path.parent}")
+```
+
+- [ ] **Step 2: Extend the nightly `_export` step**
+
+In `_cmd_nightly`, the `_export` inner function (writes `bids.json` + `schema.json`) gains the bulk formats. After the `export_schema(conn, export_dir / "schema.json", generated_at)` line, add:
+
+```python
+            write_parquet_files(conn, export_dir)
+            write_csv_zip(conn, export_dir / "bids-csv.zip")
+```
+
+- [ ] **Step 3: Write the CLI + nightly tests**
+
+Append to `scrapers/tests/test_cli.py`:
+
+```python
+def test_export_writes_parquet_and_csv_bundle(monkeypatch, tmp_path):
+    import toronto_bids.config as config
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "bids.sqlite")
+    assert main(["export"]) == 0
+    export_dir = tmp_path / "export"
+    assert (export_dir / "bids-csv.zip").exists()
+    assert (export_dir / "solicitation.parquet").exists()
+```
+
+In `scrapers/tests/test_nightly.py`, extend the clean-run assertion (`test_a_clean_run_exits_zero_and_writes_the_export`) with:
+
+```python
+    assert (tmp_path / "export" / "bids-csv.zip").exists()
+    assert (tmp_path / "export" / "solicitation.parquet").exists()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd scrapers && uv run pytest tests/test_cli.py tests/test_nightly.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scrapers/toronto_bids/cli.py scrapers/tests/test_cli.py scrapers/tests/test_nightly.py
+git commit -m "feat(cli): tb export + nightly emit Parquet files and bids-csv.zip (#161)"
+```
+
+---
+
+### Task 5: Publish the bulk formats in `publish-data.sh`
+
+**Files:**
+- Modify: `deploy/publish-data.sh`
+
+**Interfaces:**
+- Consumes: the parquet files + `bids-csv.zip` written by the nightly export (Task 4); `tb manifest` (#168).
+- Produces: parquet files + csv zip uploaded to the release; `manifest.json` includes their sizes.
+
+- [ ] **Step 1: Add path variables and a presence check**
+
+In `deploy/publish-data.sh`, after the `MANIFEST=...` line, add:
+
+```bash
+CSV_ZIP="$EXPORT_DIR/bids-csv.zip"        # bundled per-table CSVs (#161)
+```
+
+After the schema.json presence check (section 4b), add a bulk-export presence check:
+
+```bash
+# 4d. The bulk exports (#161) ride the nightly `tb export` too. Require them — a missing bulk
+#     artifact is a publish gap. The parquet files are per-table; glob and confirm at least one.
+[ -f "$CSV_ZIP" ] || fail "no bids-csv.zip at $CSV_ZIP — did 'tb export' run?"
+PARQUET_FILES=("$EXPORT_DIR"/*.parquet)
+[ -e "${PARQUET_FILES[0]}" ] || fail "no *.parquet in $EXPORT_DIR — did 'tb export' run?"
+```
+
+- [ ] **Step 2: Add the bulk files to the manifest generation and ASSETS**
+
+Change the manifest generation (section 4c) to include the bulk files:
+
+```bash
+"$UV" run --project "$SCRAPERS" tb manifest \
+  "$JSON" "$GZ" "$SQLITE" "$CSV_ZIP" "${PARQUET_FILES[@]}" --out "$MANIFEST" \
+  || fail "could not generate manifest.json"
+```
+
+Change the `ASSETS` array to include the bulk files:
+
+```bash
+ASSETS=("$JSON" "$GZ" "$SQLITE" "$SCHEMA" "$MANIFEST" "$CSV_ZIP" "${PARQUET_FILES[@]}")
+```
+
+(Note: `PARQUET_FILES` is defined in Step 1 before the manifest/ASSETS lines that use it — confirm ordering when editing.)
+
+- [ ] **Step 3: Update the header doc-comment**
+
+In the header comment (the "Uploads bids.json, ..." line), append the bulk formats so the doc stays accurate:
+
+```bash
+# Uploads bids.json, bids.json.gz, bids.sqlite, schema.json, manifest.json, bids-csv.zip and the
+# per-table *.parquet files to a rolling `latest` release (bulk formats added in #161), giving the
+# static
+```
+
+(Preserve the rest of the existing sentence.)
+
+- [ ] **Step 4: Dry-run the publish script**
+
+Run:
+```bash
+cd /home/alex/toronto-bids
+rm -rf /tmp/tb-pub161 && mkdir -p /tmp/tb-pub161/export
+echo '{"meta":{"generated_at":"2026-07-20T00:00:00Z"}}' > /tmp/tb-pub161/export/bids.json
+echo '{"generated_at":"2026-07-20T00:00:00Z","tables":{}}' > /tmp/tb-pub161/export/schema.json
+printf 'x' > /tmp/tb-pub161/export/bids-csv.zip
+printf 'p' > /tmp/tb-pub161/export/solicitation.parquet
+printf 'p' > /tmp/tb-pub161/export/award.parquet
+echo 'db' > /tmp/tb-pub161/bids.sqlite
+TB_DATA_DIR=/tmp/tb-pub161 TB_PUBLISH_DRY_RUN=1 bash deploy/publish-data.sh 2>&1 | grep -iE "manifest|upload latest" | head
+echo "=== manifest ==="; cat /tmp/tb-pub161/export/manifest.json
+```
+Expected: the `DRY-RUN gh release upload latest ...` line includes `bids-csv.zip`, `solicitation.parquet`, `award.parquet`; `manifest.json` lists all of them with sizes.
+
+- [ ] **Step 5: Verify the missing-bulk failure path**
+
+Run:
+```bash
+cd /home/alex/toronto-bids
+rm -rf /tmp/tb-pub161b && mkdir -p /tmp/tb-pub161b/export
+echo '{"meta":{"generated_at":"2026-07-20T00:00:00Z"}}' > /tmp/tb-pub161b/export/bids.json
+echo '{"generated_at":"t","tables":{}}' > /tmp/tb-pub161b/export/schema.json
+echo 'db' > /tmp/tb-pub161b/bids.sqlite
+TB_DATA_DIR=/tmp/tb-pub161b TB_PUBLISH_DRY_RUN=1 bash deploy/publish-data.sh 2>&1 | grep -iE "csv|parquet|fail" | head
+```
+Expected: fails loudly with "no bids-csv.zip ...".
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/publish-data.sh
+git commit -m "feat(deploy): publish Parquet files + bids-csv.zip and size them in the manifest (#161)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Per-table Parquet (pyarrow), individual files → Task 3 + Task 5 (uploaded individually). ✅
+- `bids-csv.zip` bundle → Task 2. ✅
+- Flat SQLite tables via `db.EXPORT_TABLES` → Tasks 2-3. ✅
+- Column exclusions (raw_json, text, local_path) → Task 2 `_EXCLUDE_COLUMNS` + name rule, tested in Tasks 2-3. ✅
+- Deterministic `ORDER BY 1`, tuple rows → Task 2. ✅
+- pyarrow core dep + re-lock → Task 1. ✅
+- `tb export` + nightly emit them → Task 4. ✅
+- publish-data.sh uploads + manifest sizes + presence check → Task 5. ✅
+- `bids.json` untouched → no task modifies `build_export_document`/`export_json`. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✅
+
+**Type consistency:** `_read_table(conn, table) -> (cols, rows)`, `write_csv_zip(conn, out_path) -> Path`, `write_parquet_files(conn, out_dir) -> list[Path]`, `db.EXPORT_TABLES` — consistent across Tasks 2-5. ✅
+
+**Risk note (Task 3):** Arrow per-column type inference assumes each column's values are type-consistent (the store's affinity discipline). If a live table has genuinely mixed Python types in one column, `pa.table` would raise `ArrowInvalid`. The mandatory live-run verification below is where that would surface; if it does, the fix is a per-column string fallback — do not pre-build it (YAGNI).
+
+**Mandatory live-run verification (after Task 5, before finishing):** against a real synced DB (or the server's `bids.sqlite` if reachable), run `uv run tb export` and confirm: all 18 `*.parquet` files write without an `ArrowInvalid`, `bids-csv.zip` opens, `pq.read_table` on the largest tables (`bid`, `award`, `solicitation`) returns the expected row counts (matching `schema.json`), and the total bulk size is reasonable (blobs excluded). Report the per-file sizes and row counts.

--- a/docs/superpowers/specs/2026-07-20-parquet-csv-bulk-export-design.md
+++ b/docs/superpowers/specs/2026-07-20-parquet-csv-bulk-export-design.md
@@ -1,0 +1,132 @@
+# Parquet + CSV bulk exports (#161)
+
+**Date:** 2026-07-20
+**Status:** approved (autonomous — maintainer reviews at the PR), not yet implemented
+**Delivers:** per-table **Parquet** files (the columnar lingua franca — DuckDB/pandas/Polars can
+query them directly over HTTP) and a **CSV** bundle (`bids-csv.zip`, for the Excel/vendor
+audience), published to the `toronto-bids-data` release beside `bids.json` / `bids.sqlite`, with
+their sizes folded into the existing `manifest.json` (#168).
+
+Builds directly on #168: it reuses `db.EXPORT_TABLES` and extends `manifest.json` rather than
+inventing its own.
+
+## 1. Source: the flat SQLite tables, not the nested JSON
+
+`build_export_document` produces a *nested* document (awards/bids under their solicitation). Parquet
+and CSV are inherently *tabular*, so their natural source is the flat store tables — one file per
+table, keys intact, an analyst joining `award.document_number` to `solicitation.document_number`
+themselves. This is the shape DuckDB/pandas want and the shape `bids.sqlite` already exposes; the
+bulk formats are a columnar mirror of the same 18 tables `schema.json` documents.
+
+The table set is **`db.EXPORT_TABLES`** (the #168 constant) — no drift from `schema.json` or
+`counts()`.
+
+## 2. Column curation — two lean rules
+
+Each table is dumped as-is except:
+
+1. **Giant blob columns are excluded** — they would dominate file size and are not analytical:
+   `ariba_posting.raw_json` (verbatim JSON blobs) and `background_pdf.text` (full pdftotext of
+   3,000+ reports). The nested JSON export already drops both for the same reason.
+2. **Server-local paths are excluded** — any column named `local_path` (a filesystem path on the
+   home server; the JSON export drops it too).
+
+Everything else stays — including `id` primary keys, `sha256`/`crc32` checksums, and City
+identifiers (`odata_id`). In *flat* tabular form the ids are useful join keys (unlike the nested
+JSON, where they are redundant and dropped), and public-PDF checksums are not sensitive. The rule
+is deliberately small and testable: a module constant `_EXCLUDE_COLUMNS: set[tuple[str, str]]`
+plus the `local_path`-by-name rule.
+
+## 3. Architecture — `export/tabular_export.py`
+
+Pure-ish builders over the connection, mirroring the export seam. pyarrow is a new core
+dependency (there is no stdlib Parquet writer); CSV uses stdlib `csv` + `zipfile`.
+
+- **`_read_table(conn, table) -> tuple[list[str], list[tuple]]`** (helper): resolve the kept
+  columns from `PRAGMA table_info` minus `_EXCLUDE_COLUMNS`/`local_path`, then
+  `SELECT <cols> FROM <table> ORDER BY 1` (order by the first output column — deterministic
+  content within a DB). Returns column names + rows.
+- **`write_parquet_files(conn, out_dir) -> list[Path]`**: for each table in `EXPORT_TABLES`,
+  build a `pyarrow.table({col: [values]})` (Arrow infers each column's type from its values; an
+  all-NULL column becomes Arrow `null` type, which Parquet stores fine) and
+  `pyarrow.parquet.write_table` to `out_dir/<table>.parquet`. Returns the written paths.
+- **`write_csv_zip(conn, out_path) -> Path`**: open a `zipfile.ZipFile(out_path, "w",
+  ZIP_DEFLATED)` and write one `<table>.csv` entry per table — header row of column names, then
+  rows via `csv.writer`; `None` renders as an empty field (Python csv default). Returns the path.
+
+Both iterate `EXPORT_TABLES`, so all 18 tables are always present.
+
+### Type handling (Parquet)
+
+sqlite3 returns native Python objects (`str`/`int`/`float`/`None`/`bytes`), and the store's
+columns are type-consistent by affinity (e.g. `award_amount_numeric` is REAL-or-NULL, text
+columns are TEXT-or-NULL), so per-column Arrow inference is safe. A column that is entirely NULL
+infers Arrow `null` type — acceptable for an archival dump. No declared-type → Arrow-type mapping
+is needed; inference over actual values is correct and simpler. (Tested against a REAL-with-NULLs
+column and an all-NULL column so the inference path is pinned.)
+
+## 4. Wiring
+
+- **`tb export`** writes the bulk formats beside `bids.json` / `schema.json`: the per-table
+  `<table>.parquet` files and `bids-csv.zip`, all in `EXPORT_DIR`. Sub-second for this corpus, so
+  it is always-on (no opt-out flag — YAGNI).
+- **Nightly `_export` step** (`_cmd_nightly`) does the same, so the production path emits them
+  (the nightly calls the builders directly, as it does for `schema.json`).
+- **`publish-data.sh`**:
+  - Require the artifacts (`bids-csv.zip` and at least one `*.parquet`) — a missing bulk export is
+    a publish gap, surfaced with `fail`, like `schema.json`.
+  - Add `"$EXPORT_DIR"/*.parquet` and `"$EXPORT_DIR/bids-csv.zip"` to the `ASSETS` array, so both
+    the `latest` release and the monthly snapshot carry them (per-table Parquet as **individual
+    release assets** — directly queryable over HTTP: `SELECT * FROM
+    'https://…/award.parquet'`).
+  - Extend the `tb manifest` invocation to include the parquet files + the csv zip, so
+    `manifest.json` states their sizes. Row counts already live in `schema.json` (#168) — the
+    frontend joins the two.
+
+## 5. Dependency
+
+`pyarrow` is added to `[project].dependencies` in `scrapers/pyproject.toml` (the nightly/publish
+path needs it, so it is core, not an extra). `uv.lock` is re-locked and committed — CI runs
+`uv sync --locked` and fails otherwise. No build step (pyarrow ships prebuilt wheels), no runtime
+network (unlike a duckdb sqlite-scanner extension), and it is the format the pandas/Arrow
+ecosystem reads natively.
+
+## 6. Determinism / size
+
+- `ORDER BY 1` gives stable row order within a DB; Parquet files are data artifacts (not diffed),
+  so pyarrow's internal metadata is not a concern.
+- Excluding `raw_json`/`text` keeps the bulk export lean; without it `background_pdf` alone would
+  carry the full text of 3,000+ PDFs.
+
+## 7. Testing
+
+Fixture-based, offline (pyarrow is a core dep, so tests import it directly — no skip guard):
+
+- **`write_csv_zip`**: produces a zip with one `<table>.csv` per `EXPORT_TABLES`; a seeded
+  table's csv has the header + a data row; a NULL column renders as an empty field; an excluded
+  column (`ariba_posting.raw_json`) is absent from the header.
+- **`write_parquet_files`**: writes one `<table>.parquet` per table; reading a seeded table back
+  with `pyarrow.parquet.read_table` yields the inserted rows; a REAL-with-NULL column and a
+  TEXT column round-trip; `background_pdf.text` / `ariba_posting.raw_json` / any `local_path`
+  column is absent from the Parquet schema.
+- **`_read_table`**: excludes the blob/path columns; `ORDER BY 1` gives stable order.
+- **CLI**: `tb export` writes the parquet files + `bids-csv.zip` into the export dir (a small
+  seeded DB, asserting the files exist).
+- **Nightly**: a clean run writes `bids-csv.zip` and at least one `*.parquet` (extends the #168
+  nightly assertion).
+- **`publish-data.sh`** dry-run: the upload list includes the parquet files + csv zip; a missing
+  bulk export fails loudly; `manifest.json` lists their sizes.
+
+## 8. Out of scope
+
+- **XLSX** — redundant with CSV for opening in Excel, and another dependency (openpyxl). CSV
+  covers the non-technical audience.
+- A single "flattened" one-table export — the data is relational; per-table with keys is the
+  faithful tabular shape.
+- Nested/JSON changes — `bids.json` and its shape are untouched.
+- Publishing Parquet partitioned/compressed beyond pyarrow's default (Snappy) — default is fine.
+
+## 9. Recording
+
+On completion, comment on #161 with the published asset URLs (the per-table Parquet + `bids-csv.zip`
+on the `latest` release) and note that `manifest.json` now carries their sizes.

--- a/scrapers/pyproject.toml
+++ b/scrapers/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "httpx",
     "lxml>=6.1.1",
     "pdfplumber>=0.11.10",
+    "pyarrow>=17",
 ]
 
 [project.optional-dependencies]

--- a/scrapers/tests/test_cli.py
+++ b/scrapers/tests/test_cli.py
@@ -155,3 +155,15 @@ def test_manifest_command_writes_sizes(tmp_path):
     assert rc == 0
     doc = json.loads(out.read_text())
     assert doc["artifacts"] == [{"name": "bids.json", "bytes": 12}]
+
+
+# --- bulk exports (#161) ------------------------------------------------------------------
+
+def test_export_writes_parquet_and_csv_bundle(monkeypatch, tmp_path):
+    import toronto_bids.config as config
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "bids.sqlite")
+    assert main(["export"]) == 0
+    export_dir = tmp_path / "export"
+    assert (export_dir / "bids-csv.zip").exists()
+    assert (export_dir / "solicitation.parquet").exists()

--- a/scrapers/tests/test_nightly.py
+++ b/scrapers/tests/test_nightly.py
@@ -39,6 +39,8 @@ def test_a_clean_run_exits_zero_and_writes_the_export(nightly, tmp_path):
     assert (tmp_path / "export" / "bids.json").exists()
     # schema.json rides the export step (#168) — publish-data.sh requires it beside bids.json.
     assert (tmp_path / "export" / "schema.json").exists()
+    assert (tmp_path / "export" / "bids-csv.zip").exists()
+    assert (tmp_path / "export" / "solicitation.parquet").exists()
 
 
 def test_a_failed_source_exits_non_zero_so_systemd_sees_it(nightly, monkeypatch):

--- a/scrapers/tests/test_tabular_export.py
+++ b/scrapers/tests/test_tabular_export.py
@@ -1,0 +1,57 @@
+import csv
+import io
+import zipfile
+
+from toronto_bids.export.tabular_export import _read_table, write_csv_zip
+from toronto_bids.models import AribaPosting, Award, Solicitation
+from toronto_bids.store import db
+
+
+def test_read_table_excludes_blob_and_path_columns(conn):
+    cols, _ = _read_table(conn, "ariba_posting")
+    assert "raw_json" not in cols          # giant blob excluded
+    assert "rfx_id" in cols                # keys kept
+    cols_pdf, _ = _read_table(conn, "background_pdf")
+    assert "text" not in cols_pdf          # giant blob excluded
+    assert "local_path" not in cols_pdf    # server path excluded
+    assert "url" in cols_pdf
+
+
+def test_read_table_orders_by_first_column(conn):
+    db.upsert_row(conn, Solicitation(document_number="2000000002", source="odata"), overwrite=True)
+    db.upsert_row(conn, Solicitation(document_number="1000000001", source="odata"), overwrite=True)
+    conn.commit()
+    cols, rows = _read_table(conn, "solicitation")
+    assert cols[0] == "document_number"
+    assert [r[0] for r in rows] == ["1000000001", "2000000002"]
+
+
+def test_write_csv_zip_has_one_csv_per_table(conn, tmp_path):
+    out = write_csv_zip(conn, tmp_path / "bids-csv.zip")
+    assert out == tmp_path / "bids-csv.zip"
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+    assert names == {f"{t}.csv" for t in db.EXPORT_TABLES}
+
+
+def test_csv_has_header_and_null_is_empty(conn, tmp_path):
+    db.upsert_row(conn, Award(document_number="1000000001", supplier_name_raw="Acme",
+                              award_amount="1000", source="odata"), overwrite=True)
+    conn.commit()
+    out = write_csv_zip(conn, tmp_path / "bids-csv.zip")
+    with zipfile.ZipFile(out) as zf:
+        text = zf.read("award.csv").decode("utf-8")
+    reader = list(csv.reader(io.StringIO(text)))
+    header = reader[0]
+    assert "supplier_name_raw" in header
+    row = reader[1]
+    # award_date was never set -> empty field, not the string "None"
+    assert row[header.index("award_date")] == ""
+    assert row[header.index("supplier_name_raw")] == "Acme"
+
+
+def test_excluded_column_absent_from_csv_header(conn, tmp_path):
+    out = write_csv_zip(conn, tmp_path / "bids-csv.zip")
+    with zipfile.ZipFile(out) as zf:
+        header = zf.read("ariba_posting.csv").decode("utf-8").splitlines()[0]
+    assert "raw_json" not in header

--- a/scrapers/tests/test_tabular_export.py
+++ b/scrapers/tests/test_tabular_export.py
@@ -2,7 +2,9 @@ import csv
 import io
 import zipfile
 
-from toronto_bids.export.tabular_export import _read_table, write_csv_zip
+import pyarrow.parquet as pq
+
+from toronto_bids.export.tabular_export import _read_table, write_csv_zip, write_parquet_files
 from toronto_bids.models import AribaPosting, Award, Solicitation
 from toronto_bids.store import db
 
@@ -55,3 +57,35 @@ def test_excluded_column_absent_from_csv_header(conn, tmp_path):
     with zipfile.ZipFile(out) as zf:
         header = zf.read("ariba_posting.csv").decode("utf-8").splitlines()[0]
     assert "raw_json" not in header
+
+
+def test_write_parquet_one_file_per_table(conn, tmp_path):
+    paths = write_parquet_files(conn, tmp_path)
+    names = {p.name for p in paths}
+    assert names == {f"{t}.parquet" for t in db.EXPORT_TABLES}
+    for p in paths:
+        assert p.exists()
+
+
+def test_parquet_roundtrips_rows_and_types(conn, tmp_path):
+    # A REAL-with-NULL column (award_amount_numeric) and a TEXT column round-trip.
+    db.upsert_row(conn, Award(document_number="1000000001", supplier_name_raw="Acme",
+                              award_amount="1000",
+                              source="odata"), overwrite=True)  # numeric derived from "1000"
+    db.upsert_row(conn, Award(document_number="1000000002", supplier_name_raw="Beta",
+                              award_amount="kj", source="odata"), overwrite=True)  # numeric NULL
+    conn.commit()
+    write_parquet_files(conn, tmp_path)
+    table = pq.read_table(tmp_path / "award.parquet").to_pylist()
+    by_supplier = {r["supplier_name_raw"]: r for r in table}
+    assert by_supplier["Acme"]["award_amount_numeric"] == 1000.0
+    assert by_supplier["Beta"]["award_amount_numeric"] is None
+
+
+def test_parquet_omits_excluded_columns(conn, tmp_path):
+    write_parquet_files(conn, tmp_path)
+    ap = pq.read_table(tmp_path / "ariba_posting.parquet")
+    assert "raw_json" not in ap.column_names
+    bp = pq.read_table(tmp_path / "background_pdf.parquet")
+    assert "text" not in bp.column_names
+    assert "local_path" not in bp.column_names

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -3,6 +3,7 @@ import sys
 
 from toronto_bids import __version__, config, pipeline
 from toronto_bids.export.json_export import export_json, export_schema
+from toronto_bids.export.tabular_export import write_csv_zip, write_parquet_files
 from toronto_bids.http import HttpClient
 from toronto_bids.store import db
 
@@ -206,6 +207,9 @@ def _cmd_export(args) -> int:
         written = export_json(conn, out_path, generated_at)
         schema_path = out_path.parent / "schema.json"
         export_schema(conn, schema_path, generated_at)
+        write_parquet_files(conn, out_path.parent)
+        write_csv_zip(conn, out_path.parent / "bids-csv.zip")
+        print(f"Wrote Parquet + CSV bulk exports to {out_path.parent}")
         counts = db.counts(conn)
         print(f"Exported {counts['solicitation']} solicitations to {written}")
         print(f"Wrote schema dictionary to {schema_path}")
@@ -580,6 +584,8 @@ def _cmd_nightly(args) -> int:
             # requires it beside bids.json (#168), so the production path must emit it here (the
             # nightly calls export_json directly, not `tb export`).
             export_schema(conn, export_dir / "schema.json", generated_at)
+            write_parquet_files(conn, export_dir)
+            write_csv_zip(conn, export_dir / "bids-csv.zip")
             export_bytes = written.stat().st_size
             return f"{export_bytes / 1_048_576:.1f} MiB"
         _run_step(steps, failures, "export", _export)

--- a/scrapers/toronto_bids/export/tabular_export.py
+++ b/scrapers/toronto_bids/export/tabular_export.py
@@ -1,0 +1,49 @@
+import csv
+import io
+import zipfile
+from pathlib import Path
+
+from toronto_bids.store import db
+
+# Columns dropped from the bulk tabular export. The two blobs would dominate file size and are
+# not analytical (the nested JSON export drops them too); `local_path` is a server filesystem
+# path. Everything else — ids, keys, checksums, City identifiers — is kept as a join key.
+_EXCLUDE_COLUMNS = {
+    ("ariba_posting", "raw_json"),
+    ("background_pdf", "text"),
+}
+
+
+def _kept_columns(conn, table: str) -> list[str]:
+    return [
+        row[1]
+        for row in conn.execute(f"PRAGMA table_info({table})")
+        if (table, row[1]) not in _EXCLUDE_COLUMNS and row[1] != "local_path"
+    ]
+
+
+def _read_table(conn, table: str) -> tuple[list[str], list[tuple]]:
+    """The kept columns and rows of one table, ORDER BY the first column (deterministic).
+
+    Rows are plain tuples so both csv.writer and pyarrow consume them without sqlite3.Row quirks.
+    """
+    cols = _kept_columns(conn, table)
+    col_list = ", ".join(cols)
+    rows = [tuple(r) for r in conn.execute(f"SELECT {col_list} FROM {table} ORDER BY 1")]
+    return cols, rows
+
+
+def write_csv_zip(conn, out_path) -> Path:
+    """One `<table>.csv` per EXPORT_TABLES, bundled into a single zip. NULL renders as an empty
+    field (csv default). For the non-technical / Excel audience (#161)."""
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for table in db.EXPORT_TABLES:
+            cols, rows = _read_table(conn, table)
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(cols)
+            writer.writerows(rows)
+            zf.writestr(f"{table}.csv", buf.getvalue())
+    return out_path

--- a/scrapers/toronto_bids/export/tabular_export.py
+++ b/scrapers/toronto_bids/export/tabular_export.py
@@ -3,6 +3,9 @@ import io
 import zipfile
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 from toronto_bids.store import db
 
 # Columns dropped from the bulk tabular export. The two blobs would dominate file size and are
@@ -47,3 +50,20 @@ def write_csv_zip(conn, out_path) -> Path:
             writer.writerows(rows)
             zf.writestr(f"{table}.csv", buf.getvalue())
     return out_path
+
+
+def write_parquet_files(conn, out_dir) -> list[Path]:
+    """One `<table>.parquet` per EXPORT_TABLES in out_dir. Arrow infers each column's type from
+    its values (an all-NULL column becomes Arrow null type, which Parquet stores fine). For the
+    DuckDB/pandas/Polars audience — the files are individually HTTP-queryable (#161)."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written = []
+    for table in db.EXPORT_TABLES:
+        cols, rows = _read_table(conn, table)
+        data = {col: [row[i] for row in rows] for i, col in enumerate(cols)}
+        arrow_table = pa.table(data)
+        path = out_dir / f"{table}.parquet"
+        pq.write_table(arrow_table, path)
+        written.append(path)
+    return written

--- a/scrapers/uv.lock
+++ b/scrapers/uv.lock
@@ -567,6 +567,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/44/fdd3a4377807b7dcabe2d4b5aa99dbbc98e2e5df3f1ca4e7f0aec492d987/pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e", size = 35850884, upload-time = "2026-07-10T08:26:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/71/9f053177a7709b8c90abb00a2375b916286f9f0d6cfb21a5cadd4ef811e8/pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec", size = 37616197, upload-time = "2026-07-10T08:26:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1a/22bfb6597dcdc861fa83c39c06e1457cb56f698940eff42fbb25de30e8e5/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f", size = 46841966, upload-time = "2026-07-10T08:27:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0e/cd705c042bc4fe7022478db577fcab4abdcfabb9bc37ab7a75556b3fcb2b/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778", size = 50088993, upload-time = "2026-07-10T08:27:14.268Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/581ccbcdb3d897eb2893328d68db3d52eca373bf2a7e964d0a6276b8e85b/pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b", size = 35878945, upload-time = "2026-07-10T08:28:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/ccb01db7329ea0411ef4fbd9b62a04d3268b36777d4e758d5e39b91ddeab/pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b", size = 37630854, upload-time = "2026-07-10T08:28:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9f/2d81ba89d1e4198d0cb25fe7529de936830fdaec0db926bb52a1ef7080d4/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec", size = 46905617, upload-time = "2026-07-10T08:28:29.376Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/0ed312ec800fb536f93783215126cee4b8977dcfeccba6f0f44df0cc87d7/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887", size = 50119765, upload-time = "2026-07-10T08:28:35.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/cab5063ba0c4d46a9f6b4b7eb1c9029dc0302d65cd5ab3510c949a386568/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62", size = 50027563, upload-time = "2026-07-10T08:28:43.848Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/fb/4d24f1b7fe2e042dc4ef315ef75e4e702d8e46fe10c37e63caff00502b03/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f", size = 53162437, upload-time = "2026-07-10T08:28:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/65/da20806de93ca6ee91e72cb6a9b08b3ac890b46efc8d94a7326c651c4c81/pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104", size = 28613262, upload-time = "2026-07-10T08:29:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9f/c632afb1d3ef4a7814cee236718235f3a47eac46e97eb87df40f550b6b48/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e", size = 36120702, upload-time = "2026-07-10T08:28:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0a/093d53a0e72ad06e45d6443e00651bbc2d21af4211295086cbf4d873d3b9/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2", size = 37750674, upload-time = "2026-07-10T08:29:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/b37fc31a69cff4bdfb8842683def5612f551b93fff6f44375e4a4a6a5535/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50", size = 46912304, upload-time = "2026-07-10T08:29:14.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +703,7 @@ dependencies = [
     { name = "httpx" },
     { name = "lxml" },
     { name = "pdfplumber" },
+    { name = "pyarrow" },
 ]
 
 [package.optional-dependencies]
@@ -687,6 +724,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.1.1" },
     { name = "pdfplumber", specifier = ">=0.11.10" },
     { name = "playwright", marker = "extra == 'council'", specifier = ">=1.61.0" },
+    { name = "pyarrow", specifier = ">=17" },
     { name = "python-dotenv", marker = "extra == 'council'", specifier = ">=1.0" },
     { name = "pyvirtualdisplay", marker = "extra == 'council'", specifier = ">=3.0" },
 ]


### PR DESCRIPTION
Closes #161.

Publishes the store as **per-table Parquet** (the columnar lingua franca — DuckDB/pandas/Polars can query the files directly over HTTP) and a **`bids-csv.zip`** bundle (for the Excel/vendor audience), alongside `bids.json` / `bids.sqlite` on the `toronto-bids-data` release. Builds directly on #168 — reuses `db.EXPORT_TABLES` and extends `manifest.json` rather than inventing its own.

## What ships

- **18 per-table `<table>.parquet` files** as individual release assets — e.g. `duckdb -c "SELECT * FROM 'https://…/award.parquet'"` with zero download.
- **`bids-csv.zip`** — one `<table>.csv` per table, opens in Excel.
- Both are sized in **`manifest.json`** (from the actual uploaded bytes); per-table row counts already live in `schema.json` (#168), which the frontend joins.

## Shaping decisions

- **Source is the flat SQLite tables** (not the nested `bids.json`) — analysts join on `document_number`/`reference` themselves, the shape DuckDB/pandas want.
- **Two giant blob columns excluded** so the bulk files stay lean: `ariba_posting.raw_json` and `background_pdf.text` (full pdftotext of 3,000+ reports); plus any `local_path` (server filesystem path). Everything else — ids, keys, checksums, `odata_id` — is kept as a join key. Exclusion lives in **one place** (`_read_table`) so Parquet and CSV can't diverge.
- Deterministic content (`ORDER BY 1`, plain-tuple rows).

## How it's wired

- New `export/tabular_export.py`: `write_parquet_files(conn, out_dir)` (pyarrow) + `write_csv_zip(conn, out_path)` (stdlib csv+zipfile).
- `tb export` and the nightly `_export` step emit both beside `bids.json`. `bids.json`'s shape is untouched.
- `publish-data.sh` uploads the `*.parquet` individually + `bids-csv.zip` (to `latest` and the monthly snapshot), folds them into the manifest, and **fails loudly** if the nightly export didn't produce them.
- `pyarrow>=17` added to core deps; `uv.lock` re-locked.

## Testing

- Fixture-based, offline: `_read_table` exclusions + `ORDER BY 1`; `write_csv_zip` (one csv/table, NULL→empty, excluded columns absent); `write_parquet_files` (one parquet/table, REAL-with-NULL round-trip, exclusions); `tb export` + nightly emit them; `publish-data.sh` dry-run (upload list + manifest sizes + missing-bulk fails loudly).
- **Live run** against real City data (`tb sync` → `tb export`): all 18 Parquet wrote with **0 `ArrowInvalid`** and **0 row-count mismatches** vs `schema.json` (solicitation 7,446 / award 15,030 / noncompetitive 2,857 / supplier 4,145); csv.zip integrity clean, `raw_json` excluded. Bulk formats 1.9 MB (parquet) + 1.36 MB (csv) vs 16.5 MB (json).
- 608 tests pass. Whole-branch review (opus): APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
