### PR TITLE
fix(agencies): cache closed council terms and skip already-stored forms (#177)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ The bidders did not stop. `tb enrich-awards --download` archives the Toronto Bid
 - **The form is a ruled table end to end, so it is read as CELLS, via pdfplumber (#116)** — `form_rows` does the I/O, `parse_award_summary(rows)` is pure over them, and the fixtures are JSON rows so the tests need neither pdfplumber nor a PDF. **`background_pdf.text` is archival here and nothing parses it**; `layout=True` is kept only because it renders a columnar form more faithfully and the bytes are already on disk under it. Measured over the 229 archived forms: **pdftotext parsed 144 and yielded 632 bids; pdfplumber parses 205 and yields 1,058.** All 229 carry ruled tables and **none are image-only** — which is exactly what separates this corpus from the staff reports #83 measured (ruled tables in only 13-20 of 229). The rule is not "pdfplumber is better", it is **"read cells where the PDF has cells"**.
 - **The count check is one-sided on purpose.** `Number of Bids Received` catches an under-parse (the agenda corpus never offered that check), but parsing *more* is kept: the count sometimes covers only the **compliant** bids while the table lists everyone (doc `5247418372` declares 2, tabulates 3, third marked `*` at $0.00). The table is the record. **Exactly 1 form is now refused** (doc `5346602194` declares 5 and tabulates 4, leaving row `5.` blank — the City's omission, not a parse failure), and the count is printed, never silent.
 - **The price cell's line count says how many bids a row holds.** A newline inside a *name* cell is otherwise ambiguous and guessing costs real bids: pdfplumber wraps a long name within its own cell, so `['2489960 Ontario Inc.\no/a Kore Infrastructure Group', '$3,198,000.00']` is **one** bidder. Reading those two lines as two names against one price made the pair unequal, which the multi-package rule then refused — silently dropping a bidder from each of 4 forms. One price, one bid. Where the price cell *does* hold several lines the row is a multi-package column and #94's rule applies verbatim: zip positionally and **refuse an unequal pair** rather than guess.
+- **`store_award_summary_bids` skips a form whose document already has `source='award_summary'` bid rows, without opening the PDF (#177).** The form on disk cannot change, so a form that already succeeded can only ever re-derive the same rows — pdfplumber's per-file table extraction over all 229 archived forms cost ~41s of pure repetition every night for +0 new bids, and the return value read as fresh growth (`1102 bids stored`) in the nightly Slack summary when it was the corpus total, not the night's delta. The one form that's REFUSED (below) has no bid rows to key the skip on, so it is retried every run unchanged — correct, since a parser fix should pick it up on the very next run rather than needing a manual reset.
 - **Four traps this parser hit, all previously documented elsewhere:** an RFP lists proponents with **no price at all** (`NOTE: Not applicable for RFP`) so the price must be optional (#84 stores these as NULL); `2489960 Ontario Inc.` is a **real firm**, so a "long digit run means a leaked price" guard eats it (#87 pins the same lesson — reading cells removes the reason that guard existed, since a name cell cannot contain a price that leaked out of the price cell); `\s` matches newlines, so `\d{1,2}[.)]\s*` walked off an empty `4.` row and captured `Page 2 of 2` as a bidder; and **the numbering is not always there** — requiring it cost 57 of 229 forms their entire bid table, so it is stripped where present and never required.
 - **Coverage is bounded and will stay bounded**: the form exists only **over $500,000** — the panel had no floor — so the bid record thins permanently for small awards. The City also says "a portion of work ... will be manual"; 223 of 244 post-cutover awards carry one (91%).
 
@@ -190,6 +191,22 @@ portal: TRCA's eSCRIBE (plain HTTP; the results TABLE is fused pdftotext and nev
 mined — bidders come from the bullet list, winners+amounts from the RECOMMENDATION
 clause) and the Zoo's ZB committee on TMMIS (same prober as BA/BD; 2025-era reports
 route values to a CONFIDENTIAL ATTACHMENT → `value_confidential=1`, not fake NULLs).
+**Every `term_starts` entry but the LAST is a closed council term, and `discover_meetings`/
+`scrape_agendas` (bid_award_panel.py) now know it (#177).** A newer entry only exists in the
+list once the term it precedes has ended and can never produce another meeting — that's true
+by construction, no wall-clock date needed. Before this, every nightly re-probed EVERY
+closed term's dead miss boundary on live network requests, forever: for Zoo (2 closed terms)
+and EP (1), that was most of a nightly's agency-capture minutes for zero possible gain.
+`.closed_terms.json` in each body's agenda dir (`{"EP2018-2022": 26}`-shaped) records a
+closed term's confirmed last meeting the first time it's found; only the LAST entry — the one
+still accepting new meetings — is ever probed live, every run, forever. **`got["awards"]`/
+`got["bids"]` from `store_*_reports` count REPORTS PROCESSED, not resulting rows** — a report
+upserts on `native_ref` with `overwrite=True`, so an amendment and its original can each
+increment the loop count while collapsing into one row (live-measured: EP processes 107
+reports into 88 actual rows). Any "what's new" reporting must diff two real
+`SELECT COUNT(*) ... WHERE source=?` queries, never `got["awards"] - before` — that arithmetic
+briefly shipped in this fix's own draft and reported a fictitious +19 before being caught
+against the real store.
 **The bids&tenders portal is fetched only under recorded permission**: `sources/bids_tenders.py`
 is a gate that raises `PermissionError` until a body's written grant lands in
 `docs/permissions/` and flips its `config.BIDS_TENDERS_PORTALS` entry (the PMMD/Ariba

--- a/scrapers/tests/test_award_summary.py
+++ b/scrapers/tests/test_award_summary.py
@@ -222,6 +222,58 @@ def test_a_priceless_rfp_bid_does_not_duplicate_on_every_run(conn, monkeypatch):
     assert conn.execute("SELECT COUNT(*) FROM bid").fetchone()[0] == first
 
 
+# --- skipping already-stored forms (#177) ------------------------------------------------
+
+def test_a_form_already_stored_is_skipped_without_opening_the_pdf(conn, monkeypatch):
+    """229 archived forms parsed via pdfplumber every night for +0 new bids cost ~41s of pure
+    repetition (#177): a form on disk cannot change, so a form that already succeeded can
+    only ever re-derive the same rows. The skip must happen BEFORE form_rows is called —
+    proven here by making a second call to form_rows raise."""
+    _seed(conn, FORM, monkeypatch)
+    assert store_award_summary_bids(conn) == 5
+
+    def boom(_p):
+        raise AssertionError("form_rows must not be called for an already-stored form")
+    monkeypatch.setattr(award_summary, "form_rows", boom)
+    assert store_award_summary_bids(conn) == 0
+    assert conn.execute("SELECT COUNT(*) FROM bid").fetchone()[0] == 5
+
+
+def test_a_new_form_is_still_stored_while_an_old_one_is_skipped(conn, monkeypatch):
+    """The skip is per-document, not global — adding a new form must not need reprocessing
+    everything that came before it."""
+    _seed(conn, FORM, monkeypatch, doc="5616191850")
+    assert store_award_summary_bids(conn) == 5
+
+    _seed(conn, RFP, monkeypatch, doc="5386487782")
+    assert store_award_summary_bids(conn) > 0
+    docs = {r[0] for r in conn.execute(
+        "SELECT DISTINCT document_number FROM bid").fetchall()}
+    assert docs == {"5616191850", "5386487782"}
+
+
+def test_a_refused_form_is_retried_every_run_not_frozen(conn, monkeypatch):
+    """A REFUSED form stores no bid rows, so it has nothing to key a skip on — it is retried
+    every run, unchanged from before #177. That is correct: a parser fix should pick it up
+    on the very next run rather than needing a manual reset."""
+    rows = [r for r in copy.deepcopy(FORM)
+            if not r[0].startswith(("2. CRCE", "3. GIO CRETE"))]
+    _seed(conn, rows, monkeypatch)
+    assert store_award_summary_bids(conn) == 0
+    called = []
+    monkeypatch.setattr(award_summary, "form_rows", lambda p: (called.append(p), rows)[1])
+    assert store_award_summary_bids(conn) == 0
+    assert called                                    # re-opened, not skipped
+
+
+def test_reports_how_many_forms_were_skipped(conn, monkeypatch):
+    _seed(conn, FORM, monkeypatch)
+    store_award_summary_bids(conn)
+    said = []
+    store_award_summary_bids(conn, log=said.append)
+    assert any("skipped: 1" in m for m in said)
+
+
 def test_an_unreadable_form_is_reported_and_skipped(conn, monkeypatch):
     """16 of the composite reports are image-only (#96) and this corpus may yet grow one. A
     form pdfplumber cannot open must not take the whole pass down with it."""

--- a/scrapers/tests/test_bid_award_panel.py
+++ b/scrapers/tests/test_bid_award_panel.py
@@ -6,6 +6,7 @@ Fixtures are real pages fetched from TMMIS, trimmed to <main>:
   2018.BA10  — a reference that does not exist (probing is how references are found)
 """
 import pathlib
+from contextlib import contextmanager
 
 import pytest
 
@@ -131,6 +132,115 @@ def test_discovery_handles_two_meetings_on_one_date():
         _fake_site({"2017.BA1": "2017-01-04", "2017.BA2": "2017-01-04"}),
         max_per_term=2, stop_after_misses=1, term_starts=[("BA", 2017, "2014-2018", 1)])
     assert set(found) == {"2017.BA1", "2017.BA2"}
+
+
+# --- closed-term caching (#177) ----------------------------------------------------------
+
+def test_a_closed_historical_term_skips_probing_past_its_known_end():
+    """Every term but the LAST is historical by construction (a newer one already follows
+    it), so once its miss boundary is known, re-probing it is pure waste — this was most of
+    a nightly's cost for EP/Zoo (#177). Passing the boundary must not touch the network past
+    it."""
+    calls = []
+
+    def fetch(ref):
+        calls.append(ref)
+        return _fake_site({"2019.EP1": "2019-01-09", "2019.EP2": "2019-02-06"})(ref)
+
+    terms = [("EP", 2019, "2018-2022", 1), ("EP", 2023, "2022-2026", 1)]
+    found = discover_meetings(fetch, max_per_term=200, stop_after_misses=4,
+                              term_starts=terms, closed_terms={"EP2018-2022": 2})
+    assert set(found) == {"2019.EP1", "2019.EP2"}
+    # Only the 2 known-real meetings of the closed term (session years 2019/2020) were
+    # probed — never the dead miss range past EP2's boundary. The open term (2023/2024)
+    # walking into ITS OWN misses is separate and expected.
+    closed_term_calls = [c for c in calls if c.startswith(("2019.", "2020."))]
+    assert closed_term_calls == ["2019.EP1", "2019.EP2"]
+
+
+def test_a_historical_terms_boundary_is_reported_exactly_once():
+    """`on_term_closed` is the hook a caller persists from — it must fire once, with the
+    confirmed last real meeting, and never for the still-open final term."""
+    closures = []
+
+    def fetch(ref):
+        return _fake_site({"2019.EP1": "2019-01-09"})(ref)
+
+    terms = [("EP", 2019, "2018-2022", 1), ("EP", 2023, "2022-2026", 1)]
+    discover_meetings(fetch, max_per_term=10, stop_after_misses=2,
+                      term_starts=terms, on_term_closed=lambda k, n: closures.append((k, n)))
+    assert closures == [("EP2018-2022", 1)]
+
+
+def test_the_open_final_term_is_never_reported_as_closed():
+    """A term that legitimately runs dry this run (e.g. no meetings posted yet) is not
+    historical — it is the LAST entry, so it must go on being probed live every run."""
+    closures = []
+    discover_meetings(_fake_site({}), max_per_term=5, stop_after_misses=2,
+                      term_starts=[("EP", 2023, "2022-2026", 1)],
+                      on_term_closed=lambda k, n: closures.append((k, n)))
+    assert closures == []
+
+
+def test_a_mistaken_closed_entry_for_the_open_term_is_ignored():
+    """closed_terms is a caller-provided cache; a bug that wrote an entry for the currently
+    open term must never freeze it — the open term is always probed live."""
+    calls = []
+
+    def fetch(ref):
+        calls.append(ref)
+        return _fake_site({"2019.EP1": "2019-01-09", "2019.EP2": "2019-02-06",
+                           "2019.EP3": "2019-03-06"})(ref)
+
+    found = discover_meetings(fetch, max_per_term=10, stop_after_misses=2,
+                              term_starts=[("EP", 2019, "2018-2022", 1)],
+                              closed_terms={"EP2018-2022": 1})   # would wrongly stop at EP1
+    assert set(found) == {"2019.EP1", "2019.EP2", "2019.EP3"}
+
+
+def test_passing_neither_hook_reproduces_the_old_always_probe_behaviour():
+    """closed_terms/on_term_closed are additive — a caller that passes neither (like the
+    existing BA/BD tests) must see exactly the pre-#177 discovery."""
+    found = discover_meetings(
+        _fake_site({"2017.BA1": "2017-01-04", "2017.BA2": "2017-01-04"}),
+        max_per_term=2, stop_after_misses=1, term_starts=[("BA", 2017, "2014-2018", 1)])
+    assert set(found) == {"2017.BA1", "2017.BA2"}
+
+
+@contextmanager
+def _fake_agenda_fetcher(pages, calls):
+    def fetch(meeting: str) -> str:
+        calls.append(meeting)
+        return _fake_site(pages)(meeting)
+    yield fetch
+
+
+def test_scrape_agendas_persists_a_closed_terms_boundary_to_disk(tmp_path, monkeypatch):
+    """The first run confirms EP2018-2022 ends at meeting 2 and must write that down; a
+    second run must read it back and never re-probe the dead range (#177)."""
+    from toronto_bids.sources import bid_award_panel as bap
+    terms = [("EP", 2019, "2018-2022", 1), ("EP", 2023, "2022-2026", 1)]
+    pages = {"2019.EP1": "2019-01-09", "2019.EP2": "2019-02-06"}
+
+    calls1 = []
+    monkeypatch.setattr(bap, "agenda_fetcher",
+                        lambda **_kw: _fake_agenda_fetcher(pages, calls1))
+    found1 = bap.scrape_agendas(tmp_path, term_starts=terms)
+    assert set(found1) == {"2019.EP1", "2019.EP2"}
+    assert (tmp_path / ".closed_terms.json").exists()
+    assert bap._load_closed_terms(tmp_path) == {"EP2018-2022": 2}
+
+    # Second run: EP1/EP2 are cached on disk (served without a live call at all), and the
+    # persisted boundary means nothing past them is probed either — the closed term costs
+    # ZERO live calls this run. The still-open 2022-2026 term is unaffected and keeps
+    # probing its own miss range live, which is correct: only a closed term can be cached.
+    calls2 = []
+    monkeypatch.setattr(bap, "agenda_fetcher",
+                        lambda **_kw: _fake_agenda_fetcher(pages, calls2))
+    found2 = bap.scrape_agendas(tmp_path, term_starts=terms)
+    assert set(found2) == {"2019.EP1", "2019.EP2"}
+    assert not any(c.endswith(("EP1", "EP2", "EP3", "EP4")) and c.startswith("201")
+                  for c in calls2), calls2
 
 
 # --- staff-report PDF index (#68) --------------------------------------------------------

--- a/scrapers/tests/test_cli_agencies.py
+++ b/scrapers/tests/test_cli_agencies.py
@@ -1,5 +1,56 @@
 from toronto_bids import cli
 from toronto_bids.buyers import seed_buyers
+from toronto_bids.models import AgencyAward
+from toronto_bids.store import db
+
+
+# --- reporting new-vs-total distinctly (#177) ---------------------------------------------
+
+def test_stored_line_reports_the_delta_beside_the_total():
+    """A quiet night's `107 solicitations, 107 awards, 115 bids` used to be indistinguishable
+    from a real one without cross-referencing the aggregate delta three lines down (#177)."""
+    line = cli._stored_line("trca", {"solicitations": 107, "awards": 107, "bids": 115},
+                            before=(88, 115), after=(88, 115))
+    assert "107 awards (+0)" in line
+    assert "115 bids (+0)" in line
+
+
+def test_stored_line_shows_growth_when_there_is_any():
+    line = cli._stored_line("trca", {"solicitations": 108, "awards": 108, "bids": 118},
+                            before=(88, 115), after=(89, 118))
+    assert "108 awards (+1)" in line
+    assert "118 bids (+3)" in line
+
+
+def test_stored_line_delta_is_the_real_row_count_not_the_loop_count():
+    """`got["awards"]` counts REPORTS PROCESSED this call, not resulting rows — a report is
+    upserted keyed on native_ref, so an amendment and its original can both increment the
+    loop count while collapsing into the same row. Live-measured: a full EP reparse processed
+    107 reports against a table holding 88 rows; `got["awards"] - before[0]` would have
+    reported a fictitious +19. The delta must come from two real row-count queries, not from
+    `got` at all (#177)."""
+    line = cli._stored_line("ep", {"solicitations": 107, "awards": 107, "bids": 115},
+                            before=(88, 115), after=(88, 115))
+    assert "awards (+0)" in line
+
+
+def test_stored_line_omits_bids_for_a_body_with_no_bid_table():
+    """Zoo's store_zoo_reports returns no 'bids' key — the line must not fabricate one."""
+    line = cli._stored_line("zoo", {"solicitations": 5, "awards": 5}, before=(5, 0), after=(5, 0))
+    assert "bids" not in line
+
+
+def test_source_row_counts_are_scoped_to_one_board(conn):
+    ids = seed_buyers(conn)
+    db.upsert_row(conn, AgencyAward(
+        buyer_id=ids["trca"], native_ref="1", supplier_name_raw="X", award_amount=None,
+        value_confidential=0, award_date=None, source="trca_board"), overwrite=True)
+    db.upsert_row(conn, AgencyAward(
+        buyer_id=ids["toronto-zoo"], native_ref="1", supplier_name_raw="Y", award_amount=None,
+        value_confidential=0, award_date=None, source="zoo_board"), overwrite=True)
+    assert cli._source_row_counts(conn, "trca_board") == (1, 0)
+    assert cli._source_row_counts(conn, "zoo_board") == (1, 0)
+    assert cli._source_row_counts(conn, "ep_board") == (0, 0)
 
 
 def test_capture_agency_bodies_isolates_a_failing_body(conn, monkeypatch):

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -675,6 +675,34 @@ def _cmd_nightly(args) -> int:
     return 1 if failures else 0
 
 
+def _source_row_counts(conn, source: str) -> tuple[int, int]:
+    """(agency_award, agency_bid) rows currently attributed to one board's `source` value."""
+    a = conn.execute("SELECT COUNT(*) FROM agency_award WHERE source=?", (source,)).fetchone()[0]
+    b = conn.execute("SELECT COUNT(*) FROM agency_bid WHERE source=?", (source,)).fetchone()[0]
+    return a, b
+
+
+def _stored_line(label: str, got: dict, before: tuple[int, int], after: tuple[int, int]) -> str:
+    """'  trca stored : 446 solicitations, 693 awards (+0), 527 bids (+0)' (#177).
+
+    `got["awards"]`/`got["bids"]` count REPORTS PROCESSED this call, not resulting rows — a
+    report is upserted with `overwrite=True` keyed on `native_ref`, so an amendment report
+    and its original can both increment the loop count while collapsing into the same row.
+    Live-measured: a full EP reparse processed 107 reports against a table holding 88 rows,
+    which is exactly the gap `got["awards"] - before` would have reported as fictitious growth
+    (+19) had the delta been computed from the loop count instead of a second real query. The
+    delta here is `after - before` over `_source_row_counts` on BOTH sides — an actual row
+    count, immune to how many reports happened to write it. `got` is still what carries the
+    "reports processed" totals shown beside the delta. No "bids" key for a body with no bid
+    table (Zoo).
+    """
+    line = (f"  {label} stored : {got['solicitations']} solicitations, "
+           f"{got['awards']} awards ({after[0] - before[0]:+d})")
+    if "bids" in got:
+        line += f", {got['bids']} bids ({after[1] - before[1]:+d})"
+    return line
+
+
 def _capture_agency_bodies(conn, ids, *, bodies, fetch, scrape, virtual_display, out):
     """Capture TRCA/Zoo/EP board-report awards+bids, each body isolated. Returns failures.
 
@@ -693,9 +721,9 @@ def _capture_agency_bodies(conn, ids, *, bodies, fetch, scrape, virtual_display,
                     print(f"  trca reports fetched : {download_reports(conn, http, log=out)}")
                 finally:
                     http.close()
+            before = _source_row_counts(conn, "trca_board")
             got = store_trca_reports(conn, ids["trca"])
-            print(f"  trca stored          : {got['solicitations']} solicitations, "
-                  f"{got['awards']} awards, {got['bids']} bids")
+            print(_stored_line("trca", got, before, _source_row_counts(conn, "trca_board")))
         except Exception as exc:
             failures.append(("trca", str(exc)))
 
@@ -714,9 +742,9 @@ def _capture_agency_bodies(conn, ids, *, bodies, fetch, scrape, virtual_display,
                           f"{download_zoo_reports(conn, http, agendas, log=out)}")
                 finally:
                     http.close()
+            before = _source_row_counts(conn, "zoo_board")
             got = store_zoo_reports(conn, ids["toronto-zoo"])
-            print(f"  zoo stored           : {got['solicitations']} solicitations, "
-                  f"{got['awards']} awards")
+            print(_stored_line("zoo", got, before, _source_row_counts(conn, "zoo_board")))
         except Exception as exc:
             failures.append(("zoo", str(exc)))
 
@@ -735,9 +763,9 @@ def _capture_agency_bodies(conn, ids, *, bodies, fetch, scrape, virtual_display,
                           f"{download_ep_reports(conn, http, agendas, log=out)}")
                 finally:
                     http.close()
+            before = _source_row_counts(conn, "ep_board")
             got = store_ep_reports(conn, ids["exhibition-place"])
-            print(f"  ep stored            : {got['solicitations']} solicitations, "
-                  f"{got['awards']} awards, {got['bids']} bids")
+            print(_stored_line("ep", got, before, _source_row_counts(conn, "ep_board")))
         except Exception as exc:
             failures.append(("ep", str(exc)))
 

--- a/scrapers/toronto_bids/sources/award_summary.py
+++ b/scrapers/toronto_bids/sources/award_summary.py
@@ -265,7 +265,7 @@ def parse_award_summary(rows) -> dict | None:
 
 
 def store_award_summary_bids(conn, log=lambda _m: None) -> int:
-    """Parse every archived Award Summary Form into `bid` rows. Idempotent, offline.
+    """Parse every archived Award Summary Form not yet reflected in `bid`. Idempotent, offline.
 
     Reads the PDFs already on disk, not `background_pdf.text` — the form is a ruled table and
     its cells are the record (#116).
@@ -275,10 +275,26 @@ def store_award_summary_bids(conn, log=lambda _m: None) -> int:
     corpus never offered that check — #94 had to infer its own ceiling from declared counts
     and could only guess at what it was dropping. Here the form states the answer, so a silent
     partial parse is a choice rather than an accident.
+
+    A form whose `document_number` already carries `source='award_summary'` bid rows is
+    skipped without opening the PDF (#177): the form on disk cannot change, so a form that
+    already succeeded can only ever re-derive the same rows, and pdfplumber's per-file table
+    extraction over all 229 archived forms was costing ~41s of pure repetition every night for
+    +0 new bids. This is why the return value is now "bids stored THIS run", not the corpus
+    total — the old total read as new growth in the nightly Slack summary when it never was.
+    A form that was REFUSED (declared count mismatch) has no bid rows to key the skip on, so
+    it keeps being retried every run — exactly the old behaviour, unchanged, and correct: a
+    fixed parser should pick it up on the very next run rather than needing a manual reset.
     """
-    stored = refused = 0
+    already = {r["document_number"] for r in conn.execute(
+        "SELECT DISTINCT document_number FROM bid "
+        "WHERE source='award_summary' AND document_number IS NOT NULL")}
+    stored = refused = skipped = 0
     for row in conn.execute("SELECT document_number, local_path FROM background_pdf "
                             "WHERE kind='award_summary' AND local_path IS NOT NULL"):
+        if row["document_number"] is not None and row["document_number"] in already:
+            skipped += 1
+            continue
         try:
             # `local_path` is an ABSOLUTE path baked in at download time on whatever machine
             # fetched the form (download_pdf returns str(dest_dir / name)). This archive is
@@ -322,4 +338,6 @@ def store_award_summary_bids(conn, log=lambda _m: None) -> int:
     if refused:
         # Never silent: a refused form is a known gap, and one nobody prints reads as coverage.
         log(f"  award summary forms refused on a bid-count mismatch: {refused}")
+    if skipped:
+        log(f"  award summary forms already stored, skipped: {skipped}")
     return stored

--- a/scrapers/toronto_bids/sources/bid_award_panel.py
+++ b/scrapers/toronto_bids/sources/bid_award_panel.py
@@ -22,6 +22,7 @@ TMMIS is Akamai-gated: plain HTTP gets 403 (verified), as does anything without 
 browser. So fetching needs the headed Chromium behind the `council` extra, exactly as
 sources/council.py already does. Parsing is pure and testable against saved HTML.
 """
+import json
 import pathlib
 import re
 import shutil
@@ -187,7 +188,8 @@ def agenda_date(html: str) -> str | None:
 
 
 def discover_meetings(fetch, log=lambda _m: None, max_per_term=260, stop_after_misses=4,
-                      *, term_starts):
+                      *, term_starts, closed_terms: dict | None = None,
+                      on_term_closed=lambda key, last_n: None):
     """Walk each term's meetings, returning {reference: html} for every agenda that exists.
 
     References cannot be derived from the City's published schedule: it lists dates but omits
@@ -204,12 +206,32 @@ def discover_meetings(fetch, log=lambda _m: None, max_per_term=260, stop_after_m
     Award Panel is abolished, so no in-repo default remains. Other TMMIS committees (e.g.
     the Zoo Board's ZB series, #135) reuse this prober by passing their own list — same
     probe-and-confirm design, different (series, start_year, term, first_n) tuples.
+
+    Every term but the LAST in `term_starts` is, by construction, a closed council term: it is
+    followed by a newer one, which only happens once the term it precedes has already ended and
+    can never produce another meeting (#177). Once such a term's miss boundary is found, that
+    boundary is permanent — but nothing remembered it, so every run re-walked into the same
+    dead miss range on live network probes, forever, for a term that provably cannot change. Two
+    hooks, not a hardcoded rule: `closed_terms` (`{f"{series}{term}": last_real_n}`) lets a
+    closed term skip straight to its known end instead of probing past it, and
+    `on_term_closed(key, last_n)` fires the first time a non-final term's boundary is confirmed,
+    so the caller can persist it. Passing neither reproduces the old always-probe behaviour
+    exactly — this is additive, not a change to what a fresh run discovers.
     """
     found = {}
-    for series, start_year, term, first_n in term_starts:
+    closed_terms = closed_terms or {}
+    last_index = len(term_starts) - 1
+    for i, (series, start_year, term, first_n) in enumerate(term_starts):
+        key = f"{series}{term}"
+        cap = first_n + max_per_term - 1
+        # The cap only ever narrows a HISTORICAL term. The last entry is the one still
+        # accepting new meetings, so it must always be probed for real — never frozen by a
+        # stale or mistaken closed_terms entry.
+        if i != last_index and key in closed_terms:
+            cap = min(cap, closed_terms[key])
         session = start_year
         misses = 0
-        for n in range(first_n, first_n + max_per_term):
+        for n in range(first_n, cap + 1):
             html = ref = None
             # The prefix only ever advances, and only at a November boundary.
             for candidate in (session, session + 1):
@@ -222,7 +244,10 @@ def discover_meetings(fetch, log=lambda _m: None, max_per_term=260, stop_after_m
                 misses += 1
                 log(f"  {series} {term}: no meeting {n} (miss {misses}/{stop_after_misses})")
                 if misses >= stop_after_misses:
-                    log(f"  {series} {term}: stopping after {n - misses} meetings")
+                    last_n = n - misses
+                    log(f"  {series} {term}: stopping after {last_n} meetings")
+                    if i != last_index and key not in closed_terms:
+                        on_term_closed(key, last_n)
                     break
                 continue
             misses = 0
@@ -293,13 +318,40 @@ def cached_agendas(agenda_dir) -> dict:
     return {p.stem: p.read_text(errors="replace") for p in sorted(root.glob("*.html"))}
 
 
+def _closed_terms_path(agenda_dir) -> pathlib.Path:
+    return pathlib.Path(agenda_dir) / ".closed_terms.json"
+
+
+def _load_closed_terms(agenda_dir) -> dict:
+    """A historical term's confirmed miss boundary, `{"EP2018-2022": 27}`-shaped (#177).
+
+    Missing or corrupt reads as empty rather than raising: this is a resumability cache, not
+    a record — losing it costs one term's worth of miss-probing on the next run, exactly the
+    pre-#177 behaviour, never a wrong discovery.
+    """
+    path = _closed_terms_path(agenda_dir)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
 def scrape_agendas(agenda_dir, *, virtual_display: bool = False, log=lambda _m: None,
                    term_starts) -> dict:
     """Discover and cache every agenda, returning {reference: html}.
 
     Resumable and safe to re-run: an agenda already on disk is never refetched, so a second
-    run costs only the probes past the last meeting. Only misses and new meetings hit the
-    network.
+    run costs only the probes past the last meeting — but "the last meeting" is only ever
+    moving for the CURRENT term. Every earlier term_starts entry is a closed council term (a
+    newer one already follows it in the list, which only happens once the term it precedes has
+    ended), so its miss boundary is permanent. Before #177 nothing remembered that, and every
+    run re-probed every closed term's dead miss range on live network requests, forever —
+    for the EP body alone, most of a nightly nine-figure minute count. `.closed_terms.json`
+    in `agenda_dir` records each closed term's confirmed last meeting the first time
+    `discover_meetings` finds it, so later runs skip straight to it. The one term that can
+    never be cached this way is whichever is LAST in `term_starts` — see `discover_meetings`.
 
     `term_starts` is the committee's term list (e.g. `zoo_board.ZB_TERM_STARTS`); the Bid
     Award Panel is abolished, so no in-repo default remains. Forwarded to
@@ -308,6 +360,11 @@ def scrape_agendas(agenda_dir, *, virtual_display: bool = False, log=lambda _m: 
     """
     root = pathlib.Path(agenda_dir)
     root.mkdir(parents=True, exist_ok=True)
+    closed_terms = _load_closed_terms(agenda_dir)
+
+    def _persist_closed(key: str, last_n: int) -> None:
+        closed_terms[key] = last_n
+        _closed_terms_path(root).write_text(json.dumps(closed_terms))
 
     with agenda_fetcher(virtual_display=virtual_display) as fetch_live:
         def fetch(meeting: str) -> str:
@@ -321,7 +378,8 @@ def scrape_agendas(agenda_dir, *, virtual_display: bool = False, log=lambda _m: 
                 cached.write_text(match.group(1) if match else html)
             return html
 
-        return discover_meetings(fetch, log=log, term_starts=term_starts)
+        return discover_meetings(fetch, log=log, term_starts=term_starts,
+                                 closed_terms=closed_terms, on_term_closed=_persist_closed)
 
 
 def parse_agenda_pdfs(html: str, meeting: str) -> list[dict]:


### PR DESCRIPTION
Closes #177.

## Two real costs, not just a reporting nuisance

### EP/Zoo re-probed every closed council term's dead miss range, every night, forever

`discover_meetings` walks each `term_starts` entry until it hits `stop_after_misses`
consecutive misses. That's correct and necessary for the CURRENT term — new meetings keep
appearing there. But **every entry except the last is a closed council term by construction**:
a newer entry only exists in the list once the term it precedes has already ended, so it can
never produce another meeting. Nothing remembered that, so every run re-walked into the same
dead miss range on live browser navigations — for the EP body alone (1 closed term), most of a
nightly's agency-capture minutes; for Zoo (2 closed terms), more.

`discover_meetings`/`scrape_agendas` now persist a closed term's confirmed last meeting to
`.closed_terms.json` in the body's agenda dir the first time it's found, and skip straight to it
on every later run — never probing past it again. Only the LAST `term_starts` entry is exempt
(and a caller-side bug that wrote a closed-entry for it is defended against and ignored, tested
explicitly).

**Live-measured** against real cached agendas (production `agencies/` copied into a scratch data
dir, `~/tb-data` untouched):

| body | cold run (establishes boundary) | next run |
|---|---|---|
| EP (1 closed term) | 55s | **15s** |
| Zoo (2 closed terms) | 37s | **20s** |

The residual time is the still-open term's own mandatory miss probe plus Chromium launch —
inherent, not something #177 can remove.

### Award Summary Forms were re-parsed via pdfplumber every night for +0 new bids

`store_award_summary_bids` opened and table-extracted all 229 archived forms every run
regardless of whether anything was new — reported in the issue as `1102 bids stored · 41s`
nightly with the `bid` table flat since 2026-07-22.

A form on disk cannot change, so a form that already produced `source='award_summary'` bid rows
can only ever re-derive the same rows. The function now skips such a form **before** opening the
PDF. The one form that's REFUSED (a declared-count mismatch, doc `5346602194`) has no bid rows to
key the skip on, so it's retried every run unchanged from before — correct, since a parser fix
should pick it up on the very next run rather than needing a manual reset.

**Verified** against a copy of the production store: 219 of 229 forms skipped, 0 new bids, 0
change to the `bid` table. The Slack "award summaries" step detail is a side effect of the fix
rather than a separate change: `store_award_summary_bids`'s return value is now the night's real
delta, so `✅ award summaries  0 bids stored` replaces the misleading corpus total on a quiet
night.

## The reporting fix caught a bug in itself

The issue's first ask — "report new vs. re-stored distinctly" — is done for the per-body
`_capture_agency_bodies` print lines (previously journal-only noise, e.g.
`ep stored : 107 solicitations, 107 awards, 115 bids` reading as growth every single night).

Getting there caught a real bug before it shipped. My first draft computed the delta as
`got["awards"] - before`, where `got["awards"]` comes from `store_ep_reports` et al. **But that
field counts REPORTS PROCESSED this call, not resulting rows** — a report upserts on
`native_ref` with `overwrite=True`, so an amendment report and its original can each increment
the loop count while collapsing into the same row. Live-measured: a full EP reparse processes
107 reports against a table holding 88 actual rows. `got["awards"] - before` computed
`107 - 88 = +19` on a run where the true row count hadn't moved at all — a fabricated growth
number in exactly the kind of place the issue is about.

Fixed to diff two independent `SELECT COUNT(*) FROM agency_award WHERE source=?` queries, taken
before and after the store call — immune to how many reports happened to write a row. Rerunning
the same scenario with the fix reports `awards (+0)`, matching the untouched table. A test
(`test_stored_line_delta_is_the_real_row_count_not_the_loop_count`) encodes this exact scenario
so it can't regress.

## Verification

- **822 tests passing** (807 + 15 new)
- Live runs against copies of the production store for EP scrape (cold + warm), Zoo scrape
  (cold + warm), and the award-summary skip — `~/tb-data` untouched throughout
- `docstring`/CLAUDE.md updated with the measured numbers and the loop-count-vs-row-count trap,
  so a future change to these delta lines has the failure mode on record

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W53WHx8mm2UHuLFAQWeF62
