### PR TITLE
fix(deploy): resolve Node by version, not presence, for the R2 mirror (#173)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -195,6 +195,16 @@ so the URL is stable), reusing `CLOUDFLARE_API_TOKEN` via `wrangler`. The step i
 Public URL: `https://pub-99a890c186c743c19ef7bcd00024dca8.r2.dev/bids.sqlite`
 (Datasette-Lite: `https://lite.datasette.io/?url=<that URL>`).
 
+**This step needs Node >= 22, and the distro's Node is not it (#173).** Ubuntu's `nodejs`
+package installs `/usr/bin/node` + `/usr/bin/npx` at **v20**, and `/usr/bin` *is* on systemd's
+minimal PATH — so a `command -v npx` check passes on the server while `wrangler` (>= 4 requires
+Node >= 22) exits 1 immediately. That combination silently broke this mirror on every nightly
+run from 2026-07-19 to 2026-07-27: the commands above work when you paste them into a login
+shell (nvm's Node is first on *your* PATH) and fail under systemd. `deploy/resolve-node.sh`
+now resolves a Node by **version, never by presence**, preferring the newest suitable nvm
+install; `TB_NODE_MIN_MAJOR` tracks wrangler's floor. Keep an nvm Node >= 22 installed on the
+box — there is no other source of one.
+
 **One-time R2 setup** (already done for the current deployment):
 
 ```shell

--- a/deploy/publish-data.sh
+++ b/deploy/publish-data.sh
@@ -150,18 +150,24 @@ if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
   echo "publish-data: R2 not configured (no CLOUDFLARE_API_TOKEN) — skipping the bucket mirror"
 elif [ "$DRY_RUN" = 1 ]; then
   echo "DRY-RUN wrangler r2 object put $R2_BUCKET/bids.sqlite --file $SQLITE --remote"
+elif ! . "$HERE/resolve-node.sh" || ! tb_resolve_node; then
+  # systemd's PATH is minimal AND carries Ubuntu's Node 20 npx, which satisfies a presence
+  # check but not wrangler (>= 22). Gating on presence is what silently killed this mirror for
+  # eight nights — see deploy/resolve-node.sh (#173).
+  # :-22 matters: if the source itself failed the var is unbound, and `set -u` would abort
+  # the whole publish over a best-effort mirror.
+  echo "publish-data: WARNING — no Node >= ${TB_NODE_MIN_MAJOR:-22} for wrangler;" \
+       "R2 mirror skipped (release is published)" >&2
 else
-  # systemd's PATH is minimal; make node/npx findable, preferring the newest nvm node.
-  if ! command -v npx >/dev/null 2>&1; then
-    _node_bin="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
-    [ -n "$_node_bin" ] && PATH="$_node_bin:$PATH"
-  fi
   # Pinned version so a warm npx cache is reused (no nightly re-resolve of "latest").
-  if npx -y wrangler@4.112.0 r2 object put "$R2_BUCKET/bids.sqlite" \
-        --file "$SQLITE" --remote --content-type application/x-sqlite3 >/dev/null 2>&1; then
+  # wrangler's stderr is CAPTURED, never discarded: sending it to /dev/null is precisely why
+  # this failed unnoticed from 2026-07-19 to 2026-07-27 (#173).
+  if _r2_err="$(npx -y wrangler@4.112.0 r2 object put "$R2_BUCKET/bids.sqlite" \
+        --file "$SQLITE" --remote --content-type application/x-sqlite3 2>&1 >/dev/null)"; then
     echo "publish-data: mirrored bids.sqlite to R2 bucket $R2_BUCKET"
   else
     echo "publish-data: WARNING — R2 upload of bids.sqlite failed (release is published)" >&2
+    printf 'publish-data: wrangler said: %s\n' "$_r2_err" >&2
   fi
 fi
 

--- a/deploy/resolve-node.sh
+++ b/deploy/resolve-node.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Put a wrangler-capable Node on PATH, or say so. Sourced by publish-data.sh (#173).
+#
+# WHY THIS IS NOT `command -v npx`:
+# Ubuntu's `nodejs` package installs /usr/bin/node + /usr/bin/npx, and /usr/bin IS on systemd's
+# minimal PATH. So a presence check is *satisfied* on the deploy box — by Node 20. Wrangler >= 4
+# requires Node >= 22 and exits 1 in under a second. publish-data.sh gated its nvm fallback on
+# `! command -v npx`, so the fallback was dead code there, and with wrangler's stderr going to
+# /dev/null the R2 mirror of bids.sqlite failed on EVERY nightly run from 2026-07-19 to
+# 2026-07-27 while the unit still exited 0. Probe the VERSION, never mere presence.
+#
+# Deliberately uses only bash builtins — no ls/sort/grep. This is sourced into a script whose
+# PATH is the thing under repair, so depending on PATH to repair PATH is how it breaks twice.
+#
+# Self-test: scrapers/tests/test_resolve_node.py drives this with stub `node` binaries.
+
+# Wrangler's floor. Overridable so bumping wrangler does not mean editing logic.
+: "${TB_NODE_MIN_MAJOR:=22}"
+
+# "v22.9.0" -> 22009000, for numeric comparison. Returns 1 on anything unparseable.
+_tb_ver_key() {
+  local v="${1#v}" maj min pat rest
+  IFS=. read -r maj min pat rest <<<"$v"
+  case "${maj:-}" in ''|*[!0-9]*) return 1 ;; esac
+  case "${min:-}" in ''|*[!0-9]*) min=0 ;; esac
+  case "${pat:-}" in ''|*[!0-9]*) pat=0 ;; esac
+  printf '%d' "$(( maj * 1000000 + min * 1000 + pat ))"
+}
+
+# Version key of a node binary, or 1 if it is missing / not runnable / not a node.
+_tb_node_key() {
+  local ver
+  ver="$("$1" --version 2>/dev/null)" || return 1
+  _tb_ver_key "$ver"
+}
+
+# Is the `node` already on PATH new enough for wrangler?
+_tb_path_node_ok() {
+  local n key
+  n="$(command -v node 2>/dev/null)" || return 1
+  [ -n "$n" ] || return 1
+  key="$(_tb_node_key "$n")" || return 1
+  [ "$(( key / 1000000 ))" -ge "$TB_NODE_MIN_MAJOR" ]
+}
+
+# Prepend the newest *suitable* nvm node to PATH when the one on PATH is too old or absent.
+# Returns 0 with PATH usable, or 1 when no Node >= $TB_NODE_MIN_MAJOR exists anywhere.
+#
+# "Newest suitable", not "newest": `sort -V | tail -1` blindly takes the highest version even
+# when it is below the floor, which would reintroduce exactly this bug on a box whose only nvm
+# install is old.
+tb_resolve_node() {
+  _tb_path_node_ok && return 0
+
+  local cand key best_key="" best_bin=""
+  for cand in "${HOME:-}"/.nvm/versions/node/*/bin/node; do
+    [ -x "$cand" ] || continue                  # unmatched glob stays literal; -x rejects it
+    key="$(_tb_node_key "$cand")" || continue
+    [ "$(( key / 1000000 ))" -ge "$TB_NODE_MIN_MAJOR" ] || continue
+    if [ -z "$best_key" ] || [ "$key" -gt "$best_key" ]; then
+      best_key="$key"
+      best_bin="${cand%/node}"
+    fi
+  done
+
+  [ -n "$best_bin" ] || return 1
+  PATH="$best_bin:$PATH"
+  export PATH
+}

--- a/scrapers/tests/helpers_deploy.py
+++ b/scrapers/tests/helpers_deploy.py
@@ -1,0 +1,48 @@
+"""Helpers for exercising the bash under `deploy/` from pytest (#173).
+
+The deploy scripts are the one part of the pipeline with no test coverage, which is how the
+R2 mirror shipped broken and stayed broken for eight nights. These helpers keep the bash
+testable without a bash test framework: build a fake PATH, run one function, read the answer.
+"""
+import os
+import pathlib
+import shutil
+import subprocess
+
+DEPLOY = pathlib.Path(__file__).resolve().parents[2] / "deploy"
+RESOLVE_NODE = DEPLOY / "resolve-node.sh"
+
+# The tests hand bash a PATH containing ONLY stub dirs, so nothing may be looked up on it —
+# not bash, not the stubs' interpreter. Absolute paths throughout; `#!/bin/sh` rather than
+# `/usr/bin/env bash`, since env would resolve `bash` against the doctored PATH and fail.
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+def fake_node(bin_dir: pathlib.Path, version: str) -> pathlib.Path:
+    """A stub `node` that reports `version`, so tests need no real Node installs."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    node = bin_dir / "node"
+    node.write_text(f'#!/bin/sh\n[ "$1" = --version ] && echo "{version}"\n')
+    node.chmod(0o755)
+    return bin_dir
+
+
+def run_resolver(tmp_path, path_dirs, home, env=None) -> subprocess.CompletedProcess:
+    """Source resolve-node.sh under a controlled PATH/HOME and print the node it selects.
+
+    Exits non-zero when the resolver finds nothing suitable, so `returncode` is the contract.
+    """
+    script = (
+        f'. "{RESOLVE_NODE}"\n'
+        "tb_resolve_node || exit 1\n"
+        'command -v node\n'
+    )
+    full_env = {
+        "PATH": os.pathsep.join(str(p) for p in path_dirs),
+        "HOME": str(home),
+    }
+    full_env.update(env or {})
+    return subprocess.run(
+        [BASH, "-c", script],
+        capture_output=True, text=True, env=full_env, cwd=tmp_path,
+    )

--- a/scrapers/tests/test_resolve_node.py
+++ b/scrapers/tests/test_resolve_node.py
@@ -1,0 +1,141 @@
+"""`deploy/resolve-node.sh` — putting a wrangler-capable Node on PATH (#173).
+
+The R2 mirror of bids.sqlite failed on every nightly run from 2026-07-19 to 2026-07-27 and
+nobody saw it. Root cause: publish-data.sh gated its nvm fallback on `command -v npx`, and
+Ubuntu's `nodejs` package puts a **Node 20** `/usr/bin/npx` on systemd's minimal PATH. The
+guard was satisfied, the fallback never fired, and wrangler (>= 4 needs Node >= 22) exited 1
+in under a second — straight into `/dev/null`.
+
+So the rule these tests pin is: **probe the version, never mere presence.**
+
+Bash-subprocess tests are a new shape for this suite (everything else is pure Python), and
+deliberately so — the deploy scripts had zero coverage, which is how this reached production.
+"""
+import shutil
+import subprocess
+
+import pytest
+
+from tests.helpers_deploy import RESOLVE_NODE, fake_node, run_resolver
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="resolve-node.sh needs bash"
+)
+
+
+def test_the_helper_exists():
+    assert RESOLVE_NODE.exists(), f"missing {RESOLVE_NODE}"
+
+
+def test_a_too_old_node_on_path_is_rejected_in_favour_of_nvm(tmp_path):
+    """The exact production failure: Node 20 on PATH, Node 22 in nvm."""
+    path_dir = fake_node(tmp_path / "usr-bin", "v20.20.2")
+    home = tmp_path / "home"
+    nvm = fake_node(home / ".nvm/versions/node/v25.4.0/bin", "v25.4.0")
+
+    res = run_resolver(tmp_path, path_dirs=[path_dir], home=home)
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == str(nvm / "node"), (
+        f"resolved {res.stdout.strip()!r}, expected the nvm node at {nvm / 'node'}"
+    )
+
+
+def test_a_new_enough_node_on_path_is_kept(tmp_path):
+    """No nvm rummaging when PATH already satisfies wrangler."""
+    path_dir = fake_node(tmp_path / "usr-bin", "v22.1.0")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    res = run_resolver(tmp_path, path_dirs=[path_dir], home=home)
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == str(path_dir / "node")
+
+
+def test_it_picks_the_newest_SUITABLE_nvm_node_not_merely_the_newest(tmp_path):
+    """`sort -V | tail -1` blindly takes the newest; if that one is too old we must keep looking."""
+    path_dir = fake_node(tmp_path / "usr-bin", "v20.20.2")
+    home = tmp_path / "home"
+    good = fake_node(home / ".nvm/versions/node/v22.9.0/bin", "v22.9.0")
+    fake_node(home / ".nvm/versions/node/v21.0.0/bin", "v21.0.0")
+
+    res = run_resolver(tmp_path, path_dirs=[path_dir], home=home)
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == str(good / "node")
+
+
+def test_no_suitable_node_anywhere_fails_loudly(tmp_path):
+    """The mirror must report 'no usable node', never proceed into a doomed wrangler call."""
+    path_dir = fake_node(tmp_path / "usr-bin", "v20.20.2")
+    home = tmp_path / "home"
+    fake_node(home / ".nvm/versions/node/v18.0.0/bin", "v18.0.0")
+
+    res = run_resolver(tmp_path, path_dirs=[path_dir], home=home)
+
+    assert res.returncode != 0
+
+
+def test_no_node_at_all_fails_rather_than_crashing(tmp_path):
+    """An empty PATH must return non-zero, not blow up on an unbound variable."""
+    home = tmp_path / "home"
+    home.mkdir()
+
+    res = run_resolver(tmp_path, path_dirs=[], home=home)
+
+    assert res.returncode != 0
+
+
+def test_an_unrunnable_node_is_treated_as_absent(tmp_path):
+    """A `node` that exists but cannot execute must not be mistaken for a usable one."""
+    broken = tmp_path / "usr-bin"
+    broken.mkdir(parents=True)
+    (broken / "node").write_text("#!/bin/sh\nexit 127\n")
+    (broken / "node").chmod(0o755)
+    home = tmp_path / "home"
+    good = fake_node(home / ".nvm/versions/node/v22.9.0/bin", "v22.9.0")
+
+    res = run_resolver(tmp_path, path_dirs=[broken], home=home)
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == str(good / "node")
+
+
+def test_the_minimum_major_is_overridable(tmp_path):
+    """TB_NODE_MIN_MAJOR tracks wrangler's requirement without editing the script."""
+    path_dir = fake_node(tmp_path / "usr-bin", "v20.20.2")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    res = run_resolver(tmp_path, path_dirs=[path_dir], home=home,
+                       env={"TB_NODE_MIN_MAJOR": "20"})
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == str(path_dir / "node")
+
+
+def test_publish_data_no_longer_gates_the_fallback_on_mere_presence():
+    """Regression guard on the actual defect: `! command -v npx` must not gate the R2 step."""
+    publish = RESOLVE_NODE.parent / "publish-data.sh"
+    body = publish.read_text()
+    assert "! command -v npx" not in body, (
+        "publish-data.sh is gating on npx PRESENCE again — that is the #173 bug: "
+        "Ubuntu's Node 20 npx satisfies it and wrangler then dies."
+    )
+    assert "resolve-node.sh" in body, "publish-data.sh should source the shared resolver"
+
+
+def test_wrangler_stderr_is_not_discarded():
+    """The reason #173 ran unseen for 8 nights: the error went to /dev/null.
+
+    Scoped to the R2 block alone — later sections discard stderr legitimately (e.g. the
+    `gh release view` existence probe for the monthly snapshot).
+    """
+    publish = (RESOLVE_NODE.parent / "publish-data.sh").read_text()
+    start = publish.index("R2_BUCKET=")
+    r2 = publish[start:publish.index("\n# 6.", start)]
+    assert "wrangler" in r2, "slice missed the R2 block — retarget this test"
+    assert ">/dev/null 2>&1" not in r2, (
+        "the R2 upload is discarding wrangler's stderr again (#173)"
+    )


### PR DESCRIPTION
Closes #173.

## Root cause

Not size, not permissions, not a timeout — a Node version shadowing bug, reproduced under `systemd-run` with the real `EnvironmentFile`:

```
npx on PATH: /usr/bin/npx        ← Ubuntu nodejs package
node version: v20.20.2
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
=== wrangler exit code: 1 ===
```

`publish-data.sh` gated its nvm fallback on `! command -v npx`. Ubuntu's `nodejs` package installs `/usr/bin/npx`, and `/usr/bin` **is** on systemd's minimal PATH — so the guard was satisfied on the server and the fallback written for exactly this case was dead code. wrangler >= 4 needs Node >= 22 and exited 1 in under a second, straight into `/dev/null`.

This is why it looked like flaky infrastructure: it succeeds in a login shell (nvm's Node shadows `/usr/bin`) and fails only under systemd. The one-time R2 provisioning in `deploy/README.md` was pasted into a login shell, which is why setup worked while the scheduled run never did.

**It never worked once.** The journal reaches back to 2026-07-17 — before the R2 block was added on 07-19 — with no success line and no "not configured" skip. The object sitting in the bucket dated Jul 21 was the manual setup upload, not a nightly.

## Impact

Narrow but real. The GitHub release was always current; the R2 copy is what the frontend's in-browser Datasette-Lite page loads (release assets no longer send CORS), so that page served a stale database for the whole window while every other artifact was fresh.

## The fix

**`deploy/resolve-node.sh`** (new) — resolves a Node by **version, never by presence**, preferring the newest *suitable* nvm install. Two deliberate choices:

- *Newest suitable*, not `sort -V | tail -1`'s newest outright — the latter reintroduces this bug on a box whose newest nvm Node is below the floor.
- *Bash builtins only*, no `ls`/`sort`/`grep` — it is sourced into a script whose PATH is the thing under repair, so depending on PATH to repair PATH breaks it twice.

`TB_NODE_MIN_MAJOR` tracks wrangler's floor without editing logic.

**`publish-data.sh`** — sources the resolver, warns loudly when no usable Node exists, and **captures wrangler's stderr** rather than discarding it. Sending it to `/dev/null` is the entire reason eight consecutive failures left no evidence; a failure now prints `wrangler said: …`.

**`deploy/README.md`** — records the requirement and the login-shell-vs-systemd trap, next to the setup commands that walk into it.

## Verification

- **10 new tests**, red → green, including the exact production scenario (Node 20 on PATH, Node 22 in nvm) plus text guards that fail if either defect returns.
- **Full suite: 622 passed.**
- **Proven in the environment that failed** — `systemd-run` with the real `EnvironmentFile`: `v20.20.2 → v25.4.0`, upload OK in 30s.
- Both dry-run branches exercised (`R2 not configured`, `DRY-RUN wrangler …`); `bash -n` clean on both scripts.
- Live object re-verified: `Content-Length: 203165696`, byte-for-byte with local `bids.sqlite`. **The mirror is already current** — it was restored during diagnosis, so this PR keeps it working rather than being needed to unbreak it.

The deploy scripts had **no test coverage at all**, which is how this shipped broken and stayed broken. `scrapers/tests/helpers_deploy.py` adds a small bash-subprocess harness — a new shape for this suite, which is otherwise pure Python and offline — so future changes to these scripts are testable.

## Deliberately not included

The staleness check (`HEAD` the public URL, fail on a stale object) is defense-in-depth against a *different* failure mode than this root cause, and overlaps the general problem in #176 — nightly steps that fail every run without ever tripping a "last run failed" check. Filed there instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
