### PR TITLE
feat(committee): committee/Council award bid capture, and its measured ~1% ceiling (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,38 @@ The bidders did not stop. `tb enrich-awards --download` archives the Toronto Bid
 - **Four traps this parser hit, all previously documented elsewhere:** an RFP lists proponents with **no price at all** (`NOTE: Not applicable for RFP`) so the price must be optional (#84 stores these as NULL); `2489960 Ontario Inc.` is a **real firm**, so a "long digit run means a leaked price" guard eats it (#87 pins the same lesson — reading cells removes the reason that guard existed, since a name cell cannot contain a price that leaked out of the price cell); `\s` matches newlines, so `\d{1,2}[.)]\s*` walked off an empty `4.` row and captured `Page 2 of 2` as a bidder; and **the numbering is not always there** — requiring it cost 57 of 229 forms their entire bid table, so it is stripped where present and never required.
 - **Coverage is bounded and will stay bounded**: the form exists only **over $500,000** — the panel had no floor — so the bid record thins permanently for small awards. The City also says "a portion of work ... will be manual"; 223 of 244 post-cutover awards carry one (91%).
 
+### Committee/Council awards (`sources/committee_awards.py`, #164) — a ~1% slice, measured
+
+`tb enrich-committee-awards`. The other half of "where awards went after the panel" (#114): the
+awards too large for the CPO go to a Standing Committee or Council. The route is voting-record
+CSV → agenda-item page (headed browser) → staff-report PDF → bid table, storing into `bid` /
+`background_pdf` with **no new tables** (a committee bid keys like a #114 award-summary bid —
+`reference` NULL, `document_number` set). Offline by default; `--scrape` drives the browser.
+Self-bounding: it only chases items that name a spine solicitation and have no bids yet.
+
+**It works end to end and recovers almost nothing. That is the finding, and it is measured —
+do not reopen it expecting a better parser to help (the #83 pattern).** First live run:
+11 award items found, 8 needing bids, 8/8 discovered, 8/8 downloaded, **3 bids from 2 reports**.
+
+- **The join key is the ceiling, not the parser.** Discovery keeps only items whose *Agenda Item
+  Title* carries a 10-digit doc number. Of **9,444** distinct agenda items, 109 are
+  award/contract-like and **only 11 name one**. Against the #164 target set — 4,942 odata awards
+  with no captured bids, of which **431 are ≥$5M totalling $25.53B** — exactly **4** are
+  reachable this way.
+- **The 98 unreachable award-like items are mostly not losses.** The sample is dominated by
+  `Amendment to Blanket Contract` and `Non-Competitive Contract`, which have no bids by nature.
+  Widening the title regex buys far less than the raw count suggests.
+- **RFTs/RFQs tabulate bids; RFPs narrate them.** That is why 6 of 8 reports yielded nothing.
+  `_BID_TABLE_ANCHORS` refuses unless `Summary of Bids Received` or `opened the following bids`
+  is present — correct behaviour (#130 discipline), not a gap: an RFP report says
+  *"The City received one submission ... from: Carla Construction and Maintenance Ltd."* in prose
+  and names no losing proponents at all. The unbuilt cheap win is that prose pattern.
+- **Most competitive awards never reach committee**, being staff-delegated or panel-handled —
+  the same mechanism #83 measured on titles. Committee is the exception tier, so a committee
+  route can only ever be a thin slice.
+- Report bytes land content-addressed at `documents/committee_award/<sha256>.pdf`, so re-parsing
+  is offline and free — the queue keys on `sha256`, never `text` (#96's lesson).
+
 ### Ariba attachments (`sources/ariba_attachments.py`, #117) — the documents behind Respond
 
 `tb enrich-ariba-attachments`. The City posts every competitive solicitation to Ariba Discovery, but the **actual documents** — RFP parts, drawings, addenda, environmental assessments, pricing forms — live inside the Sourcing event, not on the Discovery posting. The preview renders `Attachments (0)`; the files are reachable only "as participating Supplier", i.e. after clicking **Respond**. Authorized by PMMD in writing (2026-07, on the City's open-by-default policy); Respond registers our supplier account as an event participant for archival access and **never submits a bid**.

--- a/docs/superpowers/plans/2026-07-19-committee-award-bids.md
+++ b/docs/superpowers/plans/2026-07-19-committee-award-bids.md
@@ -1,0 +1,236 @@
+# Committee/Council Award Bid Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture the bid tables for large awards decided by Council / a Standing Committee (above the Bid Award Panel threshold) from their staff reports on legdocs, attaching the bids directly to their spine solicitations by document number.
+
+**Architecture:** A new `sources/committee_awards.py`. The target index comes from the open-data voting-record CSVs (plain HTTP — item titles carry the doc number). Report URLs come from TMMIS agenda-item pages (headed browser, cached). Report PDFs are plain HTTP + `pdftotext`; a pure parser reads the two bid-table shapes; bids store with the report's `document_number` (source='committee_award') and attach directly like #114 Award Summary bids — no bridge, no fuzzy match.
+
+**Tech Stack:** Python 3.12, `uv`, pytest (offline, fixture-based). Playwright/Xvfb for discovery only. `pdftotext` (poppler).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-19-committee-award-bids-design.md`.
+- **No lint/typecheck** — only `uv run pytest` from `scrapers/`.
+- **Refuse rather than invent** (#130): a report with no bid table (emergency/sole-source/confidential attachment) stores NO bids; the award stays honestly zero-bid.
+- **Match the number, not the vocabulary** (#77/#114): extract the 10-digit doc from `Doc<n>` / `Document Number <n>` / `Ariba Document Number <n>`.
+- **Bids attach by document_number directly** — these awards are already in the spine, so no linking pass, no false-merge surface.
+- **Amounts**: `bid_price` verbatim (keep the winner `*`), `bid_price_numeric` via `amount.py`; never aggregate the raw string.
+- Browser discovery is **on-demand, not nightly** (reuse the `council` extra + `--virtual-display`).
+- Real fixtures already captured: `scrapers/tests/fixtures/committee/district2_rfq_doc4553928310.txt` (RFQ, `Summary of Bids Received`, 2 bidders) and `ashbridges_tender_2010.txt` (RFT, `opened the following bids`, 3 bidders).
+- Commit trailers on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01B9GFHCLueSNypaFqkgpPRE
+  ```
+- Branch `feat-164-committee-award-bids` (already checked out). Do not commit to `main`.
+
+## File Structure
+
+- `scrapers/toronto_bids/sources/committee_awards.py` — the whole source (Tasks 1-4).
+- `scrapers/toronto_bids/store/schema.sql` — `background_pdf.kind='committee_award'` needs no schema change (kind is free text); confirm.
+- `scrapers/toronto_bids/cli.py` — `tb enrich-committee-awards` (Task 4).
+- `scrapers/tests/test_committee_awards.py` — tests (Tasks 1-3).
+
+---
+
+## Task 1: Voting-record target index (pure + CKAN fetch)
+
+**Files:** Create `scrapers/toronto_bids/sources/committee_awards.py`; Test `scrapers/tests/test_committee_awards.py`; fixture `scrapers/tests/fixtures/committee/voting_record_sample.csv`.
+
+**Interfaces:**
+- `award_doc_number(title: str) -> str | None` — the 10-digit doc from an item title, else None.
+- `award_items_from_voting_record(csv_text: str) -> list[dict]` — distinct `{document_number, reference, committee, title}` for award rows.
+- `fetch_voting_records(http) -> list[str]` — the per-term CSV bodies from CKAN.
+
+- [ ] **Step 1: Create the fixture** `scrapers/tests/fixtures/committee/voting_record_sample.csv` (real header + a few rows, incl. the three title vocabularies and a non-award row):
+
+```csv
+_id,Term,First Name,Last Name,Committee,Date/Time,Agenda Item #,Agenda Item Title,Motion Type,Vote,Result,Vote Description
+1,2022-2026,A,B,City Council,2024-05-01 10:00 AM,2024.GG16.12,"Award of Doc4553928310 to GFL Environmental Inc., for District 2 Waste Collection",Adopt,Yes,Carried,x
+2,2022-2026,A,B,City Council,2024-05-01 10:00 AM,2024.GG16.12,"Award of Doc4553928310 to GFL Environmental Inc., for District 2 Waste Collection",Adopt,Yes,Carried,x
+3,2022-2026,C,D,City Council,2024-06-01 10:00 AM,2024.GG14.8,Process for Award of Negotiable Request for Proposal Document Number 4053424337 for Ferry Vessels,Adopt,Yes,Carried,x
+4,2022-2026,C,D,General Government Committee,2023-03-01 10:00 AM,2023.GG2.11,Award of Ariba Document Number 3448368603 to CH2M Hill Canada for Basement Flooding,Adopt,Yes,Carried,x
+5,2022-2026,C,D,City Council,2024-06-01 10:00 AM,2024.MM1.1,Election of the Speaker,Adopt,Yes,Carried,x
+```
+
+- [ ] **Step 2: Write failing tests** in `tests/test_committee_awards.py`:
+
+```python
+from pathlib import Path
+from toronto_bids.sources.committee_awards import award_doc_number, award_items_from_voting_record
+
+FIX = Path(__file__).parent / "fixtures" / "committee"
+
+
+def test_award_doc_number_reads_the_title_vocabulary():
+    assert award_doc_number("Award of Doc4553928310 to GFL") == "4553928310"
+    assert award_doc_number("Process for Award of Negotiable RFP Document Number 4053424337 for x") == "4053424337"
+    assert award_doc_number("Award of Ariba Document Number 3448368603 to CH2M") == "3448368603"
+    assert award_doc_number("Election of the Speaker") is None
+
+
+def test_award_items_from_voting_record_dedups_and_skips_non_awards():
+    items = award_items_from_voting_record((FIX / "voting_record_sample.csv").read_text())
+    by_doc = {i["document_number"]: i for i in items}
+    assert set(by_doc) == {"4553928310", "4053424337", "3448368603"}   # non-award row dropped, dupes merged
+    assert by_doc["4553928310"]["reference"] == "2024.GG16.12"
+    assert by_doc["4553928310"]["committee"] == "City Council"
+```
+
+- [ ] **Step 3: Run — fails** (`cd scrapers && uv run pytest tests/test_committee_awards.py -v`).
+
+- [ ] **Step 4: Implement** `committee_awards.py`:
+
+```python
+import csv
+import io
+import re
+
+_DOC = re.compile(r"(?:Ariba\s+)?Doc(?:ument)?(?:\s*Number)?\s*[:#]?\s*(\d{10})", re.IGNORECASE)
+
+
+def award_doc_number(title):
+    """The 10-digit document number an award item names, else None. Match the number, not the
+    vocabulary — titles say 'Doc<n>', 'Document Number <n>', 'Ariba Document Number <n>'."""
+    if not title:
+        return None
+    m = _DOC.search(title)
+    return m.group(1) if m else None
+
+
+def award_items_from_voting_record(csv_text):
+    """Distinct award items carrying a document number, from one voting-record CSV.
+    Returns [{document_number, reference, committee, title}]. Dedups the per-member vote rows."""
+    out = {}
+    for row in csv.DictReader(io.StringIO(csv_text)):
+        title = row.get("Agenda Item Title") or ""
+        doc = award_doc_number(title)
+        if not doc:
+            continue
+        out.setdefault(doc, {"document_number": doc, "reference": row.get("Agenda Item #"),
+                             "committee": row.get("Committee"), "title": title})
+    return list(out.values())
+
+
+def fetch_voting_records(http):
+    """The per-term voting-record CSV bodies from CKAN (UUIDs resolved at runtime, never hardcoded)."""
+    import json
+    base = "https://ckan0.cf.opendata.inter.prod-toronto.ca/api/3/action"
+    pkg = json.loads(http.get(f"{base}/package_show?id=members-of-toronto-city-council-voting-record").text)
+    csvs = []
+    for r in pkg["result"]["resources"]:
+        if r.get("format", "").upper() == "CSV" and r.get("name", "").startswith("member-voting-record-2"):
+            csvs.append(http.get(r["url"]).text)
+    return csvs
+```
+
+(Verify `HttpClient.get(url).text` is the right accessor — read `toronto_bids/http.py`; adjust if it's `.get(url)` returning bytes/other.)
+
+- [ ] **Step 5: Run tests + full suite; Commit** (`git add` the source, test, fixture; message: `feat(committee): voting-record award-item index (#164)`).
+
+---
+
+## Task 2: `parse_committee_bids` — the two-format bid-table parser
+
+**Files:** Modify `committee_awards.py`; Test `tests/test_committee_awards.py`.
+
+**Interfaces:** `parse_committee_bids(text: str) -> list[tuple[str, str]]` — `(bidder, bid_price)` per bid; `[]` when no table (refuse).
+
+- [ ] **Step 1: Failing tests** (against the REAL captured fixtures):
+
+```python
+from toronto_bids.sources.committee_awards import parse_committee_bids
+
+def test_parse_rfq_summary_of_bids_received():
+    bids = parse_committee_bids((FIX / "district2_rfq_doc4553928310.txt").read_text())
+    names = {b for b, _ in bids}
+    assert "GFL Environmental Inc." in names
+    assert any("Halton Recycling" in b for b, _ in bids)      # the losing bidder captured
+    assert len(bids) == 2
+
+def test_parse_rft_opened_the_following_bids():
+    bids = parse_committee_bids((FIX / "ashbridges_tender_2010.txt").read_text())
+    names = {b for b, _ in bids}
+    assert any("Kenaidan" in b for b in names)
+    assert any("Torbear" in b for b in names)
+    assert any("Alberici" in b for b in names)
+    assert len(bids) == 3
+
+def test_parse_refuses_a_report_with_no_bid_table():
+    assert parse_committee_bids("... the only supplier able to provide ... emergency ...") == []
+```
+
+- [ ] **Step 2: Run — fails.**
+
+- [ ] **Step 3: Implement `parse_committee_bids`.** Read both fixture .txt files in full first to see the exact layout. Anchor on the two table headers:
+  - `Summary of Bids Received` (RFQ/RFP): the rows below pair a supplier name with the first `$amount` on/near its line, until a blank-line gap or a footnote (`*…`) / next section. Strip the winner `*`. Skip the column-header line(s) (`Supplier Name`, `Bid Price…`).
+  - `opened the following bids` (RFT): the `Tenderer … Total Tender Price` table; each row is `<name> … <$amount>`.
+  Use a shared line-walk that, after either header, reads `<name> … <$price>` rows and stops at the first line with no `$amount` after a name (the #94/#116 "read cells, refuse an unequal/blank row" discipline). Return `[]` if neither header is present. `parse_amount` (from `toronto_bids.amount`) validates the price; keep the raw `$` string as `bid_price`.
+
+- [ ] **Step 4: Run tests + full suite; Commit** (`feat(committee): parse_committee_bids for both report bid-table shapes (#164)`).
+
+---
+
+## Task 3: Store — download reports + attach bids by document_number
+
+**Files:** Modify `committee_awards.py`; Test `tests/test_committee_awards.py`.
+
+**Interfaces:**
+- `download_committee_reports(conn, http, url_map: dict, log) -> int` — fetch each report PDF (plain HTTP), store in `background_pdf` (kind='committee_award', with `document_number` + url + text via pdftotext). Reuse the resilient download pattern (`trca_board._store_pending_pdfs` or equivalent) — skip a dead URL, `%PDF` guard, sha256-queued.
+- `store_committee_bids(conn, log) -> int` — for each `background_pdf WHERE kind='committee_award'`, parse its text with `parse_committee_bids` and upsert `Bid(document_number=<report doc>, reference=None, bidder_name_raw, bid_price, bid_price_numeric, source='committee_award')`. Returns bids stored.
+
+- [ ] **Step 1: Failing test** (store path, no network — seed a background_pdf row with the fixture text):
+
+```python
+def test_store_committee_bids_attaches_by_document_number(conn):
+    from toronto_bids.store import db
+    from toronto_bids.models import Solicitation, BackgroundPdf
+    from toronto_bids.sources.committee_awards import store_committee_bids
+    db.upsert_row(conn, Solicitation(document_number="4553928310", source="odata"), overwrite=True)
+    db.upsert_row(conn, BackgroundPdf(url="https://x/backgroundfile-1.pdf", document_number="4553928310",
+                  kind="committee_award", text=(FIX / "district2_rfq_doc4553928310.txt").read_text()),
+                  overwrite=True)
+    conn.commit()
+    n = store_committee_bids(conn)
+    assert n == 2
+    rows = conn.execute("SELECT bidder_name_raw, document_number FROM bid WHERE source='committee_award'").fetchall()
+    assert {r[0] for r in rows} >= {"GFL Environmental Inc."}
+    assert all(r[1] == "4553928310" for r in rows)
+```
+
+- [ ] **Step 2: Run — fails.**
+
+- [ ] **Step 3: Implement.** `store_committee_bids` iterates the committee_award reports, parses, and upserts Bid rows via `db.upsert_row`. Confirm `BackgroundPdf` model carries `document_number`, `kind`, `text` (it does — used by #114/#126). Confirm `Bid` upsert with `reference=None, document_number=<doc>` keys cleanly (bid_key COALESCEs both — a committee bid looks like a #114 award-summary bid). `download_committee_reports` mirrors `trca_board.download_reports` (read that first).
+
+- [ ] **Step 4: Run tests + full suite; Commit** (`feat(committee): download reports + attach bids by document_number (#164)`).
+
+---
+
+## Task 4: Browser discovery + CLI
+
+**Files:** Modify `committee_awards.py`, `cli.py`.
+
+**Interfaces:** `discover_report_urls(items, cache_dir, *, virtual_display, log) -> dict[reference, url]`; CLI `tb enrich-committee-awards [--scrape] [--virtual-display]`.
+
+- [ ] **Step 1: Implement `discover_report_urls`** (browser, no unit test — as with council/agency scrapers). Reuse the council/agency headed-browser fetch (see `bid_award_panel.agenda_fetcher` / `sources/council.py`): for each item `reference`, fetch `https://secure.toronto.ca/council/agenda-item.do?item=<reference>`, cache the HTML under `cache_dir`, and scrape the `<a href=…backgroundfile-<n>.pdf>` whose link text contains `Award of Doc<doc>` (fall back to the first `bgrd/backgroundfile` link if only one). Return `{reference: url}`. An item already cached is not refetched.
+
+- [ ] **Step 2: Wire the CLI** `_cmd_enrich_committee_awards`:
+  - `--scrape`: `fetch_voting_records(http)` → `award_items_from_voting_record` (all terms) → filter to spine awards with no captured bids → `discover_report_urls(..., virtual_display=args.virtual_display)` → `download_committee_reports` → `store_committee_bids` → `build_supplier_dimension`.
+  - default (offline): `store_committee_bids` over already-downloaded reports + `build_supplier_dimension`.
+  Add the subparser + dispatch, mirroring `enrich-agencies`.
+
+- [ ] **Step 3: Run full suite; Commit** (`feat(committee): browser discovery + tb enrich-committee-awards (#164)`).
+
+---
+
+## Task 5: Live run + recording
+
+- [ ] **Step 1:** `cd scrapers && TB_DATA_DIR="$HOME/tb-data" uv run tb enrich-committee-awards --scrape --virtual-display` over a bounded sample of the target awards (start with the ≥$10M tier to keep the first browser run small). Capture: report URLs discovered, reports with a parseable bid table vs refused, bids attached, and the zero-bid-count drop.
+- [ ] **Step 2:** Comment on #164 with the measured recovery; **close #167 as folded in**; update #163's accounting.
+
+## Self-Review
+
+**Spec coverage:** voting-record index → Task 1; two-format parser + refusal → Task 2; direct-attachment store → Task 3; browser discovery + CLI → Task 4; live gate + recording → Task 5. ✓
+**Placeholder scan:** Task 2 Step 3 says "read the fixtures first" — the fixtures are real and committed; the parser shape is described concretely (two anchors + line-walk + refuse). No TBD.
+**Type consistency:** `award_doc_number -> str|None`, `award_items_from_voting_record -> list[dict{document_number,reference,committee,title}]`, `parse_committee_bids -> list[(bidder,price)]`, `store_committee_bids -> int`, `discover_report_urls -> dict[ref,url]` — consistent across tasks.

--- a/docs/superpowers/specs/2026-07-19-committee-award-bids-design.md
+++ b/docs/superpowers/specs/2026-07-19-committee-award-bids-design.md
@@ -1,0 +1,130 @@
+# Committee/Council award bid capture (#164 + #167)
+
+**Date:** 2026-07-19
+**Status:** approved (autonomous — maintainer reviews at the PR), not yet implemented
+**Delivers:** the bid record for large awards decided by Council / a Standing Committee — above the
+Bid Award Panel's delegation ceiling, so absent from the panel-agenda corpus the archive mines
+today (#84/#94). Folds #167 (2013-2018, ≥$500K) into #164 (2020+, ≥$3M): one committee-report
+source, both eras.
+
+## 1. Feasibility (probed live 2026-07-19)
+
+The assumption behind #164 — that committee reports tabulate the bids "the same way Bid Award Panel
+reports do" — **holds**, verified against real reports:
+
+- **RFQ/RFP** (District 2 Waste Collection, `Doc4553928310`, $197M): the report has
+  `Table 2: Summary of Bids Received including Bid Price` — `GFL Environmental Inc. $36,182,930` /
+  `Halton Recycling Ltd. $37,247,071` (the losing bidder, captured).
+- **RFT** (Ashbridges tender, $85M): `opened the following bids:` → `Kenaidan $83,658,000 /
+  Torbear $88,910,095 / Alberici $95,995,000`.
+
+(An earlier "reports withhold bids" read was WebFetch's small-model misreading the PDF; `pdftotext`
+— the archive's own tool — finds the tables cleanly.)
+
+The reports live on **legdocs** (`toronto.ca/legdocs/mmis/<year>/<cmte>/bgrd/backgroundfile-<n>.pdf`,
+plain HTTP, not Akamai-gated — the same host `download_reports` already fetches).
+
+## 2. Discovery — mostly plain HTTP
+
+The one gated resource is TMMIS agenda-item pages (403 to plain HTTP). The chain:
+
+1. **doc → (committee, agenda item#): plain HTTP.** The **open-data voting-record CSVs**
+   (`members-of-toronto-city-council-voting-record`, one resource per council term) list every
+   award item with the document number **in the title** — `Award of Doc<10>`,
+   `Award of … Document Number <10>`, `Award of Ariba Document Number <10>`. Parsing those yields
+   `{document_number, reference, committee, title}` with no browser. This is the target index.
+2. **agenda item# → report PDF URL: headed browser.** For each item, fetch
+   `secure.toronto.ca/council/agenda-item.do?item=<ref>` under Xvfb (reuse the council prober),
+   scrape the `backgroundfile-<n>.pdf` link whose title is `Award of Doc<n>`. One page per item;
+   cached on disk so a re-run never re-drives the browser (like the BA-agenda cache).
+3. **report PDF → bid table: plain HTTP + pdftotext.**
+
+## 3. Architecture — `sources/committee_awards.py`
+
+Pure/impure split, mirroring the agency board-report sources (#130/#141):
+
+- **`award_items_from_voting_record(csv_text) -> list[dict]`** (pure): parse one voting-record CSV,
+  return distinct `{document_number, reference, committee, title}` for rows whose *Agenda Item Title*
+  names a 10-digit document number via `award_doc_number(title)`. Tested against a fixture CSV.
+- **`award_doc_number(title) -> str | None`** (pure): extract the 10-digit doc from the title
+  vocabulary (`Doc<n>`, `Document Number <n>`, `Ariba Document Number <n>`) — match the number, not
+  the words (the #77/#114 lesson).
+- **`fetch_voting_records(http) -> list[str]`** (impure): CKAN `package_show` → the per-term CSV
+  resource URLs → the CSV bodies. UUIDs resolved at runtime (never hardcoded, #CKAN gotcha).
+- **`discover_report_urls(items, cache_dir, *, virtual_display, log) -> dict[ref, url]`** (browser):
+  fetch each item page under Xvfb, cache the HTML, scrape the `Award of Doc<n>` background-file URL.
+- **`download_committee_reports(conn, http, url_map, log) -> int`** (impure, plain HTTP): fetch each
+  report PDF, store it in `background_pdf` (kind=`committee_award`, carrying `document_number` and
+  the legdocs URL), `pdftotext` the text. Resilient loop (`_store_pending_pdfs` pattern), sha256-queued.
+- **`parse_committee_bids(text) -> list[tuple[str, str]]`** (pure): the bid table. Two shapes:
+  - `Summary of Bids Received …` → rows of `<supplier> … <$price>` until a blank/section boundary.
+  - `opened the following bids …` → `<Tenderer> … <$Total Tender Price>` rows.
+  Read cells/lines positionally; refuse a row without a clean `name … $price`. **Refuse the whole
+  report** when no table is present (emergency / sole-source / "only supplier" / confidential
+  attachment) — no bids by nature, don't invent them (#130 discipline). `bid_price` verbatim,
+  `bid_price_numeric` via `amount.py`; the winner's `*` marker kept.
+- **`store_committee_bids(conn, log) -> int`** (impure): for each stored committee-award report,
+  parse its text and upsert `Bid` rows with the report's **`document_number`** and
+  `source='committee_award'`. Because the award is already in the spine with that document number,
+  the bids attach **directly** — no bridge, no fuzzy match, no false-merge surface (the opposite of
+  #124's hard part).
+
+### CLI
+
+`tb enrich-committee-awards [--scrape] [--virtual-display]`:
+- default (offline): parse cached item pages + stored reports → attach bids.
+- `--scrape`: refresh the voting-record index + browser-discover report URLs + download reports.
+
+On-demand, **not on the nightly path** (browser-bound), like `enrich-titles --scrape` was and the
+agency scrapers are.
+
+## 4. Data flow
+
+voting-record CSV (plain HTTP) → `award_items_from_voting_record` → `discover_report_urls`
+(browser, cached) → `download_committee_reports` (plain HTTP + pdftotext) → `parse_committee_bids`
+(pure) → `store_committee_bids` (Bid rows keyed on document_number, source='committee_award') →
+`build_supplier_dimension` picks up new bidders → export nests them under the solicitation (they
+carry a document_number, exactly like #114 Award Summary bids — no export change).
+
+## 5. Scope / target set
+
+- Award items from the voting-record whose title names a document number AND whose solicitation is
+  in the spine with **no captured bids** (the ~99 modern ≥$3M + ~266 older ≥$500K, refreshed by
+  query). Parsing every award item is fine too — a bid table found is a bid table stored; the
+  no-captured-bids filter just bounds the browser discovery.
+- **Both eras** (#164 + #167) — one source; #167 closes as folded here.
+
+## 6. Refusal / genuine-zero (load-bearing)
+
+Some large awards genuinely have no bid table: emergency, sole-source, "only supplier",
+non-competitive, or a value routed to a confidential attachment (MFIPPA). `parse_committee_bids`
+returns `[]` for those and `store_committee_bids` writes nothing — the award stays honestly
+zero-bid. Validate the refusal against real negatives (an emergency/sole-source report) per the
+#130 discipline, so a report's prose ("$X to the only supplier") is never mistaken for a bid.
+
+## 7. Testing
+
+- **Pure parsers** against real report text captured as fixtures: the RFQ `Summary of Bids Received`
+  table (District 2 — 2 bidders), the RFT `opened the following bids` table (Ashbridges — 3
+  bidders), `award_doc_number` across the title vocabulary, `award_items_from_voting_record` against
+  a fixture CSV, and **negatives** (an emergency/sole-source report → `[]`).
+- **`store_committee_bids`**: bids attach to the right solicitation by document_number; `bid_price_numeric`
+  parsed; the winner marker kept; a no-table report stores nothing.
+- **Browser discovery** stays untested by unit tests (as with the council/agency scrapers).
+- **Mandatory live run** (#136/#138): a real `--scrape` over a sample of the target awards; report
+  how many report URLs discovered, how many reports carried a parseable bid table vs refused, how
+  many bids attached, and the drop in the zero-bid count. The offline fixtures are a starting point.
+
+## 8. Out of scope
+
+- The pre-Ariba unique-match bridge (#124/#165 — different mechanism; this is exact by document
+  number).
+- Non-award committee reports (status updates, budgets) — the parser refuses them by finding no bid
+  table.
+- Full-text/OCR of the reports beyond the bid table.
+- Putting the browser discovery on the nightly path (browser-bound, on-demand only).
+
+## 9. Recording
+
+On completion, comment on #164 with the measured recovery (report URLs found, bid tables parsed vs
+refused, bids attached, zero-bid drop) and **close #167 as folded in**. Update #163's accounting.

--- a/scrapers/tests/fixtures/committee/ashbridges_tender_2010.txt
+++ b/scrapers/tests/fixtures/committee/ashbridges_tender_2010.txt
@@ -1,0 +1,140 @@
+                                                 STAFF REPORT
+                                                 ACTION REQUIRED
+
+Contract Award - Contract 09FS – 66WP
+Tender Call 214-2009
+Ashbridges Bay Treatment Plant
+D Building Upgrade
+
+Date:        March 22, 2010
+
+To:          Public Works & Infrastructure Committee
+
+             Executive Director, Technical Services
+From:
+             Director, Purchasing and Materials Management Division
+
+Wards:       Ward 32 – Beaches – East York
+
+Reference
+          P:/2010/Internal Services/pmmd/PW10016pmmd (AFS #9028)
+Number:
+
+
+
+SUMMARY
+
+The purpose of this report is to advise on the results of the Tender Call 214-2009 issued
+for the Ashbridges Bay Treatment Plant, D Building Upgrade in accordance with
+specifications and drawings as required by Technical Services and to request authority to
+award a contract to the recommended bidder.
+
+RECOMMENDATIONS
+
+The Executive Director of Technical Services and the Director of Purchasing and
+Materials Management Division recommend that Public Works & Infrastructure
+Committee grant authority to:
+
+1. Award Contract 09FS-66WP, Tender Call 214-2009 for the Ashbridges Bay
+   Treatment Plant( ABTP), D Building Upgrade in the amount of $85,130,380.80 net of
+   GST and HST Recoveries, to Kenaidan Contracting Ltd., having submitted the lowest
+   bid meeting specifications in conformance with the Tender requirements.
+
+FINANCIAL IMPACT
+
+The total contract award identified in this report is $83,658,000.00 net of all applicable
+taxes and charges. The cost to the City is $85,130,380.80 net of GST and HST
+Recoveries. The funding for the contract award of $85,130,380.80 net of GST and HST
+
+
+Staff Report for action on Award for Tender Call 214-2009                               1
+Recoveries is included in the approved 2010 Toronto Water Capital Budget and 2011-
+2019 Capital Plan in WAS Element CWW042 – Ashbridges Bay WWTP.
+
+The cash flow requirements for this project net of GST and HST Recoveries are
+$4,986,240.00 in 2010, $19,537,920.00 in 2011, $19,240,780.80 in 2012, $13,788,480.00
+in 2013, $13,788,480.00 in 2014, $13,788,480.00 in 2015.
+
+The engineering estimate for this project was $74,000,000.00 net of GST. The increased
+cost is due to inclusion in this contract of additional equipment and appurtenances
+designed under other projects that overlap with the D Building work in time and space.
+This approach will prevent the City from being designated as the Constructor under the
+Occupational Health and Safety Act.
+
+The Deputy City Manager and Chief Financial Officer has reviewed this report and
+agrees with the financial impact information.
+
+BACKGROUND
+
+The overall scope of the D Building upgrade includes significant improvements to the
+preliminary process area, odour control, and ventilation and electrical systems.
+
+The D Building process upgrades include new screens, a new grit removal system, new
+handling and loading systems for screenings and grit. The project also includes the
+realignment of existing conduits and construction of a new split flow conduit in order
+to improve treatment and flow management during major wet weather events.
+
+The odour control system for D Building includes a new biofilter with a dedicated stack.
+This system was selected following a one year pilot test of biological odour control units.
+The project will also render the preliminary process areas compliant with the current
+electrical and fire protection standards due to the installation of new ventilation and
+electrical systems.
+
+Tender Call 214-2009 was issued by Purchasing and Materials Management Division and
+was advertised in the Daily Commercial News on November 30, 2009 and on the City’s
+Internet Website.
+
+The Purchasing and Materials Management Division at its Public Opening held on
+February 12, 2010, opened the following bids for Contract 09FS-66WP, Tender Call 214-
+2009, for the Ashbridges Bay Treatment Plant, D Building Upgrade and Odour Control.
+
+
+Tenderer                                        Total Tender Price Including All Charges
+                                                Net of GST
+
+Kenaidan Contracting Ltd.                       $83,658,000.00*
+Torbear Contracting Inc                         $88,910,095.00
+Alberici Constructors Ltd.                      $95,995,000.00
+
+
+
+Staff Report for action on Award for Tender Call 214-2009                                  2
+*For Kenaidan Contracting Ltd. the amount net of GST and HST Recoveries is
+$85,130,380.80.
+
+
+COMMENTS
+
+The Tender documentation submitted by the recommended bidder has been reviewed by
+the Executive Director of Technical Services and was found to be in conformance with
+the Tender requirements.
+
+Technical Services staff have compared the bid to the estimated cost and found the price
+of the recommended bidder to be reasonable given the tender prices of all bidders.
+
+The Fair Wage Office has reported that the recommended firm has indicated that it
+reviewed and understands the Fair Wage Policy and Labour Trades requirements and has
+agreed to comply fully.
+
+CONTACTS
+
+Katrina Blom, M. Eng., P. Eng.                  Victor Tryl, P. Eng.
+Senior Engineer                                 Manager
+Technical Services                              Purchasing and Materials Management
+Telephone: (416) 397-5368                       Telephone: (416) 397-4801
+e-mail: kblom@toronto.ca                        e-mail: vtryl@toronto.ca
+
+SIGNATURES
+
+
+
+
+William G. Crowther, P. Eng.                    Lou Pagano, P. Eng.
+Executive Director                              Director
+Technical Services                              Purchasing and Materials Management
+
+
+
+
+Staff Report for action on Award for Tender Call 214-2009                             3
+

--- a/scrapers/tests/fixtures/committee/district2_rfq_doc4553928310.txt
+++ b/scrapers/tests/fixtures/committee/district2_rfq_doc4553928310.txt
@@ -1,0 +1,364 @@
+                                                            REPORT FOR ACTION
+~TORONTO
+Award of Doc4553928310 to GFL Environmental Inc.
+for Curbside Collection Services in District 2 for Solid
+Waste Management Services
+
+Date: September 3, 2024
+To: General Government Committee
+From: General Manager, Solid Waste Management Services and Chief Procurement
+Officer
+Wards: 4 (Parkdale-High Park), 5 (York South-Weston), 6 (York Centre), 7 (Humber
+River-Black Creek), 8 (Eglinton-Lawrence), 9 (Davenport), part of 10 (Spadina-Fort
+York), 11 (University-Rosedale), 12 (Toronto-St. Paul's) and 18 (Willowdale)
+
+SUMMARY
+
+The purpose of this report is to advise on the results of the Request for Quotation
+Doc4553928310 for the collection, transportation and off-loading of Garbage, Bulky
+Items, Organic Materials and Yard Waste from curbside collected Single Family homes,
+multi-residential locations, Commercial locations, Charities, Institutions and Religious
+Organizations and Divisions, Agencies and Corporations. The collection, transportation
+and off-loading of Recyclable Materials from Non-eligible Customer Types, in the
+Collection Area bounded by Yonge Street to the east, the Humber River to the west,
+Steeles Avenue to the north and Lake Ontario to the south (District 2) in the amount of
+$284,250,333 net of all applicable taxes and charges ($289,253,139 net of HST
+recoveries). This collection contract service award is for a five (5) year period with the
+option to extend the agreement on the same terms and conditions for an additional two
+(2) separate one (1) year periods. This report requests the authority to enter into a legal
+agreement with GFL Environmental Inc. being the lowest supplier meeting
+specifications.
+
+RECOMMENDATIONS
+
+The General Manager, Solid Waste Management Services and the Chief Procurement
+Officer recommend that:
+
+1. City Council in accordance with Section 195-8.4 of Toronto Municipal Code Chapter
+195 (Purchasing By-law), authorize the General Manager, Solid Waste Management
+Services to award and enter into an agreement with GFL Environmental Inc. being the
+lowest Supplier meeting specifications for Request for Quotation Doc4553928310 for
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 1 of 8
+curbside collection, transportation and off-loading of materials in the District 2 area in
+the amount of $284,250,333 net of all applicable taxes and charges ($289,253,139 net
+of HST recoveries) for a period of five (5) years commencing on August 3, 2026 to
+August 2, 2031 with an option to extend the agreement for an additional two (2)
+separate one (1) year periods, all in accordance with the terms and conditions as set
+out in the Request for Quotation and any other terms and conditions satisfactory to the
+General Manager, Solid Waste Management and in a form satisfactory to the City
+Solicitor.
+
+
+FINANCIAL IMPACT
+
+The total estimated contract award value including optional years is $284,250,333 net of
+all taxes and including an estimated 3% Consumer Price Index increase for years two
+(2) through seven (7), also included in this value is a contingency amount of one (1)
+million dollars per year. The total potential cost to the City is $289,253,139 including
+adjustments for Consumer Price Index and yearly contingency value, net of HST
+recoveries ($321,202,876 including HST). The estimated funding for the period of
+August 3, 2026 to December 31, 2026 is approximately $12,612,450 net of HST
+recoveries and the funding required for 2026 will be included in the 2026
+Recommended Operating Budget for Solid Waste Management Services in cost centre
+SW1020, cost elements 4390, 4391, 4392, 4393, 4394 and 4424. Funding details are
+provided in Table 1.
+
+Table 1: Recommended Collection Contract - District 2 - Net of HST Recoveries ($'s):
+
+
+
+
+                                                                     Total (Net of HST
+ Term
+                                                                     Recoveries)
+
+
+ Initial Term - August 3, 2026 to December 31, 2026
+                                                                     $12,612,450
+
+
+ Initial Term - January 1, 2027 to August 2, 2027                    $25,224,900
+
+ Initial Term Year 2 - August 3, 2027 to August 2, 2028              $38,941,942
+
+ Initial Term Year 3 - August 3, 2028 to August 2, 2029              $40,079,672
+
+ Initial Term Year 4 - August 3, 2029 to August 2, 2030              $41,251,535
+
+ Initial Term Year 5 - August 3, 2030 to August 2, 2031              $42,458,552
+
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 2 of 8
+                                                                     Total (Net of HST
+ Term
+                                                                     Recoveries)
+
+
+ Option Year 1, August 3, 2031 to August 2, 2032                     $43,701,781
+
+ Option Year 2, August 3, 2032 to August 2, 2033                     $44,982,307
+
+ Total Potential Contract Value (Net of HST Recoveries)              $289,253,139
+
+Solid Waste Management Services has included a contingency of $1.0 million per year,
+excluding all taxes, for emergencies or other unplanned/unforeseen work that may be
+required in each of the years in the contract term.
+
+The Chief Financial Officer and Treasurer has reviewed this report and agrees with the
+information as presented in the financial impact section.
+
+DECISION HISTORY
+
+At its meeting on June 18, 2019, Toronto City Council considered the item
+"Management of Solid Waste contracts under Transition to a Full Extended Producer
+Responsibility Model" (Item IE5.10) and adopted recommendations in Confidential
+Attachment 1 to the report. Furthermore, Council authorized the General Manager,
+Solid Waste Management Services and/or designate to negotiate and enter into any
+new agreements or amending agreements (including but not limited to amending
+agreements to receive external funding) necessary for the City's continued waste
+diversion operations throughout the transition period under the Waste Diversion
+Transition Act, 2016, based in part on the recommendations on pricing set out in the
+Confidential Attachment 1 to the report (May 15, 2019) from General Manager, Solid
+Waste Management Services and each in a form satisfactory to the City Solicitor .
+
+The City Council Decision document can be viewed at:
+http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2019.IE5.10
+
+At its meeting on July 16, 17 and 18, 2019 Toronto City Council adopted the following
+IE6.8 "Vision Zero 2.0 - Road Safety Plan Update." City Council endorse in principle the
+Vision Zero 2.0 plan as outlined in the report (June 13, 2019) from the General
+Manager, Transportation Services and the General Manager, Solid Waste Management
+Services, and direct the General Manager, Transportation Services to report back to the
+appropriate committee where additional authorities are required in order to implement
+the Vision Zero 2.0 Plan.
+
+
+
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 3 of 8
+City Council authorize the General Manager, Solid Waste Management Services to
+implement vehicle side guards and to further the current video-based telematics
+technology to improve road safety by:
+
+a. authorizing the General Manager, Solid Waste Management Services to negotiate,
+and enter into, and execute any and all agreements and amending agreements
+necessary, subject to available funding, to implement a fleet safety and accountability
+program for all new and existing, in-house and contracted out vehicles, which aligns
+with the principles of Vision Zero and the technologies outlined in the report and
+Attachment 3 to the report (June 13, 2019) from the General Manager, Transportation
+Services and the General Manager, Solid Waste Management Services on terms and
+conditions satisfactory to the General Manager, Solid Waste Management Services,
+and in a form satisfactory to the City Solicitor;
+
+b. authorizing 360 degree external and all in-cab video telematics technology to support
+road safety and quality service, and that City Council request the General Manager,
+Solid Waste Management Services to incorporate the requirement of similar
+technologies for any future outsourcing of collection services;
+
+c. requesting the General Manager, Solid Waste Management Services to report back
+annually, through the budget process, on any fleet-related safety and accountability
+enhancements that have been implemented and integrate fleet safety performance as a
+key performance indicator moving forward;
+
+d. approving funding for the capital acquisition for the safety and accountability
+enhancement retrofits to existing solid waste vehicles in the amount of $3,850,000 to be
+budgeted in the amount of $2,530,000 in 2019 and $1,320,000 in 2020 from the Waste
+Management Reserve Fund (XR1404); and
+
+e. approving funding for annual operating costs associated with monitoring and
+equipment maintenance to be budgeted in the annual Operating Budget in the amount
+of $55,200 in the 2019 Operating Budget with an equal offset to the contribution to the
+Waste Management Reserve Fund (XR1404), and directing that future costs be
+included in the annual Solid Waste Management Services Budget.
+
+The City Council Decision document can be viewed at:
+https://secure.toronto.ca/council/agenda-item.do?item=2019.IE6.8
+
+At its meeting on December 17 and 18, 2019, City Council adopted EX11.3 entitled
+"2020 Rate Supported Budgets - Solid Waste Management Services and
+Recommended 2020 Solid Waste Rates and Fees". Amongst other directions, City
+Council authorized the General Manager, Solid Waste Management Services and/or
+designate until the end of 2025, to negotiate and enter into any new agreements,
+amendments of existing agreements, or acknowledgements, including on the basis of a
+non-competitive procurement under Municipal Code, Chapter 195, Purchasing,
+necessary in connection with the efforts indicated in Article 4 "Responsibilities of
+Divisions" - including advocacy, business transformation, financial analysis, or receipt
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 4 of 8
+of funding on terms and conditions satisfactory to the General Manager, Solid Waste
+Management Services and each in a form satisfactory to the City Solicitor.
+
+The City Council Decision document can be viewed at:
+http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2019.EX11.3
+
+At its meeting on September 30, 2020, City Council adopted IE15.4 entitled "Transition
+of Toronto's Blue Box Program to Extended Producer Responsibility". Amongst other
+directions, City Council authorized the General Manager, Solid Waste Management
+Services or designate to negotiate and enter into any new agreements or amending
+agreements (including but not limited to amending agreements to receive external
+funding) necessary for the City's continued waste diversion operations until the latter of
+December 31, 2026 or the transition period end date indicated by the Resource
+Recovery and Circular Economy Act, 2016, or the Waste Diversion Transition Act, 2016,
+or any regulations thereunder, on terms satisfactory to the General Manager, Solid
+Waste Management Services and each in a form satisfactory to the City Solicitor and
+conditional on approved funding.
+
+The City Council Decision document can be viewed at:
+http://app.toronto.ca/tmmis/viewAgendaItemHistory.do?item=2020.IE15.4
+
+First Amending Agreement - Contract Term 2021-2023
+The General Manager, Solid Waste Management Services, under delegated authority,
+negotiated and amended the original contract in June 2019 for a term of two years,
+commencing on August 7, 2021 and terminating on August 5, 2023 with the option of an
+additional one year period, at the agreement of both Parties.
+
+Second Amending Agreement - Contract Term 2023-2026
+Under Council's authority the General Manager of Solid Waste Management Services,
+requested GFL Environmental Inc. to submit an additional quote for services to be in
+line with the EPR Transition expected to be completed by 2026.
+
+Based on the existing authority provided by City Council to the General Manager of
+Solid Waste Management Services and the adopted staff report, IE19.7 Extended
+Producer Responsibility Transition Update – Curbside Collection Strategy with the
+Confidential Attachment 1, adopted by City Council on February 2, 2021, staff has
+extended the current GFL Environmental Inc. (District 2) contract for the period of
+August 6, 2023 to August 2, 2026.
+
+At its meeting on April 17, 2024, "Post-Transition of the Blue Box Program to Extended
+Producer Responsibility and Results of District 2 Service Delivery Options" (IE12.1)
+Toronto City Council, authorize the General Manager, Solid Waste Management
+Services to negotiate and enter into any service agreements or amending agreements
+with any Blue Box Program administrator, and/or their designate to pursue competitive
+procurement of daytime curbside collection services in District 2 to ensure collection
+services continue following the expiration of the current agreement on August 2, 2026.
+
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 5 of 8
+The City Council Decision document can be viewed at:
+Agenda Item History - 2024.IE12.1 (toronto.ca)
+
+
+COMMENTS
+
+The area of District 2 includes approximately 158,690 single family households.
+Currently, daytime curbside collection locations (residential and non-residential) in
+District 2 receive contracted collection services for curbside collection of garbage,
+recycling, organic materials, bulky items and yard waste. Starting from the
+commencement date of this Request for Quotation, the collection of recycling materials
+will be provided to non-eligible customers (Charities, Institutions and Religious
+Organizations, Divisions, Agencies and Corporations and Commercial establishments).
+
+Request For Quotation Doc4553928310 includes the requirement for external 360
+degree camera systems and side guards as part of the fleet safety and accountability
+program as directed by Council, and is strategically aligned with the City's Vision Zero
+initiative.
+
+Procurement Process
+Request For Quotation Doc4553928310 for the collection, transportation and off-loading
+of materials from curbside collected locations in the area bounded by Yonge Street to
+the east, the Humber River to the west, Steeles Avenue to the north and Lake Ontario
+to the south (District 2), was issued by Purchasing and Materials Management Division
+and was advertised on both the City's and Ariba Discovery websites on Friday May 3,
+2024 with closing date of June 7, 2024, and an issuance of two (2) Addenda. A total of
+two (2) bid submissions were received, which are summarized in Table 2 below:
+
+Table 2: Summary of Bids Received including Bid Price
+
+                                                          Bid Price Excluding HST and
+ Supplier Name
+                                                          Contingency
+
+ GFL Environmental Inc.*                                  $36,182,930.00*
+
+ Halton Recycling Ltd.                                    $37,247,071.64
+
+*Pursuant to the Request for Quotation document, the contract award value includes contingency.
+
+The award of the contract is time sensitive to allow appropriate lead time for the
+recommended contractor to acquire vehicles and prepare for the start-up on August 3,
+2026.
+
+
+
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 6 of 8
+Contract Award
+GFL Environmental Inc. is the lowest supplier, meeting the requirements as set out in
+Request for Quotation Doc4553928310, which included: having 5 (five) years of proven
+experience in providing residential Curbside Collection services in the past seven (7)
+years to 100,000 single family households per week within a single community made up
+primarily of urban and suburban sections, providing a list of key personnel consisting of
+at least one (1) Operations Manager and four (4) on Road Supervisors or equivalent
+that have a minimum three (3) years of experience supervising a residential curbside
+collection program, a minimum of two (2) references from municipalities, or from whom
+the Supplier has satisfactorily provided residential Curbside Collection services with the
+similar scope in the past seven (7) years, a proposed list of equipment with at least
+seventy-five (75) collection vehicles, required permits and certificates, office information
+and a completed price form.
+
+GFL Environmental Inc. indicated in their bid that they will utilize a new Compressed
+Natural Gas fuelled fleet in an effort to mitigate environmental impacts.
+
+Contract Start Date
+The contract with GFL Environmental Inc. will commence on August 3, 2026 to coincide
+with the end of the current contract with GFL Environmental Inc., which terminates on
+August 2, 2026.
+
+Service Impacts
+GFL Environmental Inc. is the incumbent currently providing collection services to
+curbside locations including single family homes, multi-residential locations, commercial
+locations, non-residential locations (Charities, Institutions and Religious Organizations)
+and Divisions, Agencies and Corporations in the District 2 area. It is anticipated that
+these curbside locations will not experience any change in service levels or standards
+when the new contract with GFL Environmental Inc. commences on August 3, 2026.
+
+The Fair Wage Office has reported that the recommended supplier has indicated it has
+reviewed and understands the Fair Wage Policy and Labour Trades requirements and
+has agreed to comply fully with both.
+
+
+CONTACT
+
+Lisa Duncan, Director, Collections and Litter Operations, Solid Waste Management
+Services, 416 392-8286, Lisa.Duncan@toronto.ca
+
+Marie Reid, Manager, Infrastructure and Development Services, Purchasing Client
+Services, Purchasing and Materials Management Division, 416-397-5187,
+Marie.Reid@toronto.ca
+
+
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 7 of 8
+SIGNATURE
+
+
+
+Matt Keliher
+General Manager, Solid Waste Management Services
+
+
+
+Geneviève Sharkey, Chief Procurement Officer
+
+
+
+
+Award of Doc4553928310 to GFL Environmental Inc. for Curbside Collection Services in District 2
+
+                                                                                           Page 8 of 8
+

--- a/scrapers/tests/fixtures/committee/item_2024_GG16_12.html
+++ b/scrapers/tests/fixtures/committee/item_2024_GG16_12.html
@@ -1,0 +1,714 @@
+<!DOCTYPE html><html lang="en" style="height: 100%;"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta http-equiv="x-ua-compatible" content="IE=Edge">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Cache-Control" content="no-cache">
+<meta http-equiv="Cache-Control" content="no-store">
+<meta http-equiv="Cache-Control" content="max-age=0">
+<meta http-equiv="Expires" content="0">
+<meta name="google-site-verification" content="Z7Gp_WiRTlvxk4vTUYla79i_1T7uqWSno4tuLETbxu4">
+<meta name="google-translate-customization" content="a10c6cb13c4a9aa0-7e58f3154085c15e-gbbd82aa58b2a5105-1d">
+<title>Agenda Item History - 2024.GG16.12</title>
+<link type="text/css" href="/council/assets/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+<link type="text/css" href="/council/assets/lib/fontawesome-free/css/all.min.css" rel="stylesheet">
+<script type="text/javascript" async="" src="https://www.toronto.ca/scripts/newtorontolinktrack.js"></script><script type="text/javascript" src="/council/assets/lib/jquery/dist/jquery.min.js"></script>
+<script type="text/javascript" src="/council/assets/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+
+<link type="text/css" href="/council/assets/themes/cot/css/cot.css" rel="stylesheet">
+<link type="text/css" href="/council/assets/themes/cot/css/cotui.css" rel="stylesheet">
+<link type="text/css" href="/council/assets/themes/cot/css/print.css" rel="stylesheet" media="print">
+<link type="text/css" href="/council/assets/css/report.css" rel="stylesheet">
+<link type="text/css" href="/council/assets/css/styles.css" rel="stylesheet">
+<script type="text/javascript" src="/council/assets/themes/cot/js/cot.shiv.js"></script>
+<script type="text/javascript">
+  function changeFontSize(factor){
+     this.document.querySelectorAll('body, h1, h2, h3, h4, h5, h6, button').forEach(container => {
+    	 let style = window.getComputedStyle(container, null).getPropertyValue('font-size');
+         let currentSize = parseFloat(style);
+         container.style.fontSize = (currentSize + factor) + 'px';
+     });
+}
+</script>
+
+<meta name="WT.ti" content="Agenda Item History">
+<meta name="WT.sp" content="SEC-TMMIS">
+<meta name="DC.title" content="Agenda Item History">
+<meta name="WT.tmmis_type" content="Agenda Item History">
+<meta name="WT.tmmis_agenda_item_id" content="2024.GG16.12">
+<!-- Twitter Card data -->
+<meta name="twitter:card" content="Agenda Item History">
+<meta name="twitter:title" content="Agenda Item History 2024.GG16.12">
+<meta name="twitter:description" content="Agenda Item History 2024.GG16.12">
+<meta name="twitter:image" content="/council/assets/images/logo.svg">
+<!-- Open Graph data -->
+<meta property="og:title" content="Agenda Item History 2024.GG16.12">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://secure.toronto.ca/council/agenda-item.do?item=2024.GG16.12">
+<meta property="og:image" content="/council/assets/images/logo.svg">
+<meta property="og:description" content="Agenda Item History 2024.GG16.12">
+<meta property="og:site_name" content="toronto.ca">
+<script type="text/javascript">
+function expandAccordin(isExpandAll){
+	if(isExpandAll){
+		$('.accordin-heading').addClass('collapsed');
+		$('.collapse').addClass('show');
+	} else {
+		$('.accordin-heading').removeClass('collapsed');
+		$('.collapse').removeClass('show');
+	}
+	$('.accordin-button-expand').attr("aria-pressed",isExpandAll);
+	$('.accordin-button-collapse').attr("aria-pressed",!isExpandAll);
+	$('.accordin-heading').attr("aria-expanded",isExpandAll);
+}
+
+function sendEmail(mailto_link){
+    window.location.href = mailto_link;
+}
+
+function emailItem(){
+	window.location.href = "mailto:?subject=Toronto Agenda Item 2024.GG16.12&body=%0ACity of Toronto Agenda Item%0A%0A2024.GG16.12 - Award of Doc4553928310 to GFL Environmental Inc., for Curbside Collection Services in District 2 for Solid Waste Management Services%0A" + encodeURIComponent(document.location.href);
+}
+function submitComments(){
+	window.location.href = "";
+}
+function requestToSpeak(){
+	window.location.href = ""
+}
+
+function goToMeeting(decisionBodyId,meetingId){
+	document.location= '/council/#/committees/'+decisionBodyId+'/'+meetingId;
+}
+
+function goToMap(){
+	document.location= '/council/#/committees/2462/agenda-item-map/2024.GG16.12';
+}
+
+function speakerMonitor(){
+	document.location= '/council/#/committees/2462/speakers/2024.GG16.12';
+}
+
+$(document).ready(function(){
+	$('#collapse0').collapse('show');
+});
+</script>
+<style>
+.btn-share {
+    color: #333;
+    background-color: #fff;
+    border-color: #ccc;
+</style>
+<link type="text/css" rel="stylesheet" charset="UTF-8" href="https://www.gstatic.com/_/translate_http/_/ss/k=translate_http.tr.zZZZhVqDDCw.L.W.O/am=BIAABw/d=0/rs=AN8SPfpWxivXbFD2WhpIdS-DPbQSwnZZjQ/m=el_main_css"><script type="text/javascript" charset="UTF-8" src="https://translate.googleapis.com/_/translate_http/_/js/k=translate_http.tr.en_US.YsdJj4HMWlA.O/am=BIAABw/d=1/exm=el_conf/ed=1/rs=AN8SPfoQ11PVS5A3DSmHNnjF9ePd9Kb68w/m=el_main"></script><meta name="DCSext.dcsid" content="dcs222clfigsgada5sghv6dw2_9b4q"><script src="https://c.oracleinfinity.io/acs/account/97j62divdr/js/main/odc.js?_ora.context=analytics:production" type="text/javascript"></script><script type="text/javascript" src="https://d.oracleinfinity.io/infy/acs/account/97j62divdr/js/main/analytics-production.js" async="true" defer="true"></script><script type="text/javascript" src="https://d.oracleinfinity.io/infy/acs/common/js/1.3.53/common.js" async="true" defer="true"></script><script type="text/javascript" src="https://d.oracleinfinity.io/infy/acs/account/97j62divdr/js/main/analytics-production/analytics.js" async="true" defer="true"></script></head>
+<body class="body loaded d-flex flex-column h-100" style="position: relative; min-height: 100%; top: 0px;">
+<main role="main" class="flex-shrink-0">
+	<div class="report">
+	<div class="row print-header" aria-hidden="true">
+		<img src="/council/assets/images/logo-print.svg" width="175" height="53" alt="City of Toronto" class="d-none d-print-block logo"> <span class="print-only report-header"></span>
+		</div>
+		<!--  Heading  -->
+	<header class="header report-header" role="banner">
+	<div class="container-fluid">
+			<div class="cot-logo">
+				<img src="/council/assets/images/logo.svg" alt="City of Toronto" class="logo-img">
+			</div>
+		</div>
+	</header>
+		<!-- Content -->
+		<section role="main" class="content-page flex-fill" id="main">
+			<div class="container-fluid">
+			<div class="mimic-cot-header mb-0 pl-0 ml-0 mt-0 row">	
+				<div class="col-md-8 text-left">
+					<h1 class="mt-3 pl-0 mimic-cot-heading" tabindex="-1">Item - 2024.GG16.12</h1>
+				</div>
+			
+				
+			
+
+	<div class="col-md-4 mb-2 text-right button-bar">
+		
+		
+			<nav id="actions" class="actions" aria-label="Page Actions">
+				<div id="sharebutton">
+					<button id="shareit" class="btn btn-share" aria-haspopup="true" aria-expanded="false" aria-controls="sharebox" aria-label="share this page">Share</button>
+					<div id="sharebox" class="sharebox" tabindex="-1" aria-labelledby="shareit">
+						<ul class="share-list">
+							<li><a target="shareit" href="https://www.facebook.com/sharer/sharer.php?u=https://secure.toronto.ca/council/agenda-item.do?item=2024.GG16.12" id="share-link-1"><img src="/council/assets/themes/cot/img/social_facebook.png" id="share-img-1" alt=""><span class="sr-only">Share to </span><span>Facebook</span></a></li>
+							<li><a target="shareit" href="https://twitter.com/share?url=https://secure.toronto.ca/council/agenda-item.do?item=2024.GG16.12&amp;text=Agenda Item History 2024.GG16.12&amp;via=cityoftoronto" id="share-link-2"><img src="/council/assets/themes/cot/img/social_twitter.png" id="share-img-2" alt=""><span class="sr-only">Share to </span><span>Twitter</span></a></li>
+							<li><a target="shareit" href="http://www.linkedin.com/shareArticle?url=https://secure.toronto.ca/council/agenda-item.do?item=2024.GG16.12&amp;title=&gt;Agenda Item History 2024.GG16.12" id="share-link-4"><img src="/council/assets/themes/cot/img/social_linkedin.png" id="share-img-5" alt=""><span class="sr-only">Share to </span><span>LinkedIn</span></a></li>
+						</ul>
+					</div>
+				</div>
+				<button type="button" id="btPrint" name="btPrint" class="btn btn-default" onclick="window.print();" title="Print" role="button">
+				Print <i class="fas fa-print" style="margin-left: 3px; opacity: 70%; color: #333;" aria-hidden="true"></i>
+			</button>
+			<input type="button" value="A+" onclick="changeFontSize(2)" title="Increase text size" aria-label="Increase text size" class="increase-text"> <input type="button" class="decrease-text" value="A-" onclick="changeFontSize(-2)" title="Decrease text size" aria-label="Decrease text size">
+			</nav>
+		
+	</div>
+
+				</div>
+				<!--  button bar  -->
+				<div class="row button-bar">
+					<div class=" col-md-8" role="navigation" aria-label="Primary">
+						<button type="button" id="btClose" name="btClose" class="btn btn-primary" onclick="window.top.close();" title="Close" role="button">
+							<i class="fas fa-times" aria-hidden="true"></i> Close
+						</button>
+						
+							<button type="button" id="btEmail" name="btEmail" class="btn btn-primary" onclick="emailItem();" title="E-mail Item" role="button">
+								<i class="far fa-envelope" aria-hidden="true"></i> E-mail <span>Item</span>
+							</button>
+						
+						
+						
+						
+						
+					</div>
+					
+				</div>
+				<!--  content  -->
+				
+					
+						<h2 class="section-title">Tracking Status</h2>
+					
+					<div class="mb-4">
+						<ul>
+							
+								
+									
+										
+						<li><a href=" #" onclick="goToMeeting(2462,24390);">City Council</a> considered this item on October 9 and 10, 2024 and referred this item to an official or another committee or body.  Consult the text of the decision for further information on the referral.</li>
+									
+								
+									
+										
+						<li>This item was considered by the <a href=" #" onclick="goToMeeting(2542,24416);">General Government Committee</a> on September 17, 2024 and adopted without amendment.  It will be considered by City Council on October 9 and 10, 2024.</li>
+									
+								
+							
+							
+							
+							
+							
+						</ul>
+					</div>
+				
+				
+				<div class="col-xs-12 col-md-12">
+					<div class="accordion__controls text-right">
+						<button class="accordin-button-expand btn btn-outline-dark btn-sm mr-2" onclick="expandAccordin(true);" type="button">
+							Expand All<span class="sr-only">&nbsp;2024.GG16.12 </span>
+						</button>
+						<button class="accordin-button-collapse btn btn-outline-dark btn-sm" onclick="expandAccordin(false);" type="button">
+							Collapse All<span class="sr-only">&nbsp;2024.GG16.12</span>
+						</button>
+					</div>
+				</div>
+				<div class="accordion" id="agenda-item-accordion">
+					
+						<div class="card">
+							<div id="heading0" class="card-header blue panel-title p-2">
+								<h2 class="m-0 p-0">
+									<button class="btn btn-link btn-block text-left accordin-heading" type="button" data-toggle="collapse" data-target="#collapse0" aria-controls="#collapse0" aria-expanded="true">
+										City Council consideration on October 9 and 10, 2024<br>
+									</button>
+								</h2>
+							</div>
+							<div id="collapse0" class="collapse show" aria-labelledby="heading0" data-parent="#agenda-item-accordion" style="">
+								<div class="card-body">
+									
+
+
+
+
+
+
+	
+
+
+	
+	
+	
+	
+
+
+
+<!-- AGENDA ITE	M -->
+
+<div class="item-separator"></div>
+	<h3 class="heading">GG16.12 - Award of Doc4553928310 to GFL Environmental Inc., for Curbside Collection Services in District 2 for Solid Waste Management Services</h3>
+
+
+<!-- SUB HEADING -->
+
+<!-- COUNCIL CONSIDER DATE -->
+
+<div class="d-info">
+
+
+	<dl>
+		<dt class="inline">Decision Type:</dt> <dd class="inline">ACTION</dd>
+	</dl>
+
+
+	<dl>
+			<dt class="inline">Status:</dt> <dd class="inline">Referred</dd>
+	</dl>
+
+
+	
+	<dl>
+		<dt class="inline">Wards:</dt> <dd class="inline">4 - Parkdale - High Park, 5 - York South - Weston, 6 - York Centre, 7 - Humber River - Black Creek, 8 - Eglinton - Lawrence, 9 - Davenport, 10 - Spadina - Fort York, 11 - University - Rosedale, 12 - Toronto - St. Paul's, 18 - Willowdale</dd>
+	</dl>
+
+
+<!-- DISCLAIMER -->
+
+<!-- DISCLAIMER -->
+
+	
+
+
+
+
+
+<!-- DECISION COUNCIL* -->
+
+	<h4>City Council Decision</h4>
+	<div class="wep"><p>City Council on October 9 and 10, 2024, referred Item GG16.12 to the November 20, 2024 meeting of the General Government Committee for consideration.</p></div>
+
+<!-- DECISION COMMITTEE* -->
+
+</div>
+<!-- STAFF RECOMMENDATION 1-->
+
+
+	
+
+
+
+
+
+<!-- DECISION ADVICE COUNCIL -->
+
+<!-- DECISION ADVICE COMMITTEE -->
+
+<!-- ANNOTATION -->
+
+
+<!-- PUBLIC NOTICE -->
+
+<!-- STATUTORY -->
+
+<!-- CONFIDENTIAL -->
+
+<!-- URGENT -->
+
+<!-- ORIGIN 1-->
+
+
+	
+
+
+
+
+
+<!-- DECISION COUNCIL* -->
+
+<!-- DECISION COMMITTEE* -->
+
+<!-- STAFF RECOMMENDATION 2-->
+
+
+	
+
+
+
+
+
+<!-- DECISION ADVICE COUNCIL -->
+
+<!-- DECISION ADVICE COMMITTEE -->
+
+<!-- ORIGIN 2-->
+
+<!-- SUMMARY -->
+
+<!-- FINANCIAL IMPACT -->
+
+	
+			<h4>Background Information (Committee)</h4>
+			<div>
+				
+
+
+
+
+	
+	
+	
+	<span class="rpt-text"> 
+	(September 3, 2024)
+       Report from the General Manager, Solid Waste Management Services, and the Chief Procurement Officer on Award of Doc4553928310 to GFL Environmental Inc., for Curbside Collection Services in District 2 for Solid Waste Management Services
+	</span>
+	
+		<br>
+		<a href="https://www.toronto.ca/legdocs/mmis/2024/gg/bgrd/backgroundfile-248375.pdf" class="rpt-text" target="_blank">https://www.toronto.ca/legdocs/mmis/2024/gg/bgrd/backgroundfile-248375.pdf</a>
+	
+	<br>
+
+			</div>
+	
+	
+	
+	
+	
+	
+	
+			<h4>Motions (City Council)</h4>
+			<div>
+				
+				
+
+
+
+
+	
+	<div>
+		<div class="italics">
+			1
+			 -  Motion
+			 to Refer Item
+			
+             moved by
+            
+                Councillor Paul Ainslie 
+            
+            
+			
+			
+				<span class="italics" style="font-weight:bold">(Carried)</span>
+			
+		</div>
+		
+			<div class="wep"><p>That City Council refer Item GG16.12 to the November 20, 2024 meeting of the General Government Committee for consideration.</p></div>
+		
+		
+			
+			
+
+
+	
+	<h4 class="vote-table-header">
+		Vote
+		<span class="normal-text">(Refer Item)</span>
+		<small class="text-muted text-right">Oct-09-2024 5:27 PM</small>
+	</h4>
+		<table class="table table-bordered table-responsive table-hover report-table">
+		<thead>
+			<tr>
+				<th>Result: Carried</th>
+				<th class="normal-text">Majority Required - GG16.12 - Ainslie - motion 1</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><span class="sr-only">Total members that voted </span>Yes: 23</td>
+				<td><span class="sr-only">Members that voted Yes are </span>Paul Ainslie, Brad Bradford, Alejandra Bravo, Shelley Carroll, Lily Cheng, Olivia Chow, Mike Colle, Vincent Crisanti, Paula Fletcher, Parthi Kandavel, Ausma Malik, Nick Mantas, Josh Matlow, Jennifer McKelvie, Chris Moise, Amber Morley, Jamaal Myers, Frances Nunziata (Chair), James Pasternak, Gord Perks, Anthony Perruzza, Dianne Saxe, Michael Thompson</td>
+			</tr>
+			<tr>
+				<td><span class="sr-only">Total members that voted </span>No: 2</td>
+				<td><span class="sr-only">Members that voted No are </span>Jon Burnside, Stephen Holyday</td>
+			</tr>
+			<tr>
+				<td><span class="sr-only">Total members that were </span>Absent: 0</td>
+				<td><span class="sr-only">Members that were absent are </span> </td>
+			</tr>
+		</tbody>
+	</table>
+
+		
+		
+			
+			
+			
+
+
+		
+		
+	</div>
+
+			</div>
+	
+	
+	
+	
+	
+
+								</div>
+							</div>
+						</div>
+					
+						<div class="card">
+							<div id="heading1" class="card-header blue panel-title p-2">
+								<h2 class="m-0 p-0">
+									<button class="btn btn-link btn-block text-left accordin-heading" type="button" data-toggle="collapse" data-target="#collapse1" aria-controls="#collapse1">
+										General Government Committee consideration on September 17, 2024<br>
+									</button>
+								</h2>
+							</div>
+							<div id="collapse1" class="collapse" aria-labelledby="heading1" data-parent="#agenda-item-accordion">
+								<div class="card-body">
+									
+
+
+
+
+
+
+	
+
+
+	
+	
+	
+	
+
+
+
+<!-- AGENDA ITE	M -->
+
+<div class="item-separator"></div>
+	<h3 class="heading">GG16.12 - Award of Doc4553928310 to GFL Environmental Inc., for Curbside Collection Services in District 2 for Solid Waste Management Services</h3>
+
+
+<!-- SUB HEADING -->
+
+<!-- COUNCIL CONSIDER DATE -->
+
+<div class="d-info">
+
+
+	<dl>
+		<dt class="inline">Decision Type:</dt> <dd class="inline">ACTION</dd>
+	</dl>
+
+
+	<dl>
+			<dt class="inline">Status:</dt> <dd class="inline">Adopted</dd>
+	</dl>
+
+
+	
+	<dl>
+		<dt class="inline">Wards:</dt> <dd class="inline">4 - Parkdale - High Park, 5 - York South - Weston, 6 - York Centre, 7 - Humber River - Black Creek, 8 - Eglinton - Lawrence, 9 - Davenport, 10 - Spadina - Fort York, 11 - University - Rosedale, 12 - Toronto - St. Paul's, 18 - Willowdale</dd>
+	</dl>
+
+
+<!-- DISCLAIMER -->
+
+<!-- DISCLAIMER -->
+
+	
+
+
+
+
+
+<!-- DECISION COUNCIL* -->
+
+<!-- DECISION COMMITTEE* -->
+
+</div>
+<!-- STAFF RECOMMENDATION 1-->
+
+
+	
+
+
+
+
+
+<!-- DECISION ADVICE COUNCIL -->
+
+<!-- DECISION ADVICE COMMITTEE -->
+
+<!-- ANNOTATION -->
+
+
+<!-- PUBLIC NOTICE -->
+
+<!-- STATUTORY -->
+
+<!-- CONFIDENTIAL -->
+
+<!-- URGENT -->
+
+<!-- ORIGIN 1-->
+
+
+	
+
+
+
+
+
+<!-- DECISION COUNCIL* -->
+
+<!-- DECISION COMMITTEE* -->
+
+	<h4>Committee Recommendations</h4>
+	<div class="wep"><p>The&nbsp;General Government Committee recommend that:</p>
+<p>&nbsp;</p>
+<p>1. City Council in accordance with Section 195-8.4 of Toronto Municipal Code Chapter 195 (Purchasing By-law), authorize the General Manager, Solid Waste Management Services to award and enter into an agreement with GFL Environmental Inc., being the lowest Supplier meeting specifications for Request for Quotation Doc4553928310 for curbside collection, transportation and off-loading of materials in the District 2 area in the amount of $284,250,333 net of all applicable taxes and charges ($289,253,139 net of Harmonized Sales Tax recoveries) for a period of five (5) years commencing on August 3, 2026 to August 2, 2031 with an option to extend the agreement for an additional two (2) separate one (1) year periods, all in accordance with the terms and conditions as set out in the Request for Quotation and any other terms and conditions satisfactory to the General Manager, Solid Waste Management and in a form satisfactory to the City Solicitor.</p></div>
+
+<!-- STAFF RECOMMENDATION 2-->
+
+
+	
+
+
+
+
+
+<!-- DECISION ADVICE COUNCIL -->
+
+<!-- DECISION ADVICE COMMITTEE -->
+
+<!-- ORIGIN 2-->
+
+	<h4>Origin</h4>
+	<div>(September 3, 2024) Report from the General Manager, Solid Waste Management Services, and the Chief Procurement Officer
+	</div>
+
+<!-- SUMMARY -->
+
+	<h4>Summary</h4>
+	<div class="wep"><p>The purpose of this report is to advise on the results of the Request for Quotation Doc4553928310 for the collection, transportation and off-loading of Garbage, Bulky Items, Organic Materials and Yard Waste from curbside collected Single Family homes, multi-residential locations, Commercial locations, Charities, Institutions and Religious Organizations and Divisions, Agencies and Corporations. The collection, transportation and off-loading of Recyclable Materials from Non-eligible Customer Types, in the Collection Area bounded by Yonge Street to the east, the Humber River to the west, Steeles Avenue to the north and Lake Ontario to the south (District 2) in the amount of $284,250,333 net of all applicable taxes and charges ($289,253,139 net of Harmonized Sales Tax recoveries). This collection contract service award is for a five (5) year period with the option to extend the agreement on the same terms and conditions for an additional two (2) separate one (1) year periods. This report requests the authority to enter into a legal agreement with GFL Environmental Inc., being the lowest supplier meeting specifications.</p></div>
+
+<!-- FINANCIAL IMPACT -->
+
+	
+		<h4>Background Information</h4>
+		<div>
+			
+
+
+
+
+	
+	
+	
+	<span class="rpt-text"> 
+	(September 3, 2024)
+       Report from the General Manager, Solid Waste Management Services, and the Chief Procurement Officer on Award of Doc4553928310 to GFL Environmental Inc., for Curbside Collection Services in District 2 for Solid Waste Management Services
+	</span>
+	
+		<br>
+		<a href="https://www.toronto.ca/legdocs/mmis/2024/gg/bgrd/backgroundfile-248375.pdf" class="rpt-text" target="_blank">https://www.toronto.ca/legdocs/mmis/2024/gg/bgrd/backgroundfile-248375.pdf</a>
+	
+	<br>
+
+		</div>
+	
+	
+	
+	
+		<h4>Motions</h4>
+		<div>
+			
+			
+
+
+
+
+	
+	<div>
+		<div class="italics">
+			
+			 Motion
+			 to Adopt Item
+			
+             moved by
+            
+                Councillor Stephen Holyday 
+            
+            
+			
+			
+				<span class="italics" style="font-weight:bold">(Carried)</span>
+			
+		</div>
+		
+		
+			
+			
+
+
+		
+		
+			
+			
+			
+
+
+		
+		
+	</div>
+
+		</div>
+	
+	
+	
+
+
+								</div>
+							</div>
+						</div>
+					
+				</div>
+			</div>
+		</section>
+		</div></main>
+
+
+<div class="footer2 mt-auto">
+<div class="content-page flex-fill mt-4">
+
+
+Source: Toronto City Clerk at <a href="http://www.toronto.ca/council">www.toronto.ca/council</a>
+
+
+<div id="google_translate_element"><div class="skiptranslate goog-te-gadget" dir="ltr" style=""><div id=":0.targetLanguage"><select class="goog-te-combo" aria-label="Language Translate Widget"><option value="">Select Language</option><option value="ab">Abkhaz</option><option value="ace">Acehnese</option><option value="ach">Acholi</option><option value="aa">Afar</option><option value="af">Afrikaans</option><option value="sq">Albanian</option><option value="alz">Alur</option><option value="am">Amharic</option><option value="ar">Arabic</option><option value="hy">Armenian</option><option value="as">Assamese</option><option value="av">Avar</option><option value="awa">Awadhi</option><option value="ay">Aymara</option><option value="az">Azerbaijani</option><option value="ban">Balinese</option><option value="bal">Baluchi</option><option value="bm">Bambara</option><option value="bci">Baoulé</option><option value="ba">Bashkir</option><option value="eu">Basque</option><option value="btx">Batak Karo</option><option value="bts">Batak Simalungun</option><option value="bbc">Batak Toba</option><option value="be">Belarusian</option><option value="bem">Bemba</option><option value="bn">Bengali</option><option value="bew">Betawi</option><option value="bho">Bhojpuri</option><option value="bik">Bikol</option><option value="bs">Bosnian</option><option value="br">Breton</option><option value="bg">Bulgarian</option><option value="bua">Buryat</option><option value="yue">Cantonese</option><option value="ca">Catalan</option><option value="ceb">Cebuano</option><option value="ch">Chamorro</option><option value="ce">Chechen</option><option value="ny">Chichewa</option><option value="zh-CN">Chinese (Simplified)</option><option value="zh-TW">Chinese (Traditional)</option><option value="chk">Chuukese</option><option value="cv">Chuvash</option><option value="co">Corsican</option><option value="crh">Crimean Tatar (Cyrillic)</option><option value="crh-Latn">Crimean Tatar (Latin)</option><option value="hr">Croatian</option><option value="cs">Czech</option><option value="da">Danish</option><option value="fa-AF">Dari</option><option value="dv">Dhivehi</option><option value="din">Dinka</option><option value="doi">Dogri</option><option value="dov">Dombe</option><option value="nl">Dutch</option><option value="dyu">Dyula</option><option value="dz">Dzongkha</option><option value="eo">Esperanto</option><option value="et">Estonian</option><option value="ee">Ewe</option><option value="fo">Faroese</option><option value="fj">Fijian</option><option value="tl">Filipino</option><option value="fi">Finnish</option><option value="fon">Fon</option><option value="fr">French</option><option value="fr-CA">French (Canada)</option><option value="fy">Frisian</option><option value="fur">Friulian</option><option value="ff">Fulani</option><option value="gaa">Ga</option><option value="gl">Galician</option><option value="ka">Georgian</option><option value="de">German</option><option value="el">Greek</option><option value="gn">Guarani</option><option value="gu">Gujarati</option><option value="ht">Haitian Creole</option><option value="cnh">Hakha Chin</option><option value="ha">Hausa</option><option value="haw">Hawaiian</option><option value="iw">Hebrew</option><option value="hil">Hiligaynon</option><option value="hi">Hindi</option><option value="hmn">Hmong</option><option value="hu">Hungarian</option><option value="hrx">Hunsrik</option><option value="iba">Iban</option><option value="is">Icelandic</option><option value="ig">Igbo</option><option value="ilo">Ilocano</option><option value="id">Indonesian</option><option value="iu-Latn">Inuktut (Latin)</option><option value="iu">Inuktut (Syllabics)</option><option value="ga">Irish</option><option value="it">Italian</option><option value="jam">Jamaican Patois</option><option value="ja">Japanese</option><option value="jw">Javanese</option><option value="kac">Jingpo</option><option value="kl">Kalaallisut</option><option value="kn">Kannada</option><option value="kr">Kanuri</option><option value="pam">Kapampangan</option><option value="kk">Kazakh</option><option value="kha">Khasi</option><option value="km">Khmer</option><option value="cgg">Kiga</option><option value="kg">Kikongo</option><option value="rw">Kinyarwanda</option><option value="ktu">Kituba</option><option value="trp">Kokborok</option><option value="kv">Komi</option><option value="gom">Konkani</option><option value="ko">Korean</option><option value="kri">Krio</option><option value="ku">Kurdish (Kurmanji)</option><option value="ckb">Kurdish (Sorani)</option><option value="ky">Kyrgyz</option><option value="lo">Lao</option><option value="ltg">Latgalian</option><option value="la">Latin</option><option value="lv">Latvian</option><option value="lij">Ligurian</option><option value="li">Limburgish</option><option value="ln">Lingala</option><option value="lt">Lithuanian</option><option value="lmo">Lombard</option><option value="lg">Luganda</option><option value="luo">Luo</option><option value="lb">Luxembourgish</option><option value="mk">Macedonian</option><option value="mad">Madurese</option><option value="mai">Maithili</option><option value="mak">Makassar</option><option value="mg">Malagasy</option><option value="ms">Malay</option><option value="ms-Arab">Malay (Jawi)</option><option value="ml">Malayalam</option><option value="mt">Maltese</option><option value="mam">Mam</option><option value="gv">Manx</option><option value="mi">Maori</option><option value="mr">Marathi</option><option value="mh">Marshallese</option><option value="mwr">Marwadi</option><option value="mfe">Mauritian Creole</option><option value="chm">Meadow Mari</option><option value="mni-Mtei">Meiteilon (Manipuri)</option><option value="min">Minang</option><option value="lus">Mizo</option><option value="mn">Mongolian</option><option value="my">Myanmar (Burmese)</option><option value="nhe">Nahuatl (Eastern Huasteca)</option><option value="ndc-ZW">Ndau</option><option value="nr">Ndebele (South)</option><option value="new">Nepalbhasa (Newari)</option><option value="ne">Nepali</option><option value="bm-Nkoo">NKo</option><option value="no">Norwegian</option><option value="nus">Nuer</option><option value="oc">Occitan</option><option value="or">Odia (Oriya)</option><option value="om">Oromo</option><option value="os">Ossetian</option><option value="pag">Pangasinan</option><option value="pap">Papiamento</option><option value="ps">Pashto</option><option value="fa">Persian</option><option value="pl">Polish</option><option value="pt">Portuguese (Brazil)</option><option value="pt-PT">Portuguese (Portugal)</option><option value="pa">Punjabi (Gurmukhi)</option><option value="pa-Arab">Punjabi (Shahmukhi)</option><option value="qu">Quechua</option><option value="kek">Qʼeqchiʼ</option><option value="rom">Romani</option><option value="ro">Romanian</option><option value="rn">Rundi</option><option value="ru">Russian</option><option value="se">Sami (North)</option><option value="sm">Samoan</option><option value="sg">Sango</option><option value="sa">Sanskrit</option><option value="sat-Latn">Santali (Latin)</option><option value="sat">Santali (Ol Chiki)</option><option value="gd">Scots Gaelic</option><option value="nso">Sepedi</option><option value="sr">Serbian</option><option value="st">Sesotho</option><option value="crs">Seychellois Creole</option><option value="shn">Shan</option><option value="sn">Shona</option><option value="scn">Sicilian</option><option value="szl">Silesian</option><option value="sd">Sindhi</option><option value="si">Sinhala</option><option value="sk">Slovak</option><option value="sl">Slovenian</option><option value="so">Somali</option><option value="es">Spanish</option><option value="su">Sundanese</option><option value="sus">Susu</option><option value="sw">Swahili</option><option value="ss">Swati</option><option value="sv">Swedish</option><option value="ty">Tahitian</option><option value="tg">Tajik</option><option value="ber-Latn">Tamazight</option><option value="ber">Tamazight (Tifinagh)</option><option value="ta">Tamil</option><option value="tt">Tatar</option><option value="te">Telugu</option><option value="tet">Tetum</option><option value="th">Thai</option><option value="bo">Tibetan</option><option value="ti">Tigrinya</option><option value="tiv">Tiv</option><option value="tpi">Tok Pisin</option><option value="to">Tongan</option><option value="lua">Tshiluba</option><option value="ts">Tsonga</option><option value="tn">Tswana</option><option value="tcy">Tulu</option><option value="tum">Tumbuka</option><option value="tr">Turkish</option><option value="tk">Turkmen</option><option value="tyv">Tuvan</option><option value="ak">Twi</option><option value="udm">Udmurt</option><option value="uk">Ukrainian</option><option value="ur">Urdu</option><option value="ug">Uyghur</option><option value="uz">Uzbek</option><option value="ve">Venda</option><option value="vec">Venetian</option><option value="vi">Vietnamese</option><option value="war">Waray</option><option value="cy">Welsh</option><option value="wo">Wolof</option><option value="xh">Xhosa</option><option value="sah">Yakut</option><option value="yi">Yiddish</option><option value="yo">Yoruba</option><option value="yua">Yucatec Maya</option><option value="zap">Zapotec</option><option value="zu">Zulu</option></select></div>Powered by <span style="white-space:nowrap"><a class="VIpgJd-ZVi9od-l4eHX-hSRGPd" href="https://translate.google.com" target="_blank"><img src="https://www.gstatic.com/images/branding/googlelogo/1x/googlelogo_color_42x16dp.png" width="37px" height="14px" style="padding-right: 3px" alt="Google Translate">Translate</a></span></div></div>
+<script type="text/javascript">
+	function googleTranslateElementInit() {
+		new google.translate.TranslateElement({
+			pageLanguage : 'en'
+		}, 'google_translate_element');
+	}
+</script>
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+
+
+</div>
+
+
+	
+<script type="text/javascript" src="https://www.toronto.ca/scripts/webtrends-infinity.load.js"></script>
+	
+	
+	
+
+
+</div>
+<footer class="footer" role="contentinfo">
+<div class="container-fluid">
+<a href="https://www.toronto.ca/home/copyright-information/">
+© City of Toronto 1998 - 2026
+</a>
+</div>
+</footer><div id="goog-gt-tt" class="VIpgJd-yAWNEb-L7lbkb skiptranslate" style="display: none; border-radius: 12px; margin: 0 0 0 -23px; padding: 0; font-family: 'Google Sans', Arial, sans-serif;" data-id=""><div id="goog-gt-vt" class="VIpgJd-yAWNEb-hvhgNd"><div class="VIpgJd-yAWNEb-hvhgNd-Ud7fr"><img src="https://fonts.gstatic.com/s/i/productlogos/translate/v14/24px.svg" width="24" height="24" alt=""><div class=" VIpgJd-yAWNEb-hvhgNd-IuizWc-i3jM8c " dir="ltr">Original text</div></div><div class="VIpgJd-yAWNEb-hvhgNd-k77Iif"><div id="goog-gt-original-text" class="VIpgJd-yAWNEb-nVMfcd-fmcmS VIpgJd-yAWNEb-hvhgNd-axAV1"></div></div><div class="VIpgJd-yAWNEb-hvhgNd-N7Eqid ltr"><div class="VIpgJd-yAWNEb-hvhgNd-N7Eqid-B7I4Od ltr" dir="ltr"><div class="VIpgJd-yAWNEb-hvhgNd-UTujCb">Rate this translation</div><div class="VIpgJd-yAWNEb-hvhgNd-eO9mKe">Your feedback will be used to help improve Google Translate</div></div><div class="VIpgJd-yAWNEb-hvhgNd-xgov5 ltr"><button id="goog-gt-thumbUpButton" type="button" class="VIpgJd-yAWNEb-hvhgNd-bgm6sf" title="Good translation" aria-label="Good translation" aria-pressed="false"><span id="goog-gt-thumbUpIcon"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M21 7h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 0S7.08 6.85 7 7H2v13h16c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73V9c0-1.1-.9-2-2-2zM7 18H4V9h3v9zm14-7l-3 7H9V8l4.34-4.34L12 9h9v2z"></path></svg></span><span id="goog-gt-thumbUpIconFilled"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M21 7h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 0S7.08 6.85 7 7v13h11c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73V9c0-1.1-.9-2-2-2zM5 7H1v13h4V7z"></path></svg></span></button><button id="goog-gt-thumbDownButton" type="button" class="VIpgJd-yAWNEb-hvhgNd-bgm6sf" title="Poor translation" aria-label="Poor translation" aria-pressed="false"><span id="goog-gt-thumbDownIcon"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M3 17h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 24s7.09-6.85 7.17-7h5V4H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2zM17 6h3v9h-3V6zM3 13l3-7h9v10l-4.34 4.34L12 15H3v-2z"></path></svg></span><span id="goog-gt-thumbDownIconFilled"><svg width="24" height="24" viewBox="0 0 24 24" focusable="false" class="VIpgJd-yAWNEb-hvhgNd-THI6Vb NMm5M"><path d="M3 17h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 24s7.09-6.85 7.17-7V4H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2zm16 0h4V4h-4v13z"></path></svg></span></button></div></div><div id="goog-gt-votingHiddenPane" class="VIpgJd-yAWNEb-hvhgNd-aXYTce"><form id="goog-gt-votingForm" action="//translate.googleapis.com/translate_voting?client=te" method="post" target="votingFrame" class="VIpgJd-yAWNEb-hvhgNd-aXYTce"><input type="text" name="sl" id="goog-gt-votingInputSrcLang"><input type="text" name="tl" id="goog-gt-votingInputTrgLang"><input type="text" name="query" id="goog-gt-votingInputSrcText"><input type="text" name="gtrans" id="goog-gt-votingInputTrgText"><input type="text" name="vote" id="goog-gt-votingInputVote"></form><iframe name="votingFrame" frameborder="0"></iframe></div></div></div>
+
+	
+  
+
+<div class="VIpgJd-ZVi9od-aZ2wEe-wOHMyf"><div class="VIpgJd-ZVi9od-aZ2wEe-OiiCO"><svg xmlns="http://www.w3.org/2000/svg" class="VIpgJd-ZVi9od-aZ2wEe" width="96px" height="96px" viewBox="0 0 66 66"><circle class="VIpgJd-ZVi9od-aZ2wEe-Jt5cK" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle></svg></div></div></body></html>

--- a/scrapers/tests/fixtures/committee/voting_record_sample.csv
+++ b/scrapers/tests/fixtures/committee/voting_record_sample.csv
@@ -1,0 +1,6 @@
+_id,Term,First Name,Last Name,Committee,Date/Time,Agenda Item #,Agenda Item Title,Motion Type,Vote,Result,Vote Description
+1,2022-2026,A,B,City Council,2024-05-01 10:00 AM,2024.GG16.12,"Award of Doc4553928310 to GFL Environmental Inc., for District 2 Waste Collection",Adopt,Yes,Carried,x
+2,2022-2026,A,B,City Council,2024-05-01 10:00 AM,2024.GG16.12,"Award of Doc4553928310 to GFL Environmental Inc., for District 2 Waste Collection",Adopt,Yes,Carried,x
+3,2022-2026,C,D,City Council,2024-06-01 10:00 AM,2024.GG14.8,Process for Award of Negotiable Request for Proposal Document Number 4053424337 for Ferry Vessels,Adopt,Yes,Carried,x
+4,2022-2026,C,D,General Government Committee,2023-03-01 10:00 AM,2023.GG2.11,Award of Ariba Document Number 3448368603 to CH2M Hill Canada for Basement Flooding,Adopt,Yes,Carried,x
+5,2022-2026,C,D,City Council,2024-06-01 10:00 AM,2024.MM1.1,Election of the Speaker,Adopt,Yes,Carried,x

--- a/scrapers/tests/test_committee_awards.py
+++ b/scrapers/tests/test_committee_awards.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from toronto_bids.sources.committee_awards import award_doc_number, award_items_from_voting_record
+from toronto_bids.sources.committee_awards import (
+    award_doc_number,
+    award_items_from_voting_record,
+    parse_committee_bids,
+)
 
 FIX = Path(__file__).parent / "fixtures" / "committee"
 
@@ -18,3 +22,24 @@ def test_award_items_from_voting_record_dedups_and_skips_non_awards():
     assert set(by_doc) == {"4553928310", "4053424337", "3448368603"}   # non-award row dropped, dupes merged
     assert by_doc["4553928310"]["reference"] == "2024.GG16.12"
     assert by_doc["4553928310"]["committee"] == "City Council"
+
+
+def test_parse_rfq_summary_of_bids_received():
+    bids = parse_committee_bids((FIX / "district2_rfq_doc4553928310.txt").read_text())
+    names = {b for b, _ in bids}
+    assert "GFL Environmental Inc." in names
+    assert any("Halton Recycling" in b for b, _ in bids)      # the losing bidder captured
+    assert len(bids) == 2
+
+
+def test_parse_rft_opened_the_following_bids():
+    bids = parse_committee_bids((FIX / "ashbridges_tender_2010.txt").read_text())
+    names = {b for b, _ in bids}
+    assert any("Kenaidan" in b for b in names)
+    assert any("Torbear" in b for b in names)
+    assert any("Alberici" in b for b in names)
+    assert len(bids) == 3
+
+
+def test_parse_refuses_a_report_with_no_bid_table():
+    assert parse_committee_bids("... the only supplier able to provide ... emergency ...") == []

--- a/scrapers/tests/test_committee_awards.py
+++ b/scrapers/tests/test_committee_awards.py
@@ -4,6 +4,7 @@ from toronto_bids.sources.committee_awards import (
     award_doc_number,
     award_items_from_voting_record,
     parse_committee_bids,
+    report_url_from_item_html,
     store_committee_bids,
 )
 
@@ -44,6 +45,24 @@ def test_parse_rft_opened_the_following_bids():
 
 def test_parse_refuses_a_report_with_no_bid_table():
     assert parse_committee_bids("... the only supplier able to provide ... emergency ...") == []
+
+
+def test_report_url_from_item_html_finds_the_award_report():
+    html = (FIX / "item_2024_GG16_12.html").read_text()
+    url = report_url_from_item_html(html, "4553928310")
+    assert url == "https://www.toronto.ca/legdocs/mmis/2024/gg/bgrd/backgroundfile-248375.pdf"
+
+
+def test_report_url_from_item_html_returns_none_without_a_matching_link():
+    assert report_url_from_item_html("<html><body>No reports here.</body></html>",
+                                     "4553928310") is None
+    # A backgroundfile link that names a different document shouldn't be mistaken for a
+    # match when there's more than one candidate on the page.
+    html = ('<div><span>Award of Doc1111111111</span>'
+            '<a href="https://www.toronto.ca/legdocs/mmis/2024/gg/bgrd/backgroundfile-1.pdf">x</a></div>'
+            '<div><span>Award of Doc2222222222</span>'
+            '<a href="https://www.toronto.ca/legdocs/mmis/2024/gg/bgrd/backgroundfile-2.pdf">x</a></div>')
+    assert report_url_from_item_html(html, "4553928310") is None
 
 
 def test_store_committee_bids_attaches_by_document_number(conn):

--- a/scrapers/tests/test_committee_awards.py
+++ b/scrapers/tests/test_committee_awards.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from toronto_bids.sources.committee_awards import award_doc_number, award_items_from_voting_record
+
+FIX = Path(__file__).parent / "fixtures" / "committee"
+
+
+def test_award_doc_number_reads_the_title_vocabulary():
+    assert award_doc_number("Award of Doc4553928310 to GFL") == "4553928310"
+    assert award_doc_number("Process for Award of Negotiable RFP Document Number 4053424337 for x") == "4053424337"
+    assert award_doc_number("Award of Ariba Document Number 3448368603 to CH2M") == "3448368603"
+    assert award_doc_number("Election of the Speaker") is None
+
+
+def test_award_items_from_voting_record_dedups_and_skips_non_awards():
+    items = award_items_from_voting_record((FIX / "voting_record_sample.csv").read_text())
+    by_doc = {i["document_number"]: i for i in items}
+    assert set(by_doc) == {"4553928310", "4053424337", "3448368603"}   # non-award row dropped, dupes merged
+    assert by_doc["4553928310"]["reference"] == "2024.GG16.12"
+    assert by_doc["4553928310"]["committee"] == "City Council"

--- a/scrapers/tests/test_committee_awards.py
+++ b/scrapers/tests/test_committee_awards.py
@@ -4,6 +4,7 @@ from toronto_bids.sources.committee_awards import (
     award_doc_number,
     award_items_from_voting_record,
     parse_committee_bids,
+    store_committee_bids,
 )
 
 FIX = Path(__file__).parent / "fixtures" / "committee"
@@ -43,3 +44,18 @@ def test_parse_rft_opened_the_following_bids():
 
 def test_parse_refuses_a_report_with_no_bid_table():
     assert parse_committee_bids("... the only supplier able to provide ... emergency ...") == []
+
+
+def test_store_committee_bids_attaches_by_document_number(conn):
+    from toronto_bids.store import db
+    from toronto_bids.models import Solicitation, BackgroundPdf
+    db.upsert_row(conn, Solicitation(document_number="4553928310", source="odata"), overwrite=True)
+    db.upsert_row(conn, BackgroundPdf(url="https://x/backgroundfile-1.pdf", document_number="4553928310",
+                  kind="committee_award", text=(FIX / "district2_rfq_doc4553928310.txt").read_text()),
+                  overwrite=True)
+    conn.commit()
+    n = store_committee_bids(conn)
+    assert n == 2
+    rows = conn.execute("SELECT bidder_name_raw, document_number FROM bid WHERE source='committee_award'").fetchall()
+    assert {r[0] for r in rows} >= {"GFL Environmental Inc."}
+    assert all(r[1] == "4553928310" for r in rows)

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -112,6 +112,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_ag.add_argument("--record", action="store_true",
                       help="With --portal: also dump each raw JSON record under "
                            "<DATA_DIR>/agencies/portal_recordings/ to seed parser fixtures.")
+
+    p_committee = sub.add_parser(
+        "enrich-committee-awards",
+        help="Archive the bid record for committee/Council awards since the Bid Award "
+             "Panel's abolition on 2025-10-01 (#164): voting-record award items -> staff "
+             "report -> bid table. Offline by default -- parses reports already on disk.")
+    p_committee.add_argument(
+        "--scrape", action="store_true",
+        help="Refresh the voting-record index, browser-discover each item's report URL "
+             "(headed Chromium, council extra), and download the reports first")
+    p_committee.add_argument(
+        "--virtual-display", action="store_true",
+        help="Run --scrape's headed browser under Xvfb (headless servers; needs Xvfb "
+             "installed)")
     return parser
 
 
@@ -727,6 +741,83 @@ def _cmd_enrich_agencies(args) -> int:
     return 1 if failures else 0
 
 
+def _cmd_enrich_committee_awards(args) -> int:
+    """Archive the bid record for committee/Council awards since the Bid Award Panel's
+    abolition on 2025-10-01 (#164): voting-record award items -> item page's report ->
+    bid table. Offline by default -- parses reports already on disk, exactly as
+    enrich-titles/enrich-awards do.
+    """
+    from toronto_bids.linking.supplier import build_supplier_dimension
+    from toronto_bids.sources.committee_awards import (
+        award_items_from_voting_record, discover_report_urls, download_committee_reports,
+        fetch_voting_records, store_committee_bids)
+
+    conn = _open_db()
+    out = lambda m: print(m, flush=True)
+    failures: list[tuple[str, str]] = []
+    try:
+        if args.scrape:
+            try:
+                http = HttpClient()
+                try:
+                    csvs = fetch_voting_records(http)
+                    print(f"  voting records fetched     : {len(csvs)}")
+                    items, seen = [], set()
+                    for text in csvs:
+                        for item in award_items_from_voting_record(text):
+                            if item["document_number"] not in seen:
+                                seen.add(item["document_number"])
+                                items.append(item)
+                    print(f"  award items found          : {len(items)}")
+
+                    # Only chase items that name a spine solicitation with no captured
+                    # bid yet -- an item whose bids are already stored (or that doesn't
+                    # match any award we track) is not worth a browser round-trip.
+                    have_bids = {r[0] for r in conn.execute(
+                        "SELECT DISTINCT document_number FROM bid "
+                        "WHERE document_number IS NOT NULL")}
+                    spine = {r[0] for r in conn.execute(
+                        "SELECT document_number FROM solicitation")}
+                    items = [i for i in items if i["document_number"] in spine
+                            and i["document_number"] not in have_bids]
+                    print(f"  items needing bids          : {len(items)}")
+
+                    url_map = discover_report_urls(
+                        items, config.COMMITTEE_ITEMS_DIR,
+                        virtual_display=args.virtual_display, log=out)
+                    print(f"  report urls discovered     : {len(url_map)}")
+
+                    by_doc = {i["reference"]: i["document_number"] for i in items}
+                    url_to_doc = {url: by_doc[ref] for ref, url in url_map.items()
+                                 if ref in by_doc}
+                    print(f"  reports downloaded         : "
+                          f"{download_committee_reports(conn, http, url_to_doc, log=out)}")
+                finally:
+                    http.close()
+            except Exception as exc:
+                failures.append(("scrape", str(exc)))
+
+        try:
+            before = conn.execute(
+                "SELECT COUNT(*) FROM bid WHERE source='committee_award'").fetchone()[0]
+            print(f"  bids from committee reports : {store_committee_bids(conn, log=out)}")
+            after = conn.execute(
+                "SELECT COUNT(*) FROM bid WHERE source='committee_award'").fetchone()[0]
+            print(f"\nCommittee award bids: {before} -> {after} ({after - before} new)")
+        except Exception as exc:
+            failures.append(("store_committee_bids", str(exc)))
+
+        try:
+            print(f"  suppliers                   : {build_supplier_dimension(conn)}")
+        except Exception as exc:
+            failures.append(("supplier_linking", str(exc)))
+    finally:
+        conn.close()
+    for name, error in failures:
+        print(f"FAILED  {name}: {error}", file=sys.stderr)
+    return 1 if failures else 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -752,6 +843,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_enrich_ariba_attachments(args)
     if args.command == "enrich-agencies":
         return _cmd_enrich_agencies(args)
+    if args.command == "enrich-committee-awards":
+        return _cmd_enrich_committee_awards(args)
     parser.print_help()
     return 0
 

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -757,6 +757,7 @@ def _cmd_enrich_committee_awards(args) -> int:
     failures: list[tuple[str, str]] = []
     try:
         if args.scrape:
+            http = None
             try:
                 http = HttpClient()
                 try:
@@ -793,7 +794,8 @@ def _cmd_enrich_committee_awards(args) -> int:
                     print(f"  reports downloaded         : "
                           f"{download_committee_reports(conn, http, url_to_doc, log=out)}")
                 finally:
-                    http.close()
+                    if http is not None:
+                        http.close()
             except Exception as exc:
                 failures.append(("scrape", str(exc)))
 

--- a/scrapers/toronto_bids/config.py
+++ b/scrapers/toronto_bids/config.py
@@ -68,6 +68,10 @@ AWARD_SUMMARY_DIR = DATA_DIR / "documents" / "award_summary"
 # pages carry the supplier/amount/Call Number that the pre-Ariba years need (#77).
 COUNCIL_AGENDAS_DIR = DATA_DIR / "council" / "agendas"
 
+# TMMIS agenda-item pages for committee awards after the Bid Award Panel's abolition
+# (#164) — kept apart from COUNCIL_AGENDAS_DIR, which holds the (retired) BA/BD series.
+COMMITTEE_ITEMS_DIR = DATA_DIR / "council" / "committee_items"
+
 # Archived Ariba posting pages from the legacy rescue; their <title> is the real
 # solicitation title (#65).
 LEGACY_ARIBA_DIR = DATA_DIR / "legacy" / "azure" / "ariba_data"

--- a/scrapers/toronto_bids/sources/committee_awards.py
+++ b/scrapers/toronto_bids/sources/committee_awards.py
@@ -3,8 +3,20 @@ import io
 import re
 
 from toronto_bids import config
+from toronto_bids.amount import parse_bid_price
 
 _DOC = re.compile(r"(?:Ariba\s+)?Doc(?:ument)?(?:\s*Number)?\s*[:#]?\s*(\d{10})", re.IGNORECASE)
+
+# Both report formats lay a bid row out as "<name>   <$price>" on one pdftotext -layout
+# line, columns separated by the layout's wide gap (2+ spaces) -- never a single space,
+# which would also fire on a name that merely contains a numeral. The price is kept
+# verbatim (footnote marker and all); only the name's trailing '*' is stripped.
+_BID_ROW = re.compile(r"^\s*(?P<name>\S.*?)\s{2,}(?P<price>\$[\d,]+(?:\.\d+)?\*?)\s*$")
+
+# Either table anchor a committee award report may carry. Refuse (return []) when neither
+# is present -- an emergency/sole-source/confidential-attachment report has no bid table
+# to invent one from (#130 discipline).
+_BID_TABLE_ANCHORS = ("Summary of Bids Received", "opened the following bids")
 
 
 def award_doc_number(title):
@@ -28,6 +40,40 @@ def award_items_from_voting_record(csv_text):
         out.setdefault(doc, {"document_number": doc, "reference": row.get("Agenda Item #"),
                              "committee": row.get("Committee"), "title": title})
     return list(out.values())
+
+
+def parse_committee_bids(text):
+    """The bidder/price table from a committee award staff report, as [(bidder, bid_price)].
+
+    Handles both report shapes: the RFQ/RFP 'Summary of Bids Received' table and the RFT
+    'opened the following bids' table. Both lay each bid out as one 'name ... $price' line
+    once pdftotext -layout has run; the header/prose lines around the table carry no '$' and
+    are skipped, never mistaken for a row. Returns [] when neither anchor is present --
+    refuse rather than invent a table (#130).
+    """
+    anchor = None
+    for candidate in _BID_TABLE_ANCHORS:
+        idx = text.find(candidate)
+        if idx != -1 and (anchor is None or idx < anchor):
+            anchor = idx
+    if anchor is None:
+        return []
+
+    bids = []
+    started = False
+    for line in text[anchor:].splitlines():
+        if not line.strip():
+            continue
+        m = _BID_ROW.match(line)
+        price = m.group("price") if m else None
+        if m is None or parse_bid_price(price) is None:
+            if started:
+                break  # first non-matching line after the table started: table is over
+            continue  # still walking through the header/caption lines before row 1
+        name = m.group("name").rstrip("*").strip()
+        bids.append((name, price))
+        started = True
+    return bids
 
 
 def fetch_voting_records(http):

--- a/scrapers/toronto_bids/sources/committee_awards.py
+++ b/scrapers/toronto_bids/sources/committee_awards.py
@@ -1,9 +1,15 @@
 import csv
+import hashlib
 import io
 import re
+import subprocess
 
 from toronto_bids import config
 from toronto_bids.amount import parse_bid_price
+from toronto_bids.models import BackgroundPdf, Bid
+from toronto_bids.store import db
+
+COMMITTEE_REPORTS_DIR = config.DATA_DIR / "documents" / "committee_award"
 
 _DOC = re.compile(r"(?:Ariba\s+)?Doc(?:ument)?(?:\s*Number)?\s*[:#]?\s*(\d{10})", re.IGNORECASE)
 
@@ -85,3 +91,74 @@ def fetch_voting_records(http):
         if r.get("format", "").upper() == "CSV" and r.get("name", "").startswith("member-voting-record-2"):
             csvs.append(http.get_text(r["url"]))
     return csvs
+
+
+def _pdftotext(path) -> str | None:
+    try:
+        out = subprocess.run(["pdftotext", "-layout", str(path), "-"],
+                             capture_output=True, timeout=120)
+        return out.stdout.decode("utf-8", errors="replace") or None
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def download_committee_reports(conn, http, url_map: dict, log=lambda _m: None) -> int:
+    """Fetch each committee award staff report PDF (plain HTTP) and store it.
+
+    `url_map` is {url: document_number} — the award items already discovered from a voting
+    record (award_items_from_voting_record) name both. Mirrors trca_board's resilient fetch
+    loop (#135): a single dead URL is logged and skipped, never aborting the batch; a body
+    that isn't actually a PDF (an HTML error page) is left unqueued rather than stored as
+    garbage. Queues/re-fetches only what isn't already held (sha256 IS NULL), keyed on url.
+    """
+    COMMITTEE_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    have = {r["url"] for r in conn.execute(
+        "SELECT url FROM background_pdf WHERE kind='committee_award' AND sha256 IS NOT NULL")}
+    n = 0
+    for url, document_number in url_map.items():
+        if url in have:
+            continue
+        try:
+            blob = http.get_bytes(url)
+        except Exception as exc:            # noqa: BLE001 — one dead URL must never abort the batch
+            log(f"  committee skip {url}: {exc}")
+            continue
+        if not blob.startswith(b"%PDF"):
+            continue                        # HTML error page, not a report
+        sha = hashlib.sha256(blob).hexdigest()
+        path = COMMITTEE_REPORTS_DIR / f"{sha}.pdf"
+        path.write_bytes(blob)
+        db.upsert_row(conn, BackgroundPdf(
+            url=url, document_number=document_number, kind="committee_award",
+            local_path=str(path), sha256=sha, text=_pdftotext(path),
+        ), overwrite=True)
+        conn.commit()
+        n += 1
+        log(f"  committee report {n}: {url}")
+    return n
+
+
+def store_committee_bids(conn, log=lambda _m: None) -> int:
+    """Parse every held committee award report's text and attach its bids by document_number.
+
+    Mirrors #114's award-summary bid attachment: reference=None, document_number=<report's>.
+    A report whose parse returns [] (no bid table -- refused, not invented) stores nothing:
+    an honest zero, not a missing row. Idempotent via db.upsert_row on bid_key.
+    """
+    n = 0
+    for row in conn.execute(
+            "SELECT document_number, text FROM background_pdf "
+            "WHERE kind='committee_award' AND text IS NOT NULL AND document_number IS NOT NULL"):
+        bids = parse_committee_bids(row["text"])
+        for bidder_name_raw, bid_price in bids:
+            db.upsert_row(conn, Bid(
+                bidder_name_raw=bidder_name_raw,
+                reference=None,
+                document_number=row["document_number"],
+                bid_price=bid_price,
+                source="committee_award",
+            ), overwrite=True)
+            n += 1
+        conn.commit()
+        log(f"  committee bids: {len(bids)} from doc {row['document_number']}")
+    return n

--- a/scrapers/toronto_bids/sources/committee_awards.py
+++ b/scrapers/toronto_bids/sources/committee_awards.py
@@ -1,0 +1,41 @@
+import csv
+import io
+import re
+
+from toronto_bids import config
+
+_DOC = re.compile(r"(?:Ariba\s+)?Doc(?:ument)?(?:\s*Number)?\s*[:#]?\s*(\d{10})", re.IGNORECASE)
+
+
+def award_doc_number(title):
+    """The 10-digit document number an award item names, else None. Match the number, not the
+    vocabulary -- titles say 'Doc<n>', 'Document Number <n>', 'Ariba Document Number <n>'."""
+    if not title:
+        return None
+    m = _DOC.search(title)
+    return m.group(1) if m else None
+
+
+def award_items_from_voting_record(csv_text):
+    """Distinct award items carrying a document number, from one voting-record CSV.
+    Returns [{document_number, reference, committee, title}]. Dedups the per-member vote rows."""
+    out = {}
+    for row in csv.DictReader(io.StringIO(csv_text)):
+        title = row.get("Agenda Item Title") or ""
+        doc = award_doc_number(title)
+        if not doc:
+            continue
+        out.setdefault(doc, {"document_number": doc, "reference": row.get("Agenda Item #"),
+                             "committee": row.get("Committee"), "title": title})
+    return list(out.values())
+
+
+def fetch_voting_records(http):
+    """The per-term voting-record CSV bodies from CKAN (UUIDs resolved at runtime, never hardcoded)."""
+    data = http.get_json(config.CKAN_BASE + "package_show",
+                          params={"id": "members-of-toronto-city-council-voting-record"})
+    csvs = []
+    for r in data["result"]["resources"]:
+        if r.get("format", "").upper() == "CSV" and r.get("name", "").startswith("member-voting-record-2"):
+            csvs.append(http.get_text(r["url"]))
+    return csvs

--- a/scrapers/toronto_bids/sources/committee_awards.py
+++ b/scrapers/toronto_bids/sources/committee_awards.py
@@ -1,8 +1,11 @@
 import csv
 import hashlib
 import io
+import pathlib
 import re
 import subprocess
+
+from lxml import html as _html
 
 from toronto_bids import config
 from toronto_bids.amount import parse_bid_price
@@ -91,6 +94,94 @@ def fetch_voting_records(http):
         if r.get("format", "").upper() == "CSV" and r.get("name", "").startswith("member-voting-record-2"):
             csvs.append(http.get_text(r["url"]))
     return csvs
+
+
+def report_url_from_item_html(html: str, document_number: str) -> str | None:
+    """The award report PDF URL from a TMMIS agenda-item page (Step 1 of #164 discovery, PURE).
+
+    The report link sits in the same block as the report's own caption text, which names
+    the award via "... on Award of Doc<n> to <supplier> ...". Preferred: the backgroundfile
+    link whose nearest block ancestor's text contains the document number. Falls back to the
+    page's sole backgroundfile link when there's exactly one candidate and none matched by
+    caption (mirrors bid_award_panel's tolerance for pages that lay the caption out
+    differently) -- but refuses to guess among several unmatched candidates.
+    """
+    root = _html.fromstring(html)
+    seen = set()
+    candidates = []
+    for a in root.xpath("//a[contains(@href, 'backgroundfile')]"):
+        url = a.get("href")
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        candidates.append((a, url))
+    if not candidates:
+        return None
+    for a, url in candidates:
+        ancestor = a.getparent()
+        text = ancestor.text_content() if ancestor is not None else ""
+        if document_number in text:
+            return url
+    if len(candidates) == 1:
+        return candidates[0][1]
+    return None
+
+
+def discover_report_urls(items, cache_dir, *, virtual_display: bool = False,
+                         log=lambda _m: None) -> dict:
+    """Browser-discover each item's award report URL (Step 2 of #164, browser -- no unit test).
+
+    One headed Chromium for the whole run, exactly bid_award_panel.agenda_fetcher's pattern:
+    launching per item would be ruinous across hundreds of committee items. An item already
+    cached under `cache_dir` is not refetched. Returns {reference: url} for the hits only --
+    an item whose report link couldn't be resolved is simply absent, not an error.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise RuntimeError(
+            "Committee award discovery needs the optional 'council' extra. "
+            "Install it with: uv sync --extra council && uv run playwright install chromium"
+        ) from exc
+
+    cache_dir = pathlib.Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    display = None
+    if virtual_display:
+        from pyvirtualdisplay import Display
+        display = Display(visible=False, size=(1440, 900))
+        display.start()
+
+    out = {}
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(
+                headless=False, args=["--disable-blink-features=AutomationControlled"])
+            try:
+                page = browser.new_context().new_page()
+                for item in items:
+                    reference = item["reference"]
+                    path = cache_dir / f"{reference}.html"
+                    if path.exists():
+                        page_html = path.read_text()
+                    else:
+                        page.goto(f"{config.COUNCIL_ITEM_URL}?item={reference}",
+                                 wait_until="domcontentloaded", timeout=45000)
+                        page.wait_for_timeout(700)
+                        page_html = page.content()
+                        path.write_text(page_html)
+                    url = report_url_from_item_html(page_html, item["document_number"])
+                    if url:
+                        out[reference] = url
+                    log(f"  committee item {reference}: "
+                        f"{'report found' if url else 'no report link'}")
+            finally:
+                browser.close()
+    finally:
+        if display is not None:
+            display.stop()
+    return out
 
 
 def _pdftotext(path) -> str | None:

--- a/scrapers/toronto_bids/sources/committee_awards.py
+++ b/scrapers/toronto_bids/sources/committee_awards.py
@@ -163,15 +163,19 @@ def discover_report_urls(items, cache_dir, *, virtual_display: bool = False,
                 for item in items:
                     reference = item["reference"]
                     path = cache_dir / f"{reference}.html"
-                    if path.exists():
-                        page_html = path.read_text()
-                    else:
-                        page.goto(f"{config.COUNCIL_ITEM_URL}?item={reference}",
-                                 wait_until="domcontentloaded", timeout=45000)
-                        page.wait_for_timeout(700)
-                        page_html = page.content()
-                        path.write_text(page_html)
-                    url = report_url_from_item_html(page_html, item["document_number"])
+                    try:
+                        if path.exists():
+                            page_html = path.read_text()
+                        else:
+                            page.goto(f"{config.COUNCIL_ITEM_URL}?item={reference}",
+                                     wait_until="domcontentloaded", timeout=45000)
+                            page.wait_for_timeout(700)
+                            page_html = page.content()
+                            path.write_text(page_html)
+                        url = report_url_from_item_html(page_html, item["document_number"])
+                    except Exception as exc:    # noqa: BLE001 — one dead item must never abort the batch
+                        log(f"  committee item {reference}: skipped ({exc})")
+                        continue
                     if url:
                         out[reference] = url
                     log(f"  committee item {reference}: "


### PR DESCRIPTION
Implements the committee/Council award bid route from #164, and — more usefully — **measures what it can actually reach.**

Merging this as a **small permanent capability**, not as a claim to have solved #164. The headline on that issue ("99 awards, $3.11B") is not what this recovers, and the gap is structural rather than a parser weakness. The measurement is the main deliverable here.

## What it does

`tb enrich-committee-awards` — voting-record CSV → agenda-item page (headed Chromium) → staff-report PDF → bid table.

- **No new tables.** Stores into `bid` / `background_pdf`, relying on `bid_key` COALESCEing both identifiers so a committee bid keys exactly like a #114 award-summary bid (`reference` NULL, `document_number` set). Only a `COMMITTEE_ITEMS_DIR` config constant is added.
- **Offline by default**, `--scrape` for the browser pass — the `enrich-titles` / `enrich-awards` idiom.
- **Self-bounding**: only chases items that name a spine solicitation *and* have no bids yet, so re-runs shrink to nothing.
- One headed Chromium for the whole run with per-item HTML caching and per-item exception isolation (`bid_award_panel.agenda_fetcher`'s pattern) — a dead item never aborts the batch.
- Report bytes land content-addressed at `documents/committee_award/<sha256>.pdf`; the download queue keys on `sha256`, never `text` (#96's lesson), so image-only PDFs are not re-fetched forever.

## First live run

```
award items found          : 11
items needing bids         : 8
report urls discovered     : 8      ← 8/8
reports downloaded         : 8      ← 8/8
bids from committee reports: 3      ← from 2 of 8 reports
```

Every stage works. The yield is 3 bids.

## The ceiling — measured, and the reason to stop here

**The join key is the ceiling, not the parser.** Discovery can only chase an item whose *Agenda Item Title* carries a 10-digit document number:

| | count |
|---|---|
| distinct agenda items in the voting records | 9,444 |
| award/contract-like items | 109 |
| **naming a 10-digit doc number** | **11** |

Against the #164 target set:

| | |
|---|---|
| odata awards with no captured bids | 4,942 |
| of those, ≥ $5M | 431 (**$25.53B**) |
| **reachable via voting records** | **4** |

Roughly **1%**. Three compounding reasons, none of which a better parser addresses:

1. **The 98 award-like items without a doc number are mostly not losses.** The sample is dominated by `Amendment to Blanket Contract` and `Non-Competitive Contract` — no bids by nature. Widening the title regex buys far less than 98 suggests.
2. **RFTs/RFQs tabulate bids; RFPs narrate them.** That is why 6 of 8 reports yielded nothing. `_BID_TABLE_ANCHORS` refuses unless `Summary of Bids Received` or `opened the following bids` is present — the #130 discipline working correctly, not a gap. One RFP report reads *"The City received one submission ... from: Carla Construction and Maintenance Ltd."* in prose and names no losing proponents at all.
3. **Most competitive awards never reach committee**, being staff-delegated or panel-handled — the same mechanism #83 measured on titles. Committee is the exception tier, so this route can only ever be a thin slice.

The one cheap extension left unbuilt is that prose pattern (*"received N submission(s) ... from: NAME"*), which would pick up at least one of the 8.

## Verification

- **630 tests pass** (622 on main + 8 committee tests); 8 committee tests cover both bid-table shapes, the voting-record index, and the store path.
- Live run against the production store: 3 bids, 8 `background_pdf` rows, supplier dimension 8074 → 8075. DB backed up beforehand.
- Rebased onto current main, 0 behind, no conflicts. Two stale commits duplicating the #168 docs (already shipped on main) were dropped.
- The browser half (`discover_report_urls`) has no unit test by design, as with the council/agency scrapers — the live run above is its verification.

The ceiling is recorded in `CLAUDE.md` so it is not re-litigated later, following the #83 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
