### PR TITLE
fix(cli): enrich-agencies reports distinct rows, not upsert counts (#142)

### DIFF
--- a/scrapers/tests/test_cli_agencies.py
+++ b/scrapers/tests/test_cli_agencies.py
@@ -1,56 +1,86 @@
 from toronto_bids import cli
 from toronto_bids.buyers import seed_buyers
-from toronto_bids.models import AgencyAward
+from toronto_bids.models import AgencyAward, AgencySolicitation
 from toronto_bids.store import db
 
 
-# --- reporting new-vs-total distinctly (#177) ---------------------------------------------
+# --- reporting new-vs-total distinctly (#177), over DISTINCT ROWS (#142) -------------------
 
-def test_stored_line_reports_the_delta_beside_the_total():
-    """A quiet night's `107 solicitations, 107 awards, 115 bids` used to be indistinguishable
-    from a real one without cross-referencing the aggregate delta three lines down (#177)."""
-    line = cli._stored_line("trca", {"solicitations": 107, "awards": 107, "bids": 115},
-                            before=(88, 115), after=(88, 115))
-    assert "107 awards (+0)" in line
+# The live EP measurement this whole line exists to report honestly: 107 upserts issued,
+# against 74 solicitation rows and 88 award rows once the tables deduped.
+_EP_GOT = {"solicitations": 107, "awards": 107, "bids": 115}
+_EP_ROWS = (74, 88, 115)
+
+
+def test_stored_line_reports_distinct_rows_not_the_upsert_count():
+    """The #142 complaint: `107 solicitations` sent a reader looking for 107 rows and finding
+    74. The leading numbers must be what the tables actually hold."""
+    line = cli._stored_line("ep", _EP_GOT, before=_EP_ROWS, after=_EP_ROWS)
+    assert "74 solicitations (+0)" in line
+    assert "88 awards (+0)" in line
     assert "115 bids (+0)" in line
+    assert "107 solicitations" not in line
+    assert "107 awards" not in line
+
+
+def test_stored_line_still_surfaces_the_upsert_totals_but_labelled():
+    """"0 upserts" and "107 upserts that all deduped" are very different runs and otherwise
+    look identical from a flat (+0) — so the upsert count stays, named for what it is."""
+    line = cli._stored_line("ep", _EP_GOT, before=_EP_ROWS, after=_EP_ROWS)
+    assert "[upserts 107/107/115]" in line
 
 
 def test_stored_line_shows_growth_when_there_is_any():
     line = cli._stored_line("trca", {"solicitations": 108, "awards": 108, "bids": 118},
-                            before=(88, 115), after=(89, 118))
-    assert "108 awards (+1)" in line
+                            before=(70, 88, 115), after=(71, 89, 118))
+    assert "71 solicitations (+1)" in line
+    assert "89 awards (+1)" in line
     assert "118 bids (+3)" in line
 
 
 def test_stored_line_delta_is_the_real_row_count_not_the_loop_count():
-    """`got["awards"]` counts REPORTS PROCESSED this call, not resulting rows — a report is
-    upserted keyed on native_ref, so an amendment and its original can both increment the
-    loop count while collapsing into the same row. Live-measured: a full EP reparse processed
-    107 reports against a table holding 88 rows; `got["awards"] - before[0]` would have
-    reported a fictitious +19. The delta must come from two real row-count queries, not from
-    `got` at all (#177)."""
-    line = cli._stored_line("ep", {"solicitations": 107, "awards": 107, "bids": 115},
-                            before=(88, 115), after=(88, 115))
+    """The delta must come from two real row-count queries, not from `got` at all — using the
+    loop count would have reported a fictitious +19 on the EP reparse (#177)."""
+    line = cli._stored_line("ep", _EP_GOT, before=_EP_ROWS, after=_EP_ROWS)
     assert "awards (+0)" in line
+    assert "+19" not in line
 
 
 def test_stored_line_omits_bids_for_a_body_with_no_bid_table():
-    """Zoo's store_zoo_reports returns no 'bids' key — the line must not fabricate one."""
-    line = cli._stored_line("zoo", {"solicitations": 5, "awards": 5}, before=(5, 0), after=(5, 0))
+    """Zoo's store_zoo_reports returns no 'bids' key — the line must not fabricate one, and
+    the upsert bracket must not invent a third figure either."""
+    line = cli._stored_line("zoo", {"solicitations": 5, "awards": 5},
+                            before=(4, 4, 0), after=(4, 4, 0))
     assert "bids" not in line
+    assert "[upserts 5/5]" in line
 
 
 def test_source_row_counts_are_scoped_to_one_board(conn):
     ids = seed_buyers(conn)
+    db.upsert_row(conn, AgencySolicitation(
+        buyer_id=ids["trca"], native_ref="1", title=None, status=None, posted_date=None,
+        closing_date=None, portal_url=None, source="trca_board"), overwrite=True)
     db.upsert_row(conn, AgencyAward(
         buyer_id=ids["trca"], native_ref="1", supplier_name_raw="X", award_amount=None,
         value_confidential=0, award_date=None, source="trca_board"), overwrite=True)
     db.upsert_row(conn, AgencyAward(
         buyer_id=ids["toronto-zoo"], native_ref="1", supplier_name_raw="Y", award_amount=None,
         value_confidential=0, award_date=None, source="zoo_board"), overwrite=True)
-    assert cli._source_row_counts(conn, "trca_board") == (1, 0)
-    assert cli._source_row_counts(conn, "zoo_board") == (1, 0)
-    assert cli._source_row_counts(conn, "ep_board") == (0, 0)
+    assert cli._source_row_counts(conn, "trca_board") == (1, 1, 0)
+    assert cli._source_row_counts(conn, "zoo_board") == (0, 1, 0)
+    assert cli._source_row_counts(conn, "ep_board") == (0, 0, 0)
+
+
+def test_source_row_counts_dedup_the_way_the_tables_do(conn):
+    """The whole reason #142 exists: two upserts sharing a `native_ref` are ONE row. This is
+    what makes the printed number differ from the upsert count, so pin it directly."""
+    ids = seed_buyers(conn)
+    for title in ("first report", "its amendment"):
+        db.upsert_row(conn, AgencySolicitation(
+            buyer_id=ids["trca"], native_ref="10039751", title=title, status=None,
+            posted_date=None, closing_date=None, portal_url=None,
+            source="trca_board"), overwrite=True)
+    assert cli._source_row_counts(conn, "trca_board")[0] == 1     # 2 upserts -> 1 row
 
 
 # --- --only ep --portal must skip cleanly, not KeyError (#152) ---------------------------

--- a/scrapers/toronto_bids/cli.py
+++ b/scrapers/toronto_bids/cli.py
@@ -751,32 +751,47 @@ def _cmd_nightly(args) -> int:
     return 1 if failures else 0
 
 
-def _source_row_counts(conn, source: str) -> tuple[int, int]:
-    """(agency_award, agency_bid) rows currently attributed to one board's `source` value."""
-    a = conn.execute("SELECT COUNT(*) FROM agency_award WHERE source=?", (source,)).fetchone()[0]
-    b = conn.execute("SELECT COUNT(*) FROM agency_bid WHERE source=?", (source,)).fetchone()[0]
-    return a, b
+def _source_row_counts(conn, source: str) -> tuple[int, int, int]:
+    """(agency_solicitation, agency_award, agency_bid) rows attributed to one board's `source`.
 
-
-def _stored_line(label: str, got: dict, before: tuple[int, int], after: tuple[int, int]) -> str:
-    """'  trca stored : 446 solicitations, 693 awards (+0), 527 bids (+0)' (#177).
-
-    `got["awards"]`/`got["bids"]` count REPORTS PROCESSED this call, not resulting rows — a
-    report is upserted with `overwrite=True` keyed on `native_ref`, so an amendment report
-    and its original can both increment the loop count while collapsing into the same row.
-    Live-measured: a full EP reparse processed 107 reports against a table holding 88 rows,
-    which is exactly the gap `got["awards"] - before` would have reported as fictitious growth
-    (+19) had the delta been computed from the loop count instead of a second real query. The
-    delta here is `after - before` over `_source_row_counts` on BOTH sides — an actual row
-    count, immune to how many reports happened to write it. `got` is still what carries the
-    "reports processed" totals shown beside the delta. No "bids" key for a body with no bid
-    table (Zoo).
+    Distinct ROWS, which is what the tables actually hold — not the number of upserts issued to
+    write them. The two differ by design and by a lot: the tables dedup on
+    `(buyer_id, native_ref)` and the award line key, so a report and its amendment collapse into
+    one row (#142).
     """
-    line = (f"  {label} stored : {got['solicitations']} solicitations, "
-           f"{got['awards']} awards ({after[0] - before[0]:+d})")
+    def n(table):
+        return conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE source=?", (source,)).fetchone()[0]
+    return n("agency_solicitation"), n("agency_award"), n("agency_bid")
+
+
+def _stored_line(label: str, got: dict, before: tuple[int, int, int],
+                 after: tuple[int, int, int]) -> str:
+    """'  ep stored : 74 solicitations (+0), 88 awards (+0), 115 bids (+0)  [upserts 107/107/115]'
+
+    **The leading numbers are DISTINCT ROWS, never the upsert count (#142).** `got[...]` counts
+    upserts ISSUED this call, and the tables dedup on `(buyer_id, native_ref)` and the award
+    line key — so a report and its amendment, or two items sharing a fallback ref, collapse
+    into one row. Live-measured on EP: **107 upserts against 74 solicitation rows and 88 award
+    rows**. Printing the upsert count as though it were the table's contents is what sent a
+    reader looking for 107 rows and finding 74. The dedup is correct and intended; only the
+    messaging was wrong.
+
+    The upsert totals are still shown, in a trailing bracket that names them, because they are
+    a real diagnostic the row counts cannot give: "0 upserts" and "107 upserts that all
+    deduped" are very different runs and otherwise look identical from a flat `(+0)`.
+
+    The delta remains `after - before` over `_source_row_counts` (#177) — two real row-count
+    queries, immune to how many upserts happened to write them. No "bids" key for a body with
+    no bid table (Zoo).
+    """
+    line = (f"  {label} stored : {after[0]} solicitations ({after[0] - before[0]:+d}), "
+           f"{after[1]} awards ({after[1] - before[1]:+d})")
+    upserts = [str(got["solicitations"]), str(got["awards"])]
     if "bids" in got:
-        line += f", {got['bids']} bids ({after[1] - before[1]:+d})"
-    return line
+        line += f", {after[2]} bids ({after[2] - before[2]:+d})"
+        upserts.append(str(got["bids"]))
+    return line + f"  [upserts {'/'.join(upserts)}]"
 
 
 def _capture_agency_bodies(conn, ids, *, bodies, fetch, scrape, virtual_display, out):


### PR DESCRIPTION
Closes #142.

## The bug

`tb enrich-agencies` printed the number of upserts **issued** as though it were the table's
contents. The tables dedup on `(buyer_id, native_ref)` and the award line key — a report and its
amendment, or two items sharing a fallback ref, collapse into one row — so a reader who saw
`107 solicitations` went looking in the DB and found 74.

The dedup is correct and intended. Only the messaging was wrong.

## The fix

Took the issue's first option: **report distinct rows**. The leading figures now come from two
real row-count queries. #177 already made the *delta* honest this way; this is the same
correction applied to the totals sitting beside it.

The upsert counts are **kept**, in a trailing bracket that names them for what they are —
`0 upserts` and `107 upserts that all deduped` are very different runs, and a flat `(+0)` alone
cannot tell them apart. That diagnostic would have been lost by simply swapping the numbers out.

`_source_row_counts` gains solicitations (it counted awards/bids only), so all three figures come
from the same source-scoped query rather than mixing sources.

## Verification

Run against a copy of the production store, with every figure checked independently against the
DB:

```
trca stored : 225 solicitations (+0), 439 awards (+0), 408 bids (+0)  [upserts 446/693/527]
zoo stored  : 46 solicitations (+0), 53 awards (+0)                   [upserts 58/58]
ep stored   : 74 solicitations (+0), 88 awards (+0), 115 bids (+0)    [upserts 107/107/115]
```

```
trca_board   DB rows: 225 solicitations, 439 awards, 408 bids
zoo_board    DB rows: 46 solicitations, 53 awards, 0 bids
ep_board     DB rows: 74 solicitations, 88 awards, 115 bids
```

Exact match on all nine figures. **EP is the 107-vs-74 case from the issue** — and the gap turned
out wider than reported: **TRCA was claiming 446 solicitations for a table holding 225.**

**778 tests passing** — 2 new (distinct-rows-not-upserts; the dedup that causes the gap, pinned
directly by upserting two rows under one `native_ref` and asserting one row results), and 4
updated to the widened 3-tuple `_source_row_counts` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W53WHx8mm2UHuLFAQWeF62
