### PR TITLE
fix(trca): index only linked documents, not the page's own stylesheet and logo (#175)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,26 @@ and attribution conditions in its permission file. Bid documents stay out of sco
 regardless — they sit behind the Vendor clickwrap. Bill 97 amalgamates TRCA away on
 2027-02-01; its capture is deadline-bound.
 
+**On eSCRIBE, a document is what the page LINKS TO, never what it LOADS (#175).** TRCA's
+meeting pages serve their own print stylesheet (`<link rel=stylesheet href>`) and header
+logo (`<img src>`) through the *same* `FileStream.ashx?DocumentId=` handler as their PDFs,
+so matching `href|src` on any element indexed two page assets per meeting page — **460
+against 3,422 real documents**. They can never satisfy the `%PDF` check, so they sat
+queued (`sha256 IS NULL`) and were re-fetched **every night forever**, and the `continue`
+that dropped them **logged nothing**, which is why an 11-line 404 list read as the whole
+problem. `escribe_document_urls` is anchor-scoped (measured live: drops exactly those 460,
+adds none — `href` is not always the first attribute, `<a class='Link' tabindex='15'
+href=...>`), and `escribe_asset_urls` NAMES the complement so `_prune_page_assets` can
+unqueue the rows already written. That prune is a **deliberate, narrow exception** to "rows
+are never deleted": a row must be unheld AND still shown as an asset by a page just loaded,
+so a document that merely stopped appearing — a meeting dropped from the calendar, a page
+that 404'd mid-walk — is untouched, and held bytes are unreachable by it.
+**The ~11 remaining 404s are not losses and should not be suppressed:** every one is a
+*minutes* link (the outlier, `20288`, is a closed-session `RES.#` on a Bill 97 negotiating
+position), no board report is among them, and all 11 are **still linked from TRCA's own
+pages** — a broken link at source, not an id rotation, so they stay queued in case TRCA
+repairs one.
+
 The bids&tenders **portal listings** (`sources/bids_tenders.py`, #135) are captured over plain
 HTTP — the grid loads from `POST /Module/Tenders/en/Tender/Search/<NodeId>` (session cookie +
 the FIRST antiforgery token; **never send `sort=` — it errors**), no browser. `fetch_listings`

--- a/scrapers/tests/fixtures/agencies/SOURCES.md
+++ b/scrapers/tests/fixtures/agencies/SOURCES.md
@@ -51,6 +51,21 @@ it POSTs GetCalendarMeetings, above.) `escribe_document_urls` still runs on the 
 *detail* pages, which ARE server-rendered with `FileStream.ashx` anchors; this
 hand-written fixture exercises that extractor on the anchor shapes it must find.
 
+## trca_escribe_meeting_assets.html — REAL, TRIMMED (#175)
+
+Verbatim fragments of a real meeting detail page,
+`Meeting.aspx?Id=61119747-5c38-4080-a3f8-0d45952a03b7&Agenda=Agenda&lang=English`
+(Board of Directors), fetched 2026-07-28; the live page is 131,700 bytes and only the
+surrounding markup was cut away. This is the fixture the synthetic
+`trca_escribe_2023.html` above could not be: it carries the two shapes that broke the
+extractor, exactly as eSCRIBE emits them —
+`<link rel='stylesheet' type='text/css' href='/FileStream.ashx?DocumentId=3253'>` and
+`<DIV class='AgendaHeaderLogo' ><img  src='filestream.ashx?DocumentId=3251' ...>`. Both
+were fetched live the same day: 3253 returns `text/css`, 3251 returns `image/jpeg` (the
+TRCA logo, the same 22,692 bytes on all 230 meeting pages). It also carries a document
+anchor whose `href` is NOT the first attribute (`<a class='Link' tabindex='15' href=...>`),
+which is the ordinary shape on these pages.
+
 ## bids_tenders_record_sample.json — SYNTHETIC (#135)
 
 Hand-built, NOT a real capture. As of 2026-07-18 both permitted bids&tenders portals (TRCA,

--- a/scrapers/tests/fixtures/agencies/trca_escribe_meeting_assets.html
+++ b/scrapers/tests/fixtures/agencies/trca_escribe_meeting_assets.html
@@ -1,0 +1,25 @@
+<!--
+REAL CAPTURE, TRIMMED (#175). Verbatim fragments of
+https://pub-trca.escribemeetings.com/Meeting.aspx?Id=61119747-5c38-4080-a3f8-0d45952a03b7&Agenda=Agenda&lang=English
+(Board of Directors, fetched 2026-07-28; the live page is 131,700 bytes). Every
+FileStream.ashx line below is byte-for-byte as eSCRIBE serves it — only the
+surrounding page has been cut away.
+
+The point of the fixture: eSCRIBE serves the meeting page's OWN print stylesheet
+and header logo through the same FileStream.ashx?DocumentId= handler as its
+documents. Fetched live on 2026-07-28, DocumentId=3253 returns text/css and
+DocumentId=3251 returns image/jpeg (the TRCA logo, the same 22,692 bytes on all
+230 meeting pages). Only an <a href> is a document.
+-->
+<html>
+<head>
+<link href="/Content/css?v=3HBqEpp8bqFx1jEAWPqC5aHyIoSdKmwCBMczyQOKLr41" rel="stylesheet"/>
+<link rel='stylesheet' type='text/css' href='/FileStream.ashx?DocumentId=3253'>
+</head>
+<body>
+<DIV class='AgendaHeaderLogo' ><img  src='filestream.ashx?DocumentId=3251' alt=''  /></DIV>
+<a href="https://pub-trca.escribemeetings.com/FileStream.ashx?DocumentId=3216">Link</a>
+<DIV class='AgendaItemAttachment AgendaItemAttachment15' ><SPAN class='Sequence' >1.</SPAN><a class='Link' tabindex='15' href='filestream.ashx?DocumentId=3235' data-toggle='tooltip' data-html='true' data-container='body' data-original-title='1815 Altona Road Pickering - Spiers Eco-Gift Donation.pdf' target='_blank' ><SPAN class='Link' >1815 Altona Road Pickering - Spiers Eco-Gift Donation.pdf</SPAN></a></DIV>
+<DIV class='AgendaItemAttachment AgendaItemAttachment15' ><SPAN class='Sequence' >2.</SPAN><a class='Link' tabindex='15' href='filestream.ashx?DocumentId=3236' data-toggle='tooltip' data-html='true' data-container='body' data-original-title='1815 Altona Rd.pdf' target='_blank' ><SPAN class='Link' >1815 Altona Rd.pdf</SPAN></a></DIV>
+</body>
+</html>

--- a/scrapers/tests/test_trca_reports.py
+++ b/scrapers/tests/test_trca_reports.py
@@ -133,6 +133,102 @@ def test_meeting_detail_urls_from_calendar_json():
     assert any("82fa331c-e7cb-4e9a-87e2-093a1a51899f" in u for u in urls)
 
 
+# --- #175: a document is linked, page furniture is loaded ---------------------
+
+def test_a_stylesheet_and_logo_served_through_filestream_are_not_documents():
+    """eSCRIBE serves the meeting page's own print stylesheet and header logo through the
+    same FileStream.ashx?DocumentId= handler as its PDFs. Matching href|src on any element
+    indexed both as documents — 2 per meeting page, 460 across the corpus, re-fetched every
+    night forever because they can never satisfy the %PDF check (#175). Fetched live
+    2026-07-28: DocumentId=3253 is text/css, 3251 is image/jpeg."""
+    from toronto_bids.sources.trca_board import escribe_asset_urls
+    html = _read("trca_escribe_meeting_assets.html")
+
+    docs = escribe_document_urls(html)
+    assert [u.rsplit("=", 1)[-1] for u in docs] == ["3216", "3235", "3236"]
+    assert not any("3253" in u or "3251" in u for u in docs)
+
+    # The assets are still NAMED, not merely ignored — that is what unqueues the rows the
+    # old regex already wrote, without guessing at which unheld rows were mistakes.
+    assert sorted(u.rsplit("=", 1)[-1] for u in escribe_asset_urls(html)) == ["3251", "3253"]
+
+
+def test_href_is_not_always_the_first_attribute_of_a_document_anchor():
+    """Real markup: `<a class='Link' tabindex='15' href=...>`. An anchor pattern that
+    demanded href immediately after `<a` would drop nearly every document on the page."""
+    urls = escribe_document_urls(
+        "<a class='Link' tabindex='15' href='filestream.ashx?DocumentId=99'>r.pdf</a>")
+    assert urls == ["https://pub-trca.escribemeetings.com/filestream.ashx?DocumentId=99"]
+
+
+def test_prune_unqueues_page_assets_but_never_a_document_or_held_bytes(tmp_path):
+    """The prune is scoped to the exact mistake: unheld AND still shown as an asset by a
+    page we just loaded. A dead document link (TRCA's own 404s — all 11 are minutes links,
+    still linked from TRCA's pages) stays queued so a repaired link is picked up."""
+    from toronto_bids.sources.trca_board import _prune_page_assets
+    from toronto_bids.store import db
+
+    base = "https://pub-trca.escribemeetings.com/"
+    asset = base + "FileStream.ashx?DocumentId=3253"      # the stylesheet
+    dead = base + "FileStream.ashx?DocumentId=5558"       # a real link that 404s at source
+    held_asset = base + "FileStream.ashx?DocumentId=7777"  # bytes on disk — never deletable
+
+    conn = db.connect(":memory:")
+    db.init_db(conn)
+    for url in (asset, dead):
+        conn.execute("INSERT INTO background_pdf (url, kind) VALUES (?, 'agency_board')",
+                     (url,))
+    conn.execute("INSERT INTO background_pdf (url, kind, sha256) VALUES (?, 'agency_board', 'x')",
+                 (held_asset,))
+    conn.commit()
+
+    assert _prune_page_assets(conn, {asset, held_asset}, lambda _m: None) == 1
+    left = {r[0] for r in conn.execute("SELECT url FROM background_pdf").fetchall()}
+    assert left == {dead, held_asset}
+    conn.close()
+
+
+def test_prune_does_nothing_when_no_page_loaded(tmp_path):
+    """An empty asset set means the walk saw no page — never a licence to delete."""
+    from toronto_bids.sources.trca_board import _prune_page_assets
+    from toronto_bids.store import db
+
+    conn = db.connect(":memory:")
+    db.init_db(conn)
+    conn.execute("INSERT INTO background_pdf (url, kind) VALUES "
+                 "('https://pub-trca.escribemeetings.com/FileStream.ashx?DocumentId=1', "
+                 "'agency_board')")
+    conn.commit()
+    assert _prune_page_assets(conn, set(), lambda _m: None) == 0
+    assert conn.execute("SELECT COUNT(*) FROM background_pdf").fetchone()[0] == 1
+    conn.close()
+
+
+def test_a_non_pdf_response_is_logged_rather_than_dropped_in_silence(tmp_path):
+    """This branch was silent, so 460 wasted fetches a night hid behind an 11-line 404
+    list (#175). The row still stays queued — only the silence is the bug."""
+    from toronto_bids.sources.trca_board import _store_pending_pdfs
+    from toronto_bids.store import db
+
+    conn = db.connect(":memory:")
+    db.init_db(conn)
+    url = "https://pub-trca.escribemeetings.com/FileStream.ashx?DocumentId=3253"
+    conn.execute("INSERT INTO background_pdf (url, kind) VALUES (?, 'agency_board')", (url,))
+    conn.commit()
+
+    class _FakeHttp:
+        def get_bytes(self, _url, **_kw):
+            return b"@media Print{...}"
+
+    lines = []
+    assert _store_pending_pdfs(conn, _FakeHttp(), tmp_path, "%escribemeetings%",
+                               lines.append, "trca") == 0
+    assert any("not a PDF" in line and url in line for line in lines)
+    assert conn.execute(
+        "SELECT sha256 FROM background_pdf WHERE url=?", (url,)).fetchone()[0] is None
+    conn.close()
+
+
 def test_escribe_document_urls_decodes_html_entities():
     """Some detail-page hrefs encode the colon as &#58; (and & as &amp;). Decode both,
     or the URL is a malformed scheme that crashes the fetch (#137, found live)."""

--- a/scrapers/toronto_bids/sources/trca_board.py
+++ b/scrapers/toronto_bids/sources/trca_board.py
@@ -133,8 +133,20 @@ def parse_trca_report(text: str, report_url: str | None = None) -> list[dict]:
             for ref in refs if winners_by_ref[ref]]
 
 
-_FILESTREAM = re.compile(r"""(?:href|src)=["']([^"']*[Ff]ile[Ss]tream\.ashx\?DocumentId=\d+[^"']*)""")
-_MEETING = re.compile(r"""href=["']([^"']*Meeting\.aspx\?[^"']+)""")
+# A document is something the page LINKS TO, never something it LOADS (#175). eSCRIBE
+# serves the meeting page's own print stylesheet (<link rel=stylesheet href>) and header
+# logo (<img src>) through the same FileStream.ashx?DocumentId= handler as its PDFs, so
+# matching href|src on any element indexed two page assets per meeting page — 460 across
+# the 230-page corpus, against 3,422 real documents. They can never be PDFs, so the fetch
+# loop dropped them at the %PDF check and left them queued, re-fetching all 460 every
+# night forever while logging nothing at all. Anchor-scoping is measured against the live
+# corpus: it drops exactly those 460 and adds none. `[^>]*?` because href is not always
+# the first attribute (`<a class='Link' tabindex='15' href=...>`).
+_ANCHOR_FILESTREAM = re.compile(
+    r"""<a\b[^>]*?href=["']([^"']*[Ff]ile[Ss]tream\.ashx\?DocumentId=\d+[^"']*)""", re.I)
+_ANY_FILESTREAM = re.compile(
+    r"""(?:href|src)=["']([^"']*[Ff]ile[Ss]tream\.ashx\?DocumentId=\d+[^"']*)""")
+_MEETING = re.compile(r"""<a\b[^>]*?href=["']([^"']*Meeting\.aspx\?[^"']+)""", re.I)
 
 
 def _absolute(url: str) -> str:
@@ -143,20 +155,40 @@ def _absolute(url: str) -> str:
     return config.TRCA_ESCRIBE_BASE.rstrip("/") + "/" + url.lstrip("/")
 
 
-def escribe_document_urls(html: str) -> list[str]:
-    """Every FileStream + Meeting link on a page, absolute, order-preserving, deduped.
-
-    HTML-decode each href before use: some detail pages encode the colon as `&#58;`
-    (and `&` as `&amp;`), so a plain `.replace('&amp;', '&')` leaves `https&#58;//…` — a
-    malformed scheme that crashes the fetch. `unescape` handles every entity (#137).
-    """
+def _absolute_unique(matches) -> list[str]:
     seen, out = set(), []
-    for m in (_FILESTREAM.findall(html) + _MEETING.findall(html)):
+    for m in matches:
+        # HTML-decode each href before use: some detail pages encode the colon as `&#58;`
+        # (and `&` as `&amp;`), so a plain `.replace('&amp;', '&')` leaves `https&#58;//…` —
+        # a malformed scheme that crashes the fetch. `unescape` handles every entity (#137).
         u = _absolute(unescape(m))
         if u not in seen:
             seen.add(u)
             out.append(u)
     return out
+
+
+def escribe_document_urls(html: str) -> list[str]:
+    """Every linked FileStream + Meeting URL on a page, absolute, order-preserving, deduped.
+
+    Anchors only — a stylesheet or logo served through FileStream.ashx is page furniture,
+    not a document (#175). See `escribe_asset_urls` for the other side of that split.
+    """
+    return _absolute_unique(_ANCHOR_FILESTREAM.findall(html) + _MEETING.findall(html))
+
+
+def escribe_asset_urls(html: str) -> list[str]:
+    """The FileStream URLs this page LOADS rather than links to — its stylesheet and logo.
+
+    The complement of `escribe_document_urls` over the same handler, and the reason it is
+    computed rather than inferred: these are the rows #175 mis-indexed as documents, and
+    naming them from the page itself is what lets `download_reports` unqueue them. A row is
+    pruned only because the page it came from still shows it as an asset — never because
+    it merely stopped appearing, which would drop a real document the moment a meeting fell
+    out of the calendar.
+    """
+    linked = set(_absolute_unique(_ANCHOR_FILESTREAM.findall(html)))
+    return [u for u in _absolute_unique(_ANY_FILESTREAM.findall(html)) if u not in linked]
 
 
 def meeting_detail_urls(calendar_json: dict) -> list[str]:
@@ -186,6 +218,7 @@ def download_reports(conn, http, log=lambda _m: None) -> int:
     """
     config.TRCA_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     # 1. Index: discover FileStream URLs and upsert a background_pdf row per document.
+    assets: set[str] = set()
     for year in config.TRCA_ESCRIBE_YEARS:
         try:
             calendar = http.post_json(config.TRCA_CALENDAR_URL,
@@ -206,10 +239,40 @@ def download_reports(conn, http, log=lambda _m: None) -> int:
                 if "ashx" in durl.lower():
                     db.upsert_row(conn, BackgroundPdf(url=durl, kind="agency_board"),
                                   overwrite=False)
+            assets.update(escribe_asset_urls(mhtml))
         conn.commit()
+    _prune_page_assets(conn, assets, log)
     # 2. Fetch: everything indexed but not yet held.
     return _store_pending_pdfs(conn, http, config.TRCA_REPORTS_DIR,
                                "%escribemeetings%", log, "trca")
+
+
+def _prune_page_assets(conn, assets: set[str], log) -> int:
+    """Unqueue rows a meeting page shows as an ASSET rather than a document (#175).
+
+    Deleting from `background_pdf` is a deliberate exception to this archive's "rows are
+    never deleted" rule, and a narrow one: these rows index a stylesheet and a logo, not a
+    record, and nothing was ever held for them. The alternative — leaving them — is not
+    inert, because `_store_pending_pdfs` queues on `sha256 IS NULL`, so all 460 were
+    re-fetched every night and would go on being re-fetched forever.
+
+    Scoped so it can only ever hit that mistake: a row must be unheld AND still named as an
+    asset by a page we just loaded. A document that merely stopped appearing — a meeting
+    dropped from the calendar, a page that 404'd mid-walk — is untouched, so no completeness
+    guard on the walk is needed. Nothing here can delete bytes we hold.
+    """
+    if not assets:
+        return 0
+    ids = [r["id"] for r in conn.execute(
+        "SELECT id, url FROM background_pdf WHERE kind='agency_board' "
+        "AND url LIKE '%escribemeetings%' AND sha256 IS NULL").fetchall()
+        if r["url"] in assets]
+    if not ids:
+        return 0
+    conn.executemany("DELETE FROM background_pdf WHERE id=?", [(i,) for i in ids])
+    conn.commit()
+    log(f"  trca: unqueued {len(ids)} page asset(s) mis-indexed as documents (#175)")
+    return len(ids)
 
 
 def _store_pending_pdfs(conn, http, reports_dir, url_like: str, log, prefix: str) -> int:
@@ -235,7 +298,13 @@ def _store_pending_pdfs(conn, http, reports_dir, url_like: str, log, prefix: str
             log(f"  {prefix} skip {row['url']}: {exc}")
             continue
         if not blob.startswith(b"%PDF"):
-            continue                        # HTML error page; leave queued
+            # Left queued — an interstitial or a transient error page may serve the real
+            # PDF next run. But SAY SO: this branch was silent, and #175 hid 460 wasted
+            # fetches a night behind it, making an 11-line 404 list look like the whole
+            # problem. A skip nobody can see is a skip nobody fixes.
+            log(f"  {prefix} not a PDF ({blob[:4]!r}, {len(blob)} bytes), left queued: "
+                f"{row['url']}")
+            continue
         sha = hashlib.sha256(blob).hexdigest()
         path = reports_dir / f"{sha}.pdf"
         path.write_bytes(blob)


### PR DESCRIPTION
Closes #175.

## The 11 404s are not the problem, and they are not losses

The issue's premise was that we were losing deadline-bound board-report PDFs. Measured, we are not.

I re-walked all 230 TRCA meeting pages and pulled the anchor label for each dead `DocumentId`:

| DocumentId | Meeting | Link label |
|---|---|---|
| 5558 | Board of Directors – 2020-04-24 | `Open Session Meeting Minutes` |
| 6817 / 6818 / 6819 | Board of Directors – 2021-02-26 | `Meeting Minutes Link` |
| 7234 | Board of Directors – 2021-04-30 | `Meeting Minutes Link` |
| 9229 | Board of Directors – 2022-05-20 | `Minutes Link` |
| 13785 | Board of Directors – 2023-02-17 | `Minutes Link` |
| 15601 | Regional Watershed Alliance – 2024-02-28 | `Minutes Link` |
| 20197 | Partners in Project Green EMC | `Minutes Link` |
| 20288 | Board of Directors – 2026-05-22 | `RES.#B29/26` |
| 20289 | Board of Directors – 2026-05-22 | `Minutes Link` |

Ten are minutes links. The eleventh, `20288`, is the only one that looked like a document — it is a
closed-session item ("VERBAL UPDATE ON REGIONAL CONSOLIDATION OF ONTARIO'S CONSERVATION AUTHORITIES
(BILL 97) … pursuant to Section C.4(2)(I) of TRCA's Administrative By-law"), so it is unpublished by
design. **No board report is among them.**

They are also not an id rotation: every one is **still linked from TRCA's own page**. TRCA's server
404s a URL TRCA's own markup emits. There is nothing to re-resolve.

## The real problem was 42× larger and completely silent

471 rows were queued, not 11. Fetching every one:

```
200 text/css     230   ← the meeting page's own print stylesheet
200 image/jpeg   230   ← the TRCA header logo (the same 22,692 bytes on all 230 pages)
404 text/html     11   ← the ones in the issue
```

eSCRIBE serves the meeting page's own assets through the *same* `FileStream.ashx?DocumentId=`
handler as its documents, and `escribe_document_urls` matched `href|src` on any element:

```html
<link rel='stylesheet' type='text/css' href='/FileStream.ashx?DocumentId=3253'>
<DIV class='AgendaHeaderLogo' ><img  src='filestream.ashx?DocumentId=3251' alt=''  /></DIV>
```

Two junk rows per meeting page × 230 pages = 460, against 3,422 real documents. They can never
satisfy the `%PDF` check, so they stayed queued (`sha256 IS NULL`) and were re-fetched **every night
forever** — and the `continue` that dropped them **logged nothing at all**. That silence is why the
issue counted 11: 460 wasted fetches a night were invisible behind it.

## The fix

**A document is what the page links to, never what it loads.**

- `escribe_document_urls` is anchor-scoped. Measured against the live corpus: **drops exactly those
  460, adds none** (3,882 → 3,422). `href` is not always the first attribute — the ordinary shape on
  these pages is `<a class='Link' tabindex='15' href=...>` — so the pattern allows attributes before it.
- `escribe_asset_urls` **names** the complement rather than inferring it, which is what lets
  `_prune_page_assets` unqueue the rows the old regex already wrote.
- That prune is a **narrow, deliberate exception** to "rows are never deleted": a row must be unheld
  **and** still shown as an asset by a page we just loaded. A document that merely stopped appearing —
  a meeting dropped from the calendar, a page that 404'd mid-walk — is untouched, and held bytes are
  unreachable by it. Leaving the rows was not an option: the queue predicate is `sha256 IS NULL`, so
  they re-fetch forever regardless of the extractor fix.
- The non-PDF branch now says what it dropped. A skip nobody can see is a skip nobody fixes.

**The 11 are deliberately left queued.** They cost 11 requests a night, they are TRCA's broken links
rather than ours, and if TRCA repairs one we should pick it up. With the 460 gone they are a legible
signal instead of noise — which is what the issue actually asked for.

## Verification

Live run against a **copy** of the production store (`~/tb-data` untouched):

```
trca: unqueued 460 page asset(s) mis-indexed as documents (#175)
trca reports fetched : 0
trca stored          : 446 solicitations, 693 awards, 527 bids

3,882 → 3,422 rows | held 3,411 unchanged | pending 471 → 11
0 "not a PDF" lines | agency_solicitation/award/bid: 345/580/523 unchanged
```

The 11 that remain are exactly the 11 dead minutes links.

**801 tests passing** (796 + 5 new). The new tests run against
`trca_escribe_meeting_assets.html` — a **real, trimmed capture** of a live meeting page (provenance
in `SOURCES.md`), carrying the stylesheet and logo markup byte-for-byte as eSCRIBE emits them. The
existing `trca_escribe_2023.html` is synthetic and could never have caught this.

## The related question in the issue

The TRCA path ingests fine — the run above re-parsed 446 solicitations / 693 awards / 527 bids. The
`+0` since 2026-07-21 is meeting cadence plus complete capture: the newest agenda'd meeting is
**2026-06-26**, and the walk found 3,422 linked documents against 3,422 rows. Nothing new exists to
ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W53WHx8mm2UHuLFAQWeF62
