### PR TITLE
fix(cli): tb export mentions agency buyers on an agency-only DB (#143)

### DIFF
--- a/scrapers/tests/test_cli_export.py
+++ b/scrapers/tests/test_cli_export.py
@@ -1,0 +1,32 @@
+"""`tb export`'s success line (#143).
+
+`counts['solicitation']` is the CITY SPINE alone. On a DB that has agency data (agency
+enrichment has run) but no City-spine `sync` data, the export correctly writes a full `buyers`
+section, but the success line read `Exported 0 solicitations to <path>` — indistinguishable from
+an export that genuinely did nothing. Realistically the deployed nightly always has City spine
+data, so this only bites an agency-only / test run.
+"""
+from toronto_bids import cli
+from toronto_bids.buyers import seed_buyers
+
+
+def _run_export(monkeypatch, conn, tmp_path, capsys):
+    from toronto_bids import config
+    monkeypatch.setattr(cli, "_open_db", lambda: conn)
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    assert cli.main(["export"]) == 0
+    return capsys.readouterr().out
+
+
+def test_an_agency_only_db_mentions_the_buyers_it_actually_exported(conn, monkeypatch, tmp_path, capsys):
+    seed_buyers(conn)              # agency enrichment has run; tb sync never has
+    out = _run_export(monkeypatch, conn, tmp_path, capsys)
+    assert "0 solicitations + 3 agency buyer(s)" in out
+
+
+def test_a_plain_city_spine_export_is_unchanged(conn, monkeypatch, tmp_path, capsys):
+    """The overwhelming majority of exports: no agency enrichment has ever run, so `buyer` is
+    empty and the line must read exactly as it always has -- no '+0 agency buyer(s)' clutter."""
+    out = _run_export(monkeypatch, conn, tmp_path, capsys)
+    assert "Exported 0 solicitations to" in out
+    assert "agency buyer" not in out

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -325,7 +325,15 @@ def _cmd_export(args) -> int:
         write_csv_zip(conn, out_path.parent / "bids-csv.zip")
         print(f"Wrote Parquet + CSV bulk exports to {out_path.parent}")
         counts = db.counts(conn)
-        print(f"Exported {counts['solicitation']} solicitations to {written}")
+        # `counts['solicitation']` is the CITY SPINE alone -- on an agency-only DB (agency
+        # enrichment has run, `tb sync` never has) it reads 0 even though the export's `buyers`
+        # section wrote real data, making a successful export look like it did nothing (#143).
+        # `buyer` is only ever non-zero once agency enrichment has seeded it, so a plain
+        # City-spine export (the overwhelming majority) is unaffected.
+        buyers = counts.get("buyer", 0)
+        detail = (f"{counts['solicitation']} solicitations + {buyers} agency buyer(s)"
+                 if buyers else f"{counts['solicitation']} solicitations")
+        print(f"Exported {detail} to {written}")
         print(f"Wrote schema dictionary to {schema_path}")
     finally:
         conn.close()


### PR DESCRIPTION
Closes #143.

## The bug

`counts['solicitation']` in `_cmd_export`'s success line counts the City spine alone. On a DB
that has agency data (`agency_solicitation`/`agency_award`/`agency_bid` + the export `buyers`
section) but no City-spine `sync` data, `tb export` printed `Exported 0 solicitations to <path>`
— even though it correctly wrote a full `buyers` section. A successful export read as though it
did nothing.

## The fix

Matches the issue's own suggested wording: mention the agency `buyer` count alongside
solicitations when it's non-zero.

```python
buyers = counts.get("buyer", 0)
detail = (f"{counts['solicitation']} solicitations + {buyers} agency buyer(s)"
         if buyers else f"{counts['solicitation']} solicitations")
print(f"Exported {detail} to {written}")
```

`buyer` is only ever non-zero once agency enrichment has seeded it (`seed_buyers`), so the plain
City-spine case — the overwhelming majority of real exports — is completely unaffected: no
`+0 agency buyer(s)` clutter on a run that's never touched agencies.

## Verification

Live, both cases:

```
agency-only DB:  Exported 0 solicitations + 3 agency buyer(s) to .../bids.json
plain fresh DB:  Exported 0 solicitations to .../bids.json
```

**2 new tests**, confirmed genuinely red against the pre-fix code by reverting the fix in place:
the agency-only assertion fails with exactly the string this issue reports, while the plain-DB
test stays green throughout — proving the fix is targeted. Restored after.

**776 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W53WHx8mm2UHuLFAQWeF62
