### PR TITLE
Read EP bid tables as cells (#151); audit the remaining regex parsers (#203)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,51 @@ Order in `default_sources()` matters: `schema_check` first (drift detection), th
 
 Normalizers read feed fields with `raw.get(...)`, so a field the City renames silently NULLs a column forever. `schema_check.py` declares exactly the fields the OData and CKAN normalizers read and samples those five feeds on each sync, failing loudly on missing keys. When a normalizer starts reading a new field, add it to the declared sets in the same change. Ariba and suspended-firms are outside its coverage (suspended-firms parsing raises on header drift itself; Ariba field drift is unguarded).
 
+### Parsing discipline: prove clean extraction, or come back — never chase edge cases
+
+Scraped PDFs are messy enough to invite an endless patch-the-next-case loop, and this repo has
+run that loop more than once. The rule:
+
+**When an extractor is wrong, do not fix the failing case. Ask whether the corpus can be
+extracted cleanly AT ALL by a small set of statable rules — and if the answer looks like no,
+STOP AND COME BACK TO THE HUMAN rather than grinding.** "No clean extraction exists here" is a
+legitimate and complete finding: #83 reached it for council staff reports, and it stands. A
+parser held together by per-document exceptions is not a finding, it is a liability.
+
+How the question gets answered — the method is what makes the answer trustworthy:
+
+- **Measure against ground truth the documents themselves carry, never against the parser being
+  replaced.** The incumbent's output is not a baseline; it is the thing under suspicion. Award
+  Summary Forms state `Number of Bids Received` (#116); EP board reports state "four (4)
+  submissions were received, three (3) of which were compliant" (#151). Compare to *that*.
+- **Count the rules, and watch whether the count moves.** *Convergent* means each new wrinkle
+  collapses into a rule already written: #151's two page-break shapes — a caption stranded at a
+  page foot, and rows continuing overleaf as a separate headerless table object — are one event
+  and one walk, and its `Non-compliant`-in-the-price-column case turned out to be #94's existing
+  rule rather than a new one. *Divergent* means every fix reveals a wrinkle somewhere else and
+  the rule count climbs — #151's four rejected regex attempts, which is the named signature of
+  an architectural problem rather than a patchable one. **Divergence is the signal to stop and
+  re-ask the question, not to write rule five.**
+- **Refuse and log; never guess.** A refused row is a known gap someone can act on; a guessed row
+  is silent corruption that reads as data. #94 refuses an unequal column pair, #96 prints its 22
+  unkeyed appendices, #116 refuses a form that under-parses its own declared count.
+- **A disagreement with ground truth is often the DOCUMENT's defect, and that is a finding, not
+  something to parse around.** Of the three EP reports whose extracted count still disagrees,
+  two tabulate only the compliant subset of the bids they declare and one carries a malformed
+  price in the City's own PDF (`$1,479,386,.57`). Adding rules to absorb those would be inventing
+  data; the archive records what the City published.
+
+Worked example, #151 (measurement only — the EP parser switch has not landed): four rules
+(caption anchor / page-break walk / row = name + price-or-outcome / normalize) over the 47 EP
+reports carrying a bid table gave 47/47 tables found, 153 rows, **0 junk rows, 0 duplicates**,
+and **32/35** exact agreement with the reports' own declared counts, with all three residuals
+traced to the documents. The rule count started at four and finished at four.
+
+And the outcome is genuinely per-corpus, so it is measured each time: the rule is **"read cells
+where the PDF HAS cells"** (#116), never "pdfplumber is better". Ruled tables in 229/229 Award
+Summary Forms and 47/47 EP board reports — but only 13–20/229 council staff reports, where cells
+measured *worse* and regex is correct and stays.
+
 ### Linking
 
 - Everything competitive is keyed on the normalized 10-digit `document_number` (`linking/document_number.py`: strip non-digits, require exactly 10, reject a placeholder denylist). Non-competitive contracts live in a separate keyspace (`workspace_number`) — there is no join between them. **A third keyspace** is `composite_award.call_number` (`linking/call_number.py`, #96): 2009-2012 awards predate Ariba and identify themselves by Call Number, so they join to neither of the other two. Two shapes cover all 1,229 in the corpus — `3905-10-0097` (RFQ/RFP) and `317-2010` (Tender Call) — and the prefix vocabulary ("Request for Quotation", "RFQ", "Tender Call No.") carries no information. Match on the shape, never on the prefix, and beware the trailing `, Contract No. 10TE-17WS`, which is a *different* identifier.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,32 @@ procurement awards** (WSIB safety, status updates, governance), so the parser an
 between the winner and the amount ("to WINNER **for the <project>** in the amount of $X"), so
 the winner regex is EP-specific, not the shared Zoo pattern. Amount/confidential primitives are
 shared via `sources/agency_report.py`. EP is the first agency source with a structured bidder
-price table (Table 1 → `agency_bid` with prices). On-demand (`--only ep --scrape`), never on
+price table (Table 1 → `agency_bid` with prices), and **that table is read as CELLS, not regex
+over `pdftotext` (#151/#203)** — ruled tables in **47/47** of the reports that carry one, the
+#116 Award Summary profile rather than the #83 staff-report profile. `ep_bid_tables` does the
+I/O via `sources/pdf_tables.py`; `parse_ep_bid_table(tables)` is pure over the cells, so its
+fixtures are JSON rows and the tests need neither pdfplumber nor a PDF. Four rules, and the
+count held at four through the measurement — **two wrinkles that looked new both collapsed into
+rules already written**: a bid table breaks across pages in two shapes (caption stranded at a
+page foot, `131331`; rows continuing overleaf as a separate headerless table object, `244929`,
+7 of 9 rows) which are one event and one walk, and an OUTCOME in the price column
+(`*Non-compliant`) is still a bid with a NULL price, which is #94's BD-agenda rule verbatim.
+The header row is rejected **structurally** — column 1 holds a price — never by a denylist,
+because column 0 is variously `Bidder`/`Tenderer` and column 1 variously `Bid Price Received`/
+`Base Bid Price`/`Initial Base Bid Price Received`. The switch removed 19 contaminated rows (13
+prose phantoms, 6 `Table 2` duplicates) and **recovered 14+ real bidders the regex silently
+dropped**: numeric-leading firm names (the #87/#116 lesson), prices carrying a leading marker
+(`*$792,900.00`, which cost `244900` its *winning* bidder) and prices published without cents.
+**`agency_bid` is now DERIVED, rebuilt per source from the held PDFs on every store pass**
+(`db.rebuild_agency_bids`) — the same sanctioned exception to "rows are never deleted" that
+`build_supplier_dimension` takes, and a permanent contract rather than a migration, so every
+future parser fix self-heals. It derives first and deletes only on success, so a machine without
+the PDFs deletes nothing. **The other three #203 candidates were measured and NOT switched** —
+TRCA (its documents are whole meeting packages: 30 of 55 bid tables cannot be attributed to a
+solicitation, and cells yield 356 rows against the incumbent's 527), the Zoo (6 ruled bid tables
+in 859 documents) and committee reports (whose money-bearing tables are budget cash-flow tables,
+where a "first table with money" rule would read years and contract terms as bidders). Do not
+re-litigate those without new evidence. On-demand (`--only ep --scrape`), never on
 the browser-free nightly path. The pre-2019 City-spine EP slice (Client_Division "Exhibition
 Place") and these post-2019 Board-of-Governors awards are separate coexisting keyspaces (#130).
 **A confidential report is kept only when its stated MFIPPA reason is commercial/financial

--- a/docs/superpowers/notes/2026-07-28-gliner2-trca-bakeoff-criterion.md
+++ b/docs/superpowers/notes/2026-07-28-gliner2-trca-bakeoff-criterion.md
@@ -1,0 +1,67 @@
+# GLiNER2 vs the incumbent regex on TRCA prose bidders — criterion, fixed in advance
+
+Written **before** installing anything or looking at any output, per CLAUDE.md's
+"Parsing discipline". Recording it first is what stops the result being chosen after the fact.
+
+## The question
+
+TRCA's bidders exist mainly in prose bullet lists. `#203` measured that cells cannot replace the
+regex there (356 rows vs the incumbent's 527, and 30 of 55 documents with a bid table cannot be
+attributed to a solicitation). The open question is whether a **local, CPU-bound extraction
+model** does better than the regex on the *prose*, which is where regex is weakest.
+
+Candidate: **GLiNER2** (Fastino Labs, Apache 2.0, 205M params, CPU-first). It is an *encoder*
+that tags spans in the input rather than generating text, so it cannot invent a bidder or a
+price. That property is why it is being tried ahead of any generative model.
+
+## Corpus and ground truth
+
+- **Population**: TRCA `agency_board` reports whose text carries the incumbent's bullet-list
+  anchor (`received from the following Proponent|vendor`) — **171 documents**, measured.
+- **Ground truth**: the report's own declared count — `"Three (3) proposals were received"` —
+  present on **128** reports corpus-wide. Ground truth comes from the documents, never from the
+  parser under test, and never from the incumbent.
+- **Input to the model**: the regex-narrowed span, not the whole document. TRCA documents run to
+  577 pages; the incumbent's anchor already locates the region, and reusing it keeps the
+  comparison about *extraction* rather than about retrieval.
+
+## Metrics
+
+1. **Count agreement** — extracted bidder count == declared count, per report. Primary.
+2. **Verbatim verification** — every extracted name and price must appear character-for-character
+   in the input span. Expected to be 100% by construction; measured anyway, because an assumed
+   safety property is not a safety property.
+3. **Superset check** — does GLiNER2 find the bidders the incumbent finds? Any incumbent bidder
+   it drops is a real loss and must be inspected individually.
+4. **Net-new** — bidders or prices GLiNER2 gets that the incumbent cannot. TRCA's 408 stored bids
+   currently carry **zero** prices, so prices are the obvious candidate gain.
+5. **Wall-clock** per document on this box (i3-13100, 4 cores, no GPU).
+
+## Switch criterion
+
+Adopt GLiNER2 for TRCA prose bidders **iff all four hold**:
+
+- (a) count agreement **≥** the incumbent's on the same 128 reports;
+- (b) **zero** verbatim-verification failures;
+- (c) **no real bidder lost** against the incumbent (every drop explained as incumbent
+  contamination, not as a miss);
+- (d) it delivers something the incumbent cannot — prices, or documents the incumbent misses.
+
+Otherwise: record the measurement, keep the regex, and do not re-litigate without new evidence.
+A negative result is a complete answer, exactly as #83's and #203's were.
+
+## Stop-and-ask gate
+
+**One** refinement pass on the schema (field names and descriptions). The rule-count analogue
+here is schema churn: if improving one report's output degrades another's, that is divergence —
+**stop, report, keep the regex.** No per-document prompt tuning; no threshold fitted to the
+failures. Tuning against the ground-truth set until it passes is not measurement, it is
+overfitting with extra steps.
+
+## Deployment constraint, decided in advance
+
+GLiNER2 pulls PyTorch (~2 GB). This project's core pipeline has no such dependency, and a
+`uv sync --locked` has already broken the nightly once by dropping optional deps. So even a
+*successful* result does **not** put torch on the nightly path: it would ship as an opt-in
+enrichment pass (the `enrich-council` pattern). The bake-off itself runs in a throwaway venv
+outside the project entirely — nothing is added to `pyproject.toml` unless it earns it.

--- a/docs/superpowers/notes/2026-07-28-gliner2-trca-bakeoff-result.md
+++ b/docs/superpowers/notes/2026-07-28-gliner2-trca-bakeoff-result.md
@@ -1,0 +1,91 @@
+# GLiNER2 vs the incumbent regex on TRCA prose bidders — result
+
+Criterion fixed in advance: `2026-07-28-gliner2-trca-bakeoff-criterion.md`. Nothing below was
+chosen after seeing the numbers, except where explicitly flagged.
+
+**Setup.** GLiNER2 1.3.2 (`fastino/gliner2-base-v1`, 205M, Apache 2.0), local weights, CPU only
+(i3-13100, 4 cores, torch pinned to 4 threads), throwaway venv outside the project. 144 TRCA
+documents carrying the incumbent's bullet anchor; ground truth is the reports' own declared bid
+counts (101 of them) and, for pairing, the ruled bid tables' own cells.
+
+## Headline: the safety argument I made before running this was WRONG
+
+The case for an extractive model over a generative one was: it tags spans in the input, so every
+output can be verified verbatim against the source, so it cannot fabricate. **That property
+holds and is worthless on its own.**
+
+| | |
+|---|---|
+| verbatim verification failures | **0** |
+| (bidder, price) pairs **correct** | **29 / 80 — 36%** |
+
+Every name is real. Every price is real. **64% of the relations between them are fabricated**,
+and verbatim checking cannot detect any of it. A bid record is a *relation*, and a relation has
+no verbatim existence in the text to check against.
+
+The mechanism, from `DocumentId=10725`: the model emitted names in **bullet-list order**
+(alphabetical, as the prose lists them) and paired them against prices in **table order**
+(ascending). Two orderings, zipped positionally. It assigned `$548,415` to
+`CDR Young's Aggregates Inc.` — a firm that was **disqualified and had no price at all**.
+
+Errors are not near-misses:
+
+```
+Doornekamp Construction  -> got '$ 209,650'   truth '$1,032,930'
+Glenn Windrem Trucking   -> got '$ 633,465'   truth '$245,105'
+AVI-SPL Canada Ltd.      -> got '$976,000'    truth '$1,155,960'
+```
+
+This is #94's lesson — *pairing is positional, so one stray line misattributes every bid after
+it* — arriving from a completely new direction. #94 and #116 solved it by **refusing an unequal
+pair rather than guessing**. GLiNER2 has no such refusal: it always produces a pairing.
+
+## Scores against the criterion
+
+| clause | result |
+|---|---|
+| (a) count agreement ≥ incumbent | **PASS** — 46/101 vs 43/101 (structured), 49/101 vs 43/101 (names-only) |
+| (b) zero verbatim failures | **PASS** — 0 structured, 1 names-only |
+| (c) no real bidder lost | **FAIL** — misses real incumbent bidders, e.g. 5 in `18386` |
+| (d) delivers what the incumbent cannot | **FAIL** — the only candidate gain is prices, and prices are 64% fabricated |
+
+**Verdict: do not adopt for (bidder, price) extraction.** The one capability it adds over the
+incumbent is the one it gets wrong, in a way no cheap verifier can catch.
+
+Cost, for the record: 0.38 s/doc names-only, 0.5 s/doc structured, ~2 s model load, on CPU. Speed
+was never the problem.
+
+## The refinement pass, and a bug in it worth recording
+
+The criterion allowed one refinement. Chosen **before** seeing the baseline: names only, no price
+relation — because all 408 stored TRCA bids carry `bid_price` NULL, so names are the incumbent's
+actual job, and a flat list has no relation to fabricate.
+
+**The first run of it was invalid and the invalid numbers were nearly reported as a GLiNER2
+failure.** It returned `0/101` and 144 verbatim failures — because `extract_entities` returns
+`{"entities": {label: [names]}}` and the harness flattened one level too few, emitting the label
+string itself as a "name", exactly one per document. That signature (a round number equal to the
+document count) is what gave it away. Corrected shape, re-run: **49/101 vs the incumbent's
+43/101**, 981 rows vs 527, 1 verbatim failure.
+
+## One genuinely open question, deliberately NOT pursued
+
+Names-only found bidders in documents where the incumbent returns **nothing** — `10725` and
+`10947` both yield 5 real firms from GLiNER2 and 0 from the regex, because `parse_trca_report`
+is gated on finding a solicitation reference first. That is a real coverage gap and a plausible
+criterion-(d) gain.
+
+**It is unverified and must not be reported as a gain.** The 981-vs-527 row difference has had
+**no precision check** — GLiNER2 may equally be picking up consultants, City staff, or
+non-bidding firms named nearby. Establishing that would be a second refinement pass, past the
+gate, so it stops here. It is a reason to look again, not a conclusion.
+
+## What this says about local models here generally
+
+Nothing about GLiNER2 disqualifies local CPU inference as an approach; the model reads names
+well and costs almost nothing. The finding is narrower and more useful:
+
+**Where the data is a relation, an extractive model's safety property does not apply, and this
+archive's corpora are almost entirely relations** — bidder↔price, table↔solicitation,
+award↔supplier. Any future local-model work here has to be scored on **relation** accuracy
+against independent ground truth, never on whether the extracted strings appear in the source.

--- a/docs/superpowers/notes/2026-07-28-h2-drift-robustness-result.md
+++ b/docs/superpowers/notes/2026-07-28-h2-drift-robustness-result.md
@@ -68,3 +68,31 @@ Backlog is 6,150 documents, one-time, resumable.
   229/229).
 
 Testing that needs GGUF + llama.cpp; the transformers path will not run a 14B at usable speed.
+
+## Addendum: the same experiment at 14B (2026-07-29)
+
+Identical harness, identical 15 docs / 51 rows, so directly comparable. Qwen3-14B-Q4_K_M via
+llama.cpp, 4 threads, schema-constrained. ~31 s/doc, 2,792 s total.
+
+| condition | regex | 14B | vs baseline |
+|---|---|---|---|
+| baseline | 100% | **100%** (51/51) | — |
+| `rename_header` | 100% | **100%** | +0% |
+| `reorder_columns` | **0%** | 96% | −4% |
+| `currency_suffix` | **12%** | **100%** | +0% |
+| `extra_column` | **0%** | **100%** | +0% |
+
+**Both hypotheses pass at 14B.** Accuracy is archive-grade on this corpus (51/51 exact, 52
+emitted against 51 truth — precision essentially clean), and worst-case drift degradation is
+−4% against regex's −88% to −100%.
+
+This confirms the 1.7B reading: the 84% ceiling was model size, not the approach. It also
+confirms the volume arithmetic — 31 s/doc against under a dozen documents a day is roughly
+**5 minutes a night**.
+
+**What this does NOT establish.** The scope is one corpus (EP), 15 documents, 51 rows — ruled
+tables, one document per award. The two structurally harder cases are untested at 14B:
+`award_summary` (212 docs / 1,120 rows) and above all TRCA, where a document is a *meeting
+package* holding many awards and the incumbent's bidders live in prose. H1 (generality across
+corpora) was planned alongside H2 and has not been run. An architecture decision on the strength
+of EP alone would be generalising from the easiest case.

--- a/docs/superpowers/notes/2026-07-28-h2-drift-robustness-result.md
+++ b/docs/superpowers/notes/2026-07-28-h2-drift-robustness-result.md
@@ -1,0 +1,70 @@
+# H2 — drift robustness: does a general LLM extractor survive reformatting that breaks regex?
+
+The load-bearing experiment for the general-extractor architecture. The maintainability argument
+("when the City changes formatting, bespoke parsers break and a general model adapts") is
+normally assumed. Here it is measured.
+
+**Setup.** 15 EP reports, 51 ground-truth rows (ground truth = `parse_ep_bid_table` on unmutated
+cells, validated in #151: 0 junk, 0 duplicates, 32/35 vs declared counts). Both extractors get
+byte-identical input. Model: Qwen3-1.7B, bf16, CPU (4 threads), **schema-constrained decoding**
+via outlines. ~23 s/doc. Mutations applied to the cell grid, each mimicking a plausible City
+reformat rather than an adversarial trick.
+
+| condition | regex | LLM | degradation (regex / LLM) |
+|---|---|---|---|
+| baseline | 100% | 84% | — |
+| `rename_header` (control) | 100% | 90% | +0% / +6% |
+| `reorder_columns` | **0%** | 69% | **−100%** / −16% |
+| `currency_suffix` | **12%** | 78% | **−88%** / −6% |
+| `extra_column` | **0%** | 84% | **−100%** / +0% |
+
+## Result: H2 passes clearly
+
+Three of four reformats destroy the parser — and it is the **hardened** cell parser built in
+#151, not a strawman regex. The same reformats cost the model 0–16 points. Inserting a single
+column takes regex from 100% to zero and costs the model nothing.
+
+## Caveats, both load-bearing
+
+- **Baseline accuracy is not archive-grade.** 84% recall, ~83% precision (8 of 51 rows missed,
+  ~9 emitted rows wrong). Too high an error rate for a public record. This is a model-size
+  finding, not an architecture finding: 1.7B was chosen to fit an existing venv.
+- **One invariant wobbled.** LLM recall ROSE 6 points on `rename_header`, and a rise under
+  mutation is exactly the signature that invalidated the first run. Benign explanation, and it
+  fits: the baseline error was the model reading the empty `Recommended Contract Price` column
+  instead of `Base Bid Price Received`, and renaming both to one unambiguous `Submitted Amount`
+  removes that ambiguity. 43→46 rows, not 12→41. Accepted, but recorded rather than forgotten.
+
+## Two invalid runs preceded this one — both caught by invariant, not inspection
+
+1. **Unconstrained JSON.** Qwen3-1.7B emitted malformed JSON (`["Powell Fence Limited",$1,484,065.00",...`),
+   the harness discarded it, and recall appeared to rise 18%→75% under corruption. Impossible,
+   therefore diagnostic. **Constrained decoding is a baseline requirement here, not an
+   optimisation** — the very first, simplest table produced broken quoting. With thinking mode
+   on, the same model read the table correctly in prose: comprehension was never the bottleneck,
+   serialisation was.
+2. **A patch that silently failed** while the relaunch fired anyway, re-running the old
+   unconstrained code.
+
+Plus, earlier in the same evaluation, a GLiNER2 harness bug returning `0/101` (144 rows for 144
+documents — the round number gave it away).
+
+**Three apparatus failures, zero of them the model's fault, each caught only because a number
+was impossible rather than merely wrong.** That is the most transferable finding here: a general
+extraction layer needs ground-truth invariants attached to every stage, and they are needed at
+least as much for the pipeline as for the model.
+
+## The decisive open question
+
+Robustness is established. Accuracy is a model-size problem, and the volume numbers say we can
+buy our way out: steady state is **under a dozen documents/day** (Award Summary Forms ~30/month,
+agency board reports ~400/year), so a 14B Q4 (~9 GB, fits 15 GB RAM) costs ~10 minutes a night.
+Backlog is 6,150 documents, one-time, resumable.
+
+- If a 14B reaches ~98% with 0–16% drift degradation → replacing ~2,000 lines of parser is
+  justified.
+- If it plateaus near 85% → hybrid: model for robustness-critical and long-tail sources,
+  deterministic parsers where they already measure clean (EP cells 100%, Award Summary Forms
+  229/229).
+
+Testing that needs GGUF + llama.cpp; the transformers path will not run a 14B at usable speed.

--- a/docs/superpowers/notes/2026-07-28-parser-audit-findings.md
+++ b/docs/superpowers/notes/2026-07-28-parser-audit-findings.md
@@ -1,0 +1,137 @@
+# Parser audit findings (#151, #203) — 2026-07-28
+
+Measured against each corpus's **own** ground truth, not against the parser being replaced.
+
+## EP board reports (#151) — SWITCHED to cells
+
+Four rules: caption anchor, page-break walk, row = name + price-or-outcome, normalise.
+
+| | |
+|---|---|
+| reports carrying a `Table 1` caption | 47 |
+| of those, reports where the anchor found the table | **47/47** |
+| rows extracted | **153** (regex: 143) |
+| rows failing a name sanity check | **0** |
+| duplicate rows within a report | **0** |
+| agreement with the reports' own declared bid counts | **32/35 exact** |
+| real bidders lost against the regex | **0** |
+| stored `agency_bid` rows | 115 → **129** |
+
+The rule count started at four and finished at four. Both wrinkles found mid-measurement
+collapsed into rules already written rather than adding new ones: the two page-break shapes
+(caption stranded at a page foot; rows continuing overleaf as a separate headerless table) are
+one event and one walk, and the `Non-compliant`-in-the-price-column case turned out to be #94's
+existing rule for the BD agendas, not a new one.
+
+**This is not a net removal.** 19 rows go (13 prose phantoms, 6 `Table 2` duplicates) and 14+
+real bidders the regex silently dropped come back: firms whose name begins with a digit
+(`1214592 Ontario Limited o/a Colonial Building Restoration`), firms whose price carries a
+leading marker (`*$792,900.00` — which cost `backgroundfile-244900` its *winning* bidder), and
+prices published without cents (`$4,365,534`, which the old `\.\d{2}` requirement read as "no
+bids at all").
+
+The 3 residual count disagreements are the City's documents, not the parser, and no rule was
+added for them: `238908` and `244923` say outright that they tabulate only the compliant subset
+(*"four (4) submissions were received, three (3) of which were compliant"*), and `254543`
+carries a malformed price in the City's own PDF (`$1,479,386,.57`).
+
+## TRCA eSCRIBE (#203) — NOT switched; regex is correct and stays
+
+The switch criterion fails on its strongest clause: **cells lose real rows.**
+
+| | |
+|---|---|
+| documents where the incumbent finds bidders | 144 |
+| tables pdfplumber finds in them | 3,233 |
+| of those, bid-shaped tables | **95** |
+| bid rows cells would yield | **356** |
+| bid rows the incumbent yields | **527** |
+
+The individual tables are excellent — `["Proponent", "Fee (Plus HST)"]`, cleanly ruled, exactly
+the shape that made EP worth switching. The corpus is the problem, and in a way EP never was:
+
+- **A TRCA "report" is a whole meeting package**, not one report. 85 tables across 102 pages,
+  6–8 separate bid tables per document, each belonging to a different item and a different
+  solicitation reference.
+- **Only 25 of the 55 documents holding a bid table have an unambiguous one-table-one-ref
+  mapping. 30 do not**, and attributing a table to the right solicitation inside a 102-page
+  package is a rule class EP never needed — locating the nearest preceding reference by page
+  position, with nothing published to confirm it against.
+- **89 of the 144 documents have no ruled bid table at all**, yet the incumbent extracts real
+  bidders from them via the prose bullet list. Those bidders exist only in prose.
+
+So switching would trade 527 attributable rows for 356 rows of which 30 documents' worth could
+not be attributed at all. The rule count also climbs rather than holding — a new attribution
+rule plus a fallback for the 89 prose-only documents — which is the divergence signal, not the
+convergence one. **Regex stays. Recorded so it is not re-litigated.**
+
+**One bounded follow-up worth its own issue, not done here.** TRCA's 408 stored bids currently
+carry **zero prices**. On the 25 documents with an unambiguous single bid table, cells could add
+prices with no attribution ambiguity at all. That is a real gain, but it is a different change
+with a different justification, and folding it into this audit would be exactly the scope creep
+the audit exists to avoid.
+
+## Zoo ZB legdocs (#203) — NOT switched; the structure is absent from the corpus
+
+| | |
+|---|---|
+| documents scanned | 859 |
+| tables pdfplumber finds | 2,713 |
+| of those, bid-shaped tables | **6** |
+| bid rows cells would yield | **17** |
+| bid rows stored today | 0 |
+
+**6 documents in 859 (0.7%)** carry a ruled bid table. This is the #83 profile exactly: the
+structure is missing from the documents, not from the parser, and no extractor invents it.
+
+The six that do exist are excellent — `PROPONENT / PROPOSAL PRICE / SCORE (OUT OF 150)`, with
+the evaluation score in its own column, which is richer than anything EP publishes. That is
+precisely why the number matters: the tables are not the problem, their absence is. Building a
+Zoo cell path for 17 rows across 859 documents is not worth a parser, and would land the same
+attribution question TRCA failed on. **Recorded, not built.**
+
+## Committee award reports (#203) — NOT switched, and a naive rule here would be harmful
+
+8 held reports; 7 carry a ruled table and 5 carry a money-bearing one. But **none of the
+money-bearing tables is a bid table.** They are budget cash-flow tables:
+
+```
+['Year', 'CH2M Hill\nCanada Limited', 'Stantec\nConsulting Limited', 'Total']
+['2023', '$3,821,411', '$4,142,471', '$7,963,882']
+
+['Term', 'Contract Total']
+['Initial Term - July 1, 2023 to December 31, 2023', '$5,309,334.15']
+```
+
+A "first ruled table containing money" heuristic — the one #151 explicitly declined to use, and
+validated against instead — would here produce **years and contract terms as bidders** and
+account numbers as suppliers. The single `Supplier`-headed table is a multi-winner *allocation*
+table (winners × per-year amounts), not a list of losing bidders.
+
+This corroborates #164 on its own terms: **RFTs and RFQs tabulate bids; RFPs narrate them**, and
+the committee tier is dominated by the latter. The existing `_BID_TABLE_ANCHORS` refusal is
+correct behaviour and stays.
+
+## Audit summary
+
+| corpus | held | ruled bid tables | verdict |
+|---|---|---|---|
+| EP board reports | 1,200 | **47/47** of those with a caption | **switched to cells** |
+| TRCA eSCRIBE | 3,411 | 95 tables, but 30 documents unattributable | regex stays |
+| Zoo ZB | 859 | **6** | regex stays |
+| committee awards | 8 | 0 real bid tables | regex stays |
+| council staff reports | 434 | 13–20/229 (#83, prior) | regex stays |
+| Award Summary Forms | 238 | 229/229 (#116, prior) | already cells |
+
+One of five candidates switched. That ratio is the finding, not a disappointment: "read cells
+where the PDF HAS cells" is a per-corpus fact, and four of these corpora do not have them.
+
+## Separate defect found while verifying EP — not fixed here
+
+Five EP reports parse a **correct** bid table whose rows are then discarded, because
+`parse_ep_report` — the *prose award-clause* parser, not the bid-table parser — refuses the
+report as a non-award: `157467` (4 bids), `167548` (5), `229322` (5), `244900` (4), `254716` (6).
+**24 real bids, correctly extracted, thrown away.**
+
+This is a defect in #130's award-clause regex, not in #151's table parser, and fixing it here
+would mean rewriting a prose parser under a ticket about tables. Worth its own issue.

--- a/docs/superpowers/notes/2026-07-29-h1-generality-result.md
+++ b/docs/superpowers/notes/2026-07-29-h1-generality-result.md
@@ -1,0 +1,63 @@
+# H1 — generality: can ONE extractor with no source-specific logic replace N bespoke parsers?
+
+Qwen3-14B-Q4_K_M, llama.cpp, schema-constrained, 4 CPU threads. 30 documents per corpus,
+scored against validated rows. **Input preparation deliberately generic** — pdfplumber tables
+where present, text windows otherwise, a money+company-suffix prefilter, 4 blocks max. No
+caption regexes, no bullet anchors: that code is what the architecture proposes to delete, so
+using it would beg the question. 8,586 s total (~95 s/doc).
+
+| corpus | structure | recall | precision |
+|---|---|---|---|
+| `ep_board` | short, one money table | **98%** | **98%** |
+| `award_summary` | ruled end-to-end, 1 doc = 1 award | 71% | 78% |
+| `trca_board` | meeting package, 1 doc = MANY awards | **29%** | **56%** |
+
+TRCA is scored on **names only** — all 408 stored TRCA rows have `bid_price` NULL, so there is
+no price ground truth. That is the *easier* task, and it still returns 29% recall with 44% of
+emitted names wrong.
+
+## Verdict: generality does NOT hold across structures
+
+A 69-point recall spread between EP and TRCA, from an identical model, prompt and retrieval
+path. What differs is document structure, not extraction difficulty.
+
+## But the failure is retrieval, not extraction
+
+The same model, same quantisation, scored **51/51 exact** on EP in H2 — when it was handed the
+correct table, caption-anchored. Here it must find the span itself, and:
+
+- **EP (98%)** — short documents, essentially one money table. Generic selection lands on it.
+- **`award_summary` (71%)** — the form is ruled *end to end*, so "tables containing money"
+  over-selects and the 4-block cap crowds out section 5. A retrieval-density problem.
+- **TRCA (29%)** — a document is a 100-to-577-page meeting package holding many awards. Four
+  generic blocks cannot cover it, and an extractor with no notion of *which* award it is reading
+  merges bidders across items, which is what 56% precision looks like.
+
+**Extraction is strong; generic retrieval is weak, and retrieval is precisely the code the
+architecture wanted to delete.**
+
+## Honest caveat on the two weak numbers
+
+The 4-block cap and the money-mention ranking are heuristics chosen in about ninety seconds, and
+`award_summary` is exactly the shape they penalise. Some of that 29-point gap is my retrieval
+heuristic, not the architecture. TRCA's gap is unlikely to be — no block cap saves a 577-page
+package with many awards.
+
+## Where this leaves the architecture
+
+Combined with H2 (drift robustness: −4% worst case vs regex's −88% to −100%):
+
+- **Full replacement is not supported.** TRCA at 29%/56% would silently corrupt the archive.
+- **The measured shape that IS supported**: deterministic *location* (captions, anchors — a
+  small fraction of the 6,195 lines) feeding LLM *extraction* (where nearly all 90 regexes and
+  the per-corpus lore live). Evidence: EP with deterministic location scored 51/51 exact and
+  degraded only 4% under reformatting that took regex to zero.
+- That hypothesis (**H3: deterministic locate + LLM extract**) is untested on `award_summary`
+  and TRCA. It is cheap to test — locators already exist for both — and it is the architecture
+  that would actually ship.
+
+## Cost note
+
+At ~95 s/doc with generic retrieval, a 6,150-document backlog is ~162 hours. With deterministic
+location (one block per document, ~31 s) it drops to ~53 hours. Steady state is unaffected
+either way — under a dozen documents a day is minutes.

--- a/docs/superpowers/notes/2026-07-29-h3-locate-plus-extract-result.md
+++ b/docs/superpowers/notes/2026-07-29-h3-locate-plus-extract-result.md
@@ -1,0 +1,72 @@
+# H3 — deterministic LOCATION + LLM EXTRACTION
+
+The architecture H1's failure pointed at: keep cheap deterministic location (captions, anchors),
+replace extraction (where nearly all 90 regexes live). Qwen3-14B-Q4_K_M, llama.cpp,
+schema-constrained, 30 documents per corpus, grouped PER DOCUMENT.
+
+| corpus | incumbent | H1 (generic locate) | H3 (deterministic locate) | `noloc` |
+|---|---|---|---|---|
+| `ep_board` | 100% | 98% / 98% | **99% / 98%** | 0 |
+| `award_summary` | 100% | 71% / 78% | **60% / 92%** | 0 |
+| `trca_board` | 100% | 29% / 56% | **45% / 49%** | 0 |
+
+(Ground truth is the incumbent parser's own validated output, so the incumbent is 100% by
+construction. TRCA is scored on names only — its 408 stored rows have no prices.)
+
+**`noloc` is 0 everywhere: every remaining failure is extraction, not retrieval.**
+
+## Verdict: LLM extraction matches the incumbent on ONE corpus of three
+
+- **EP (99%/98%)** — parity. A short document with one caption-anchored table.
+- **`award_summary` (60%/92%)** — precision improved over H1 as the span tightened, but recall
+  FELL to 60%. With the correct span, no truncation (5.4 rows/doc against a 40-row window), the
+  model misses 40% of the rows the existing cell parser gets.
+- **TRCA (45%/49%)** — better than H1 once the double-counting artifact was fixed, but **half
+  the emitted names are still wrong**, with the correct span in hand.
+
+## The likely reason, and it is the important part
+
+The value in these parsers is not the regex — it is the **documented exceptions**, each of which
+cost real measurement to discover:
+
+- #116: the City leaves numbered row `5.` blank; an RFP lists proponents with **no price at
+  all**; a multi-package cell holds a whole column and must be zipped positionally or refused.
+- #94: an OUTCOME in the price column (`Non-Compliant`) is still a bid.
+- #87/#116: `2489960 Ontario Inc.` is a real firm, not a leaked price.
+
+A general prompt does not reproduce these, and cannot: there is no way for a model to know that
+the City leaves a numbered row blank rather than omitting the bidder. Capability does not fix
+this; corpus knowledge does, and corpus knowledge is what the parsers ARE.
+
+**Unverified:** whether `award_summary`'s missing 40% actually clusters on those shapes. Cheap
+to check by diffing missed rows against the incumbent's, and worth doing before any migration —
+it separates "buy a bigger model" from "the exceptions do not transfer".
+
+## Where the whole evaluation lands
+
+Across H1/H2/H3 plus the GLiNER2 bake-off:
+
+- **Accuracy: the incumbent parsers win**, decisively on 2 of 3 corpora. Replacing the
+  extraction layer would degrade the archive.
+- **Drift robustness: the model wins, decisively.** H2: reformatting that takes the hardened
+  parser from 100% to 0-12% costs the 14B 0-4 points.
+
+Those are not in conflict; they describe different regimes. The parsers are better *until the
+format changes*, at which point they produce nothing and the model still works.
+
+## Recommended architecture (not full replacement, not hybrid-by-source)
+
+1. **Keep the existing parsers as the primary path.** They measure better and encode discoveries.
+2. **LLM as a drift FALLBACK**: when a parser returns zero rows, or fails its own ground-truth
+   check (a declared bid count it cannot satisfy), fall back to LLM extraction and flag the row
+   set for review. Cost is near zero — it fires only on failure — and it converts a City
+   reformat from a silent outage into a degraded-but-working night. This directly addresses the
+   drift risk, which was the actual motivation.
+3. **LLM as the FIRST pass for NEW sources.** This is where the O(n)-per-source cost lives: every
+   new agency has needed a bespoke parser. Start new sources on LLM extraction plus a
+   ground-truth check, and write a parser only where it measurably underperforms.
+
+(3) delivers the maintainability win going forward; (2) delivers the robustness win now. Neither
+regresses the 99-100% accuracy the current parsers deliver. **Honest limitation: this does not
+reduce the existing 6,195 lines** — the original goal — because the measurement does not support
+deleting them.

--- a/docs/superpowers/plans/2026-07-28-pdf-cell-tables.md
+++ b/docs/superpowers/plans/2026-07-28-pdf-cell-tables.md
@@ -1,0 +1,1062 @@
+# PDF Cell Tables Implementation Plan (#151, #203)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract EP board-report bid tables from PDF *cells* instead of regex over flattened text, and audit the remaining regex-over-flattened-text parsers to decide, per corpus, whether they should switch too.
+
+**Architecture:** A new `sources/pdf_tables.py` holds every structural rule as **pure** functions (caption anchoring with page-break handling; positional column zipping) plus two thin pdfplumber I/O readers. `sources/ep_board.py`'s bid-table parser becomes pure over cells; `award_summary.py` is rewired onto the shared rules so there is one copy. `agency_bid` becomes a derived table rebuilt from held PDFs on every store pass.
+
+**Tech Stack:** Python 3.12+, `uv`, pytest, pdfplumber 0.11.10, SQLite.
+
+## Global Constraints
+
+- Work on branch `fix-151-203-pdf-cells`. **Never commit to `main`** — this checkout is production; `main` deploys to live systemd timers.
+- All commands run from `/home/alex/toronto-bids/scrapers`.
+- The live corpus is at `TB_DATA_DIR=/home/alex/tb-data` (1,200 EP / 859 Zoo / 3,411 TRCA held reports). Tests must **never** require it.
+- No lint/format/typecheck exists in this repo. Do not invent one.
+- **Future maintainability, not past compatibility.** No shims, no deprecated aliases, no old-signature wrappers, no regex fallback, no inert dead code. Delete what is replaced.
+- **Never chase edge cases** (CLAUDE.md, "Parsing discipline"). A wrinkle that does not collapse into an existing rule is a signal to stop and report, not to add a rule.
+- **Refuse and log, never guess.** A refused row is a known gap; a guessed row is silent corruption.
+- Every task ends green: `uv run pytest` passes before commit.
+
+---
+
+### Task 1: `choose_tables` — caption anchoring and page-break walking (pure)
+
+This is the highest-risk logic in the change and it is deliberately pure, so it is tested with synthetic geometry and no PDF.
+
+**Files:**
+- Create: `toronto_bids/sources/pdf_tables.py`
+- Test: `tests/test_pdf_tables.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `is_price(cell: str | None) -> bool`, `is_continuation(rows: list[list]) -> bool`, `choose_tables(pages) -> list[list[list]]` where `pages` is `[(caption_tops: list[float], tables: list[tuple[float, rows]]), ...]` in document order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_pdf_tables.py`:
+
+```python
+from toronto_bids.sources.pdf_tables import choose_tables, is_continuation, is_price
+
+HDR = ["Bidder", "Bid Price Received", "Recommended\nContract Price"]
+R1 = ["Powell Fence Limited", "$1,484,065.00", "$1,484,065.00"]
+R2 = ["M.J.K. Construction Incorporated", "$1,619,001.00", ""]
+
+
+def test_is_price_accepts_the_shapes_the_city_publishes():
+    assert is_price("$1,484,065.00")
+    assert is_price("$4,365,534")            # no cents (backgroundfile-229405)
+    assert is_price("*$792,900.00")          # leading marker (backgroundfile-244900)
+    assert is_price("$470,700.00*")          # trailing marker (backgroundfile-137241)
+    assert is_price("$ 449,000.00")          # space after the sign
+    assert not is_price("*Non-compliant")
+    assert not is_price("Bid Price Received")
+    assert not is_price("")
+    assert not is_price(None)
+
+
+def test_choose_tables_takes_the_first_table_below_each_caption():
+    # backgroundfile-254716: two captions, two tables, on one page.
+    pages = [([195.2, 386.5], [(219.8, [HDR, R1]), (411.1, [HDR, R2])])]
+    assert choose_tables(pages) == [[HDR, R1], [HDR, R2]]
+
+
+def test_choose_tables_ignores_a_table_above_its_caption():
+    # backgroundfile-139154: an unrelated cost-breakdown table sits above the caption.
+    decoy = [["Item", "Amount", "Comments"], ["Exterior Windows", "373,000", "..."]]
+    pages = [([427.6], [(54.3, decoy), (452.6, [HDR, R1])])]
+    assert choose_tables(pages) == [[HDR, R1]]
+
+
+def test_caption_at_page_foot_finds_its_table_overleaf():
+    # backgroundfile-131331: caption at y=705.8 on page 1, whole table at y=54.2 on page 2.
+    pages = [([705.8], []), ([], [(54.2, [HDR, R1])])]
+    assert choose_tables(pages) == [[HDR, R1]]
+
+
+def test_a_table_broken_across_a_page_absorbs_its_continuation():
+    # backgroundfile-244929: 2 rows on page 1, 7 more on page 2 as a headerless table.
+    cont = [["Crawford Roofing Corporation", "$1,660,000.00", "$1,720,000.00"]]
+    pages = [([624.7], [(635.5, [HDR, R1])]), ([], [(54.2, cont[0:1])])]
+    assert choose_tables(pages) == [[HDR, R1, cont[0]]]
+
+
+def test_a_next_page_with_its_own_caption_is_not_absorbed():
+    # The next page's table belongs to that page's caption, not to ours.
+    pages = [([624.7], [(635.5, [HDR, R1])]), ([100.0], [(120.0, [HDR, R2])])]
+    assert choose_tables(pages) == [[HDR, R1], [HDR, R2]]
+
+
+def test_a_next_page_opening_with_a_header_is_a_new_table_not_a_continuation():
+    pages = [([624.7], [(635.5, [HDR, R1])]), ([], [(54.2, [HDR, R2])])]
+    assert choose_tables(pages) == [[HDR, R1]]
+
+
+def test_a_caption_with_no_table_anywhere_yields_nothing():
+    assert choose_tables([([100.0], [])]) == []
+
+
+def test_is_continuation_needs_a_price_in_the_second_column():
+    assert is_continuation([["Crawford Roofing Corporation", "$1,660,000.00", ""]])
+    assert not is_continuation([HDR])
+    assert not is_continuation([])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_pdf_tables.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'toronto_bids.sources.pdf_tables'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `toronto_bids/sources/pdf_tables.py`:
+
+```python
+"""Reading tables out of PDFs that HAVE tables (#151, #203).
+
+The rule this module serves is #116's: **read cells where the PDF HAS cells** — never
+"pdfplumber is better". Whether a given corpus qualifies is a per-corpus measurement
+(CLAUDE.md, "Parsing discipline"); #83 measured a corpus where cells are *worse*. This module
+is only the machinery for the corpora that qualify.
+
+Split so the risky part needs no PDF to test: `choose_tables` and `zip_columns` are pure and
+carry every structural rule; `all_tables`/`caption_tables` do the I/O and nothing else — the
+same fetch/normalize seam `sources/base.py` draws for a Source.
+"""
+import re
+
+# A published price, with or without cents, with a compliance marker on either side, and with
+# or without a space after the sign. Every shape here is live-measured on the EP corpus: the
+# old regex required `\.\d{2}` and so read `$4,365,534` (backgroundfile-229405) as "no bids".
+_PRICE = re.compile(r"^[*\s]*\$\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})?[*\s]*$")
+
+
+def is_price(cell) -> bool:
+    return bool(_PRICE.match((cell or "").strip()))
+
+
+def is_continuation(rows) -> bool:
+    """True when a table opens with DATA rather than a header — the signature of a table that
+    broke across a page boundary and resumed at the top of the next page."""
+    return bool(rows) and len(rows[0]) > 1 and is_price(rows[0][1])
+
+
+def choose_tables(pages):
+    """One table per caption, page-break continuations absorbed.
+
+    `pages` is `[(caption_tops, [(table_top, rows), ...]), ...]` in document order — the
+    geometry, with pdfplumber already out of the picture.
+
+    A caption claims the first table BELOW it on its own page. Two page-break shapes then
+    complicate that, and both are the same event so both are handled by one walk:
+
+      - the caption sits at the foot of its page and the whole table is overleaf
+        (backgroundfile-131331: caption y=705.8 page 1, table y=54.2 page 2);
+      - the caption's table starts on its page and the remaining rows land at the top of the
+        next page as a SEPARATE table object with no header row
+        (backgroundfile-244929: 2 rows, then 7).
+
+    Absorption requires the next page to have no caption of its own competing for the table,
+    and the table to open with data rather than a header. Without this, 131331 loses its only
+    bidder and 244929 seven of its nine.
+    """
+    out = []
+    for i, (captions, tables) in enumerate(pages):
+        for top in sorted(captions):
+            below = [t for t in tables if t[0] > top]
+            j = i
+            if below:
+                rows = list(min(below, key=lambda t: t[0])[1])
+            elif i + 1 < len(pages) and pages[i + 1][1] and not pages[i + 1][0]:
+                j = i + 1
+                rows = list(min(pages[j][1], key=lambda t: t[0])[1])
+            else:
+                continue          # a caption with no table is absent, not someone else's rows
+            while j + 1 < len(pages) and pages[j + 1][1] and not pages[j + 1][0]:
+                nxt = min(pages[j + 1][1], key=lambda t: t[0])[1]
+                if not is_continuation(nxt):
+                    break
+                rows.extend(nxt)
+                j += 1
+            out.append(rows)
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_pdf_tables.py -v`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toronto_bids/sources/pdf_tables.py tests/test_pdf_tables.py
+git commit -m "feat(pdf_tables): caption anchoring with page-break walking, pure and tested
+
+choose_tables takes page geometry and returns one table per caption. A bid
+table breaks across pages in two shapes — caption stranded at a page foot
+(131331), and rows continuing overleaf as a separate headerless table
+(244929, 7 of 9 rows) — and both are one event, so one walk covers both.
+
+Pure by construction: the geometry is passed in, so the riskiest rule in
+this change is tested with no PDF and no pdfplumber."
+```
+
+---
+
+### Task 2: `zip_columns` — the positional-zip rule, one canonical copy
+
+**Files:**
+- Modify: `toronto_bids/sources/pdf_tables.py`
+- Modify: `toronto_bids/sources/award_summary.py:180-215` (delete `_zip_cell`, import `zip_columns`)
+- Test: `tests/test_pdf_tables.py`
+
+**Interfaces:**
+- Consumes: `toronto_bids.sources.pdf_tables` from Task 1.
+- Produces: `zip_columns(name_cell: str, price_cell: str) -> list[tuple[str, str | None]]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_pdf_tables.py`:
+
+```python
+from toronto_bids.sources.pdf_tables import zip_columns
+
+
+def test_one_price_line_is_one_bid_even_when_the_name_wraps():
+    # #116: reading a wrapped name's two lines as two names dropped a bidder from 4 forms.
+    assert zip_columns("2489960 Ontario Inc.\no/a Kore Infrastructure Group",
+                       "$3,198,000.00") == [
+        ("2489960 Ontario Inc. o/a Kore Infrastructure Group", "$3,198,000.00")]
+
+
+def test_a_multi_package_column_zips_positionally():
+    assert zip_columns("26TW-CPI-17CWD (Package A):\nClean Water Works Inc.*\nAqua Tech Inc.",
+                       "$3,551,718.88\n$3,978,656.19") == [
+        ("Clean Water Works Inc.*", "$3,551,718.88"),
+        ("Aqua Tech Inc.", "$3,978,656.19")]
+
+
+def test_unequal_columns_are_refused_rather_than_guessed():
+    # #94: pairing is positional, so one stray line misattributes every bid after it.
+    assert zip_columns("A Ltd.\nB Ltd.\nC Ltd.", "$1.00\n$2.00") == []
+
+
+def test_a_proponent_with_no_price_at_all_is_still_a_bid():
+    # An RFP publishes proponents with "NOTE: Not applicable for RFP" (#84 stores price NULL).
+    assert zip_columns("Some Consulting Inc.", "") == [("Some Consulting Inc.", None)]
+
+
+def test_an_empty_name_yields_nothing():
+    assert zip_columns("", "$1.00") == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_pdf_tables.py -k zip -v`
+Expected: FAIL — `ImportError: cannot import name 'zip_columns'`
+
+- [ ] **Step 3: Add `zip_columns` to `pdf_tables.py`**
+
+Append to `toronto_bids/sources/pdf_tables.py`:
+
+```python
+def zip_columns(name_cell, price_cell):
+    """Pair one row's bidder lines against its price lines.
+
+    Usually a row is one bidder. A multi-package tender instead puts a whole column in a single
+    cell, exactly as the BD agendas did (#94). Same rule, same reason: pairing is positional, so
+    one stray line misattributes every bid after it. Zip the columns and REFUSE an unequal pair
+    rather than guess. A package heading is dropped first — it ends in ':' and has no price.
+
+    **THE PRICE CELL'S LINE COUNT SAYS HOW MANY BIDS THE ROW HOLDS.** A newline inside a name
+    cell is otherwise ambiguous, and guessing costs real bids: pdfplumber wraps a long name
+    within its own cell, so
+
+        ['2489960 Ontario Inc.\\no/a Kore Infrastructure Group', '$3,198,000.00']
+
+    is ONE bidder, and reading its two lines as two names refused the pair and silently dropped
+    a bidder from each of 4 forms (#116). One price, one bid — join the name.
+    """
+    prices = [ln.strip() for ln in (price_cell or "").split("\n") if ln.strip()]
+    names = [ln.strip() for ln in (name_cell or "").split("\n") if ln.strip()]
+    names = [n for n in names if not n.endswith(":")]
+    if len(prices) <= 1:
+        name = " ".join(names)
+        if not name:
+            return []
+        # An RFP publishes its proponents with NO price at all ("NOTE: Not applicable for
+        # RFP"). #84 already stores those as bid_price NULL — requiring a price here dropped
+        # every proponent on every scored RFP.
+        return [(name, prices[0] if prices else None)]
+    if len(names) != len(prices):
+        return []
+    return list(zip(names, prices))
+```
+
+- [ ] **Step 4: Rewire `award_summary.py` onto it**
+
+In `toronto_bids/sources/award_summary.py`, **delete the entire `_zip_cell` function** (lines 180-215) and add the import at the top of the `# --- parsing ---` block:
+
+```python
+from toronto_bids.sources.pdf_tables import zip_columns
+```
+
+Then in `parse_award_summary`, change the one call site:
+
+```python
+        for name, price in zip_columns(label, value):
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS. `tests/test_award_summary.py` must still be green — it exercises the wrapped-name, multi-package and unequal-pair cases through `parse_award_summary`, which is the proof the rewire is behaviour-preserving.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toronto_bids/sources/pdf_tables.py toronto_bids/sources/award_summary.py tests/test_pdf_tables.py
+git commit -m "refactor(pdf_tables): one canonical copy of #94's positional-zip rule
+
+The rule has now been independently re-derived three times (#94's BD agenda
+tables, #116's Award Summary Forms, and EP), which is the signal that it is
+one rule rather than three similar ones. award_summary._zip_cell is deleted
+and that module imports zip_columns instead.
+
+Two correct copies are exactly the thing that diverges the first time one is
+fixed; the existing award_summary tests pass unchanged, which is the proof
+the rewire preserves behaviour."
+```
+
+---
+
+### Task 3: the pdfplumber readers
+
+**Files:**
+- Modify: `toronto_bids/sources/pdf_tables.py`
+- Modify: `toronto_bids/sources/award_summary.py:165-177` (delete `form_rows`'s body, delegate)
+- Test: `tests/test_pdf_tables.py`
+
+**Interfaces:**
+- Consumes: `choose_tables` from Task 1.
+- Produces: `all_tables(path) -> list[list[str]]` (flattened non-empty rows, empty cells dropped), `caption_tables(path, caption_re: re.Pattern) -> list[list[list]]` (raw cells, empties **kept**).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pdf_tables.py`:
+
+```python
+import pathlib
+import re
+
+import pytest
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+
+def test_caption_tables_on_a_pdf_with_no_tables_returns_nothing():
+    pytest.importorskip("pdfplumber")
+    from toronto_bids.sources.pdf_tables import caption_tables
+    assert caption_tables(FIXTURES / "tiny.pdf", re.compile(r"Table\s+1", re.I)) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_pdf_tables.py -k caption_tables -v`
+Expected: FAIL — `ImportError: cannot import name 'caption_tables'`
+
+- [ ] **Step 3: Add the readers**
+
+Append to `toronto_bids/sources/pdf_tables.py`:
+
+```python
+def all_tables(path):
+    """Every non-empty row of every table in the PDF, as stripped cells with empties DROPPED.
+
+    Column position is not preserved — this is for forms read as (label, value) pairs, where a
+    blank trailing cell is noise. Use `caption_tables` when column INDEX matters. Does I/O.
+    """
+    import pdfplumber
+
+    rows = []
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            for table in page.extract_tables() or []:
+                for row in table:
+                    cells = [(c or "").strip() for c in row]
+                    if any(cells):
+                        rows.append([c for c in cells if c])
+    return rows
+
+
+def caption_tables(path, caption_re):
+    """The table under each `caption_re` match, as RAW cells — empties KEPT.
+
+    Column index is load-bearing here (column 1 is the price column whether or not column 2 is
+    blank), so unlike `all_tables` this must not compact a row. Does I/O; every structural
+    decision belongs to `choose_tables`, which is pure.
+    """
+    import pdfplumber
+
+    pages = []
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            captions = [m["top"] for m in
+                        page.search(caption_re.pattern, regex=True, case=False)]
+            tables = [(t.bbox[1], t.extract()) for t in page.find_tables()]
+            pages.append((captions, tables))
+    return choose_tables(pages)
+```
+
+- [ ] **Step 4: Delegate `award_summary.form_rows`**
+
+Replace the body of `form_rows` in `toronto_bids/sources/award_summary.py` (keep the name — it is the domain term used throughout that module):
+
+```python
+def form_rows(path) -> list[list[str]]:
+    """Every non-empty row of every ruled table in the form, as stripped cells. Does I/O."""
+    from toronto_bids.sources.pdf_tables import all_tables
+
+    return all_tables(path)
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toronto_bids/sources/pdf_tables.py toronto_bids/sources/award_summary.py tests/test_pdf_tables.py
+git commit -m "feat(pdf_tables): pdfplumber readers, with the empty-cell rule made explicit
+
+all_tables drops empty cells (forms read as label/value pairs); caption_tables
+keeps them, because for a bid table column INDEX is load-bearing — column 1 is
+the price column whether or not column 2 is blank. Conflating those two would
+silently shift a row's columns.
+
+award_summary.form_rows delegates to all_tables and keeps its name, which is
+the domain term the rest of that module uses."
+```
+
+---
+
+### Task 4: EP bid table reads cells (pure parser + fixtures)
+
+**Files:**
+- Modify: `toronto_bids/sources/ep_board.py:141-167` (delete `_EP_BID_ROW` and the 1,500-char window; rewrite `parse_ep_bid_table`)
+- Create: `tests/fixtures/agencies/ep_bid_table_2023_three_bidders.json`
+- Create: `tests/fixtures/agencies/ep_bid_table_2019_five_bidders.json`
+- Create: `tests/fixtures/agencies/ep_bid_table_noncompliant.json`
+- Create: `tests/fixtures/agencies/ep_bid_table_no_cents.json`
+- Modify: `tests/test_ep_reports.py:108-132` (rewrite the three bid-table tests)
+
+**Interfaces:**
+- Consumes: `pdf_tables.is_price` (Task 1).
+- Produces: `parse_ep_bid_table(tables: list[list[list]]) -> list[tuple[str, str | None]]` — **pure**, takes what `caption_tables` returned.
+
+- [ ] **Step 1: Create the fixtures**
+
+These are the real cells from the live corpus. `tests/fixtures/agencies/ep_bid_table_2023_three_bidders.json` (backgroundfile-240943):
+
+```json
+[[["Bidder", "Base Bid Price\nReceived", "Recommended\nContract Price"],
+  ["Powell Fence Limited", "$1,484,065.00", "$1,484,065.00"],
+  ["M.J.K. Construction Incorporated", "$1,619,001.00", ""],
+  ["Clearway Construction Incorporated", "$1,851,100.00", ""]]]
+```
+
+`tests/fixtures/agencies/ep_bid_table_2019_five_bidders.json` (backgroundfile-137241 — note the header says `Tenderer`, and the marker is *inside* the price cell):
+
+```json
+[[["Tenderer", "Tender Price\nReceived", "Recommended\nContract Price"],
+  ["Sutherland-Schultz Ltd.", "$418,854.47", "$403,854.47"],
+  ["Ontario Electrical Construction Co. Ltd.", "$461,522.00", ""],
+  ["Modern Niagara Toronto Inc.", "$470,700.00*", ""],
+  ["Stevens & Black Electrical Contractors Ltd.", "$518,000.00", ""],
+  ["Rogol Electric Company Limited", "$546,350.00", ""]]]
+```
+
+`tests/fixtures/agencies/ep_bid_table_noncompliant.json` (backgroundfile-238906 — declares 8 bids, and only reaches 8 because the outcome rows count):
+
+```json
+[[["Bidder", "Base Bid Price\nReceived", "Additional\nPrices\nIncluded", "Recommended\nTotal Contract\nPrice"],
+  ["CMS Electrical Group Ltd.", "$1,095,900.00", "$860,239.00", "$1,956,139.00"],
+  ["Energy Network Services Inc.", "$1,223,029.36", "", ""],
+  ["Kudlak-Baird (1982) Limited", "$2,334,973.00", "", ""],
+  ["Modern Niagara Toronto Inc.", "$1,496,274.61", "", ""],
+  ["OZZ Electric Inc.", "$1,328,914.00", "", ""],
+  ["Stevens & Black Electrical\nContractors Ltd.", "$1,576,400.00", "", ""],
+  ["* Plaza Electric Ltd.", "*Non-compliant", "", ""],
+  ["* Trade Electrical Contractors Inc.", "*Non-compliant", "", ""]]]
+```
+
+`tests/fixtures/agencies/ep_bid_table_no_cents.json` (backgroundfile-229405):
+
+```json
+[[["Bidder", "Base Bid Price\nReceived", "Recommended Contract\nPrice"],
+  ["Black & McDonald Limited", "$2,619,221", "$2,619,221"]]]
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Replace `tests/test_ep_reports.py` lines 108-132 (the three `parse_ep_bid_table` tests) with:
+
+```python
+import json
+
+
+def _rows(name):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_bid_table_extracts_all_three_bidders_with_prices():
+    assert parse_ep_bid_table(_rows("ep_bid_table_2023_three_bidders.json")) == [
+        ("Powell Fence Limited", "$1,484,065.00"),
+        ("M.J.K. Construction Incorporated", "$1,619,001.00"),
+        ("Clearway Construction Incorporated", "$1,851,100.00"),
+    ]
+
+
+def test_bid_table_2019_five_bidders_strips_a_marker_inside_the_price_cell():
+    # The header here says "Tenderer", not "Bidder" — the header row is rejected because its
+    # price column holds no price, never by a denylist of header words.
+    assert parse_ep_bid_table(_rows("ep_bid_table_2019_five_bidders.json")) == [
+        ("Sutherland-Schultz Ltd.", "$418,854.47"),
+        ("Ontario Electrical Construction Co. Ltd.", "$461,522.00"),
+        ("Modern Niagara Toronto Inc.", "$470,700.00"),      # trailing * stripped
+        ("Stevens & Black Electrical Contractors Ltd.", "$518,000.00"),
+        ("Rogol Electric Company Limited", "$546,350.00"),
+    ]
+
+
+def test_bid_table_keeps_a_non_compliant_bidder_with_a_null_price():
+    # #94's rule: the City writes OUTCOMES in the price column. The bidder is still a bid.
+    # backgroundfile-238906 declares 8 bids and only reaches 8 because these two count.
+    got = parse_ep_bid_table(_rows("ep_bid_table_noncompliant.json"))
+    assert len(got) == 8
+    assert got[-2:] == [("Plaza Electric Ltd.", None),        # leading marker stripped from name
+                        ("Trade Electrical Contractors Inc.", None)]
+
+
+def test_bid_table_accepts_a_price_with_no_cents():
+    # The old regex required \\.\\d{2} and read this report as having no bids at all.
+    assert parse_ep_bid_table(_rows("ep_bid_table_no_cents.json")) == [
+        ("Black & McDonald Limited", "$2,619,221")]
+
+
+def test_bid_table_wrapped_name_arrives_whole():
+    rows = [[["Bidder", "Bid Price Received", "Recommended\nContract Price"],
+             ["Enercare Home and\nCommercial Services Limited Partnership", "$653,323.00", ""]]]
+    assert parse_ep_bid_table(rows) == [
+        ("Enercare Home and Commercial Services Limited Partnership", "$653,323.00")]
+
+
+def test_bid_table_absent_returns_empty():
+    assert parse_ep_bid_table([]) == []
+
+
+def test_bid_table_refuses_a_row_whose_price_column_is_neither_price_nor_outcome():
+    # Refuse, never guess — a row we cannot read is a gap, not an invented bid.
+    rows = [[["Bidder", "Bid Price Received"], ["Some Firm Ltd.", "see Appendix B"]]]
+    assert parse_ep_bid_table(rows) == []
+```
+
+Also delete the now-unused `_read`-based bid-table calls; `_read` stays because `parse_ep_report` still uses it.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_ep_reports.py -k bid_table -v`
+Expected: FAIL — the current `parse_ep_bid_table` takes text, so passing a list raises `TypeError: expected string or bytes-like object`.
+
+- [ ] **Step 4: Rewrite the parser**
+
+In `toronto_bids/sources/ep_board.py`, **delete `_EP_BID_ROW` entirely** and replace the `parse_ep_bid_table` block (lines 141-167) with:
+
+```python
+# The Table 1 caption. UNCHANGED from the regex era, and it already excludes
+# "Table 2: Tender Separate Price Submission" — after "Table 2" that text reads "Tender
+# Separate Price Submission", so there is no "Tender Price Submission" to match. That is what
+# identifies Table 1 without hardcoding the digit.
+_EP_TABLE_HEAD = re.compile(r"Table\s+\d[^\n]*Tender\s+Price\s+Submission", re.I)
+# The City writes OUTCOMES in the price column instead of a number — the same practice #94
+# documented on the BD agendas, where the raw string is kept and bid_price_numeric is NULL for
+# exactly those. Such a row is still a bid; its price is simply not a number.
+_EP_OUTCOME = re.compile(r"^[*\s]*(?:non[-\s]?compliant|no\s+bid|not\s+applicable|withdrawn|"
+                         r"disqualified|incomplete)\b", re.I)
+# Compliance markers leading or trailing a name ("* Plaza Electric Ltd."), stripped so the firm
+# keys consistently in the supplier dimension.
+_MARKERS = re.compile(r"^[\s*^+†‡§]+|[\s*^+†‡§]+$")
+
+
+def ep_bid_tables(path):
+    """The report's 'Table 1: Tender Price Submission' as cells. Does I/O."""
+    return pdf_tables.caption_tables(path, _EP_TABLE_HEAD)
+
+
+def parse_ep_bid_table(tables) -> list[tuple[str, str | None]]:
+    """Every (bidder, price) in an EP Table 1. Pure over the cells ep_bid_tables() read.
+
+    Four rules, and they were measured to converge rather than proliferate (#151): the caption
+    anchor and page-break walk live in pdf_tables.choose_tables; this function is the row rule
+    and the normalisation.
+
+    A row is a bid when column 0 names something and column 1 holds either a price or an
+    outcome. The header row is rejected structurally by that same test, never by a denylist of
+    header words — column 0 is variously "Bidder" and "Tenderer", and column 1 variously
+    "Bid Price Received", "Base Bid Price\\nReceived" and "Initial Base Bid\\nPrice Received".
+
+    Anything else is REFUSED rather than guessed at: backgroundfile-254543 carries a malformed
+    price in the City's own PDF ($1,479,386,.57) and yields one bid instead of two, which is
+    the document's defect and is not something to add a rule for.
+    """
+    if not tables:
+        return []
+    out = []
+    for row in tables[0]:
+        cells = [(c or "").strip() for c in row]
+        if len(cells) < 2 or not cells[0]:
+            continue
+        name = _MARKERS.sub("", _WS.sub(" ", cells[0]).strip())
+        if not name:
+            continue
+        if pdf_tables.is_price(cells[1]):
+            out.append((name, cells[1].strip("* ").replace(" ", "")))
+        elif _EP_OUTCOME.match(cells[1]):
+            out.append((name, None))
+    return out
+```
+
+Add the import at the top of `ep_board.py`, beside the existing source imports:
+
+```python
+from toronto_bids.sources import pdf_tables
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_ep_reports.py -v`
+Expected: the seven bid-table tests PASS. `test_store_ep_reports_lands_award_and_bids` FAILS — it feeds `background_pdf.text` and expects 3 bids, and that path no longer exists. Task 5 fixes it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toronto_bids/sources/ep_board.py tests/test_ep_reports.py tests/fixtures/agencies/ep_bid_table_*.json
+git commit -m "feat(ep): read the bid table as cells; delete the regex and its 1,500-char window
+
+#151's window truncated nothing (longest real table 732 chars) and instead
+over-reached, pulling Table 2 duplicates and prose into agency_bid. Cells make
+both impossible by construction.
+
+The row rule is structural: column 0 names something, column 1 holds a price
+or an outcome. That rejects the header row without a denylist, which matters
+because the header is variously Bidder/Tenderer and Bid Price Received/Base
+Bid Price Received/Initial Base Bid Price Received.
+
+Two rules carried over rather than invented: an outcome in the price column is
+still a bid with a NULL price (#94), and a numeric-leading firm name is real
+(#87/#116). Both were bidders the regex silently dropped.
+
+_EP_BID_ROW and the window are deleted outright — no flag, no fallback. A
+fallback would reimport exactly the prose contamination this removes.
+
+Test failure in test_store_ep_reports_lands_award_and_bids is expected and is
+fixed in the next commit."
+```
+
+---
+
+### Task 5: `rebuild_agency_bids` and the store pass
+
+**Files:**
+- Modify: `toronto_bids/store/db.py` (add `rebuild_agency_bids`)
+- Modify: `toronto_bids/sources/ep_board.py:170-198` (`store_ep_reports`)
+- Test: `tests/test_ep_reports.py`, `tests/test_db.py`
+
+**Interfaces:**
+- Consumes: `parse_ep_bid_table`, `ep_bid_tables` (Task 4).
+- Produces: `db.rebuild_agency_bids(conn, source: str, rows: list[AgencyBid]) -> int`; `store_ep_reports(conn, buyer_id, tables_for=ep_bid_tables) -> dict`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_db.py`:
+
+```python
+def test_rebuild_agency_bids_replaces_only_its_own_source(conn):
+    from toronto_bids.models import AgencyBid
+    from toronto_bids.store import db
+    keep = AgencyBid(buyer_id=1, native_ref="T-1", bidder_name_raw="Keep Ltd.",
+                     bid_price="$1.00", source="trca_board")
+    stale = AgencyBid(buyer_id=1, native_ref="E-1", bidder_name_raw="Phantom",
+                      bid_price="$2.00", source="ep_board")
+    db.upsert_row(conn, keep, overwrite=True)
+    db.upsert_row(conn, stale, overwrite=True)
+    fresh = [AgencyBid(buyer_id=1, native_ref="E-1", bidder_name_raw="Real Ltd.",
+                       bid_price="$3.00", source="ep_board")]
+    assert db.rebuild_agency_bids(conn, "ep_board", fresh) == 1
+    names = {r["bidder_name_raw"] for r in conn.execute("SELECT bidder_name_raw FROM agency_bid")}
+    assert names == {"Keep Ltd.", "Real Ltd."}          # phantom gone, TRCA untouched
+
+
+def test_rebuild_agency_bids_deletes_nothing_when_it_derived_nothing(conn):
+    from toronto_bids.models import AgencyBid
+    from toronto_bids.store import db
+    db.upsert_row(conn, AgencyBid(buyer_id=1, native_ref="E-1", bidder_name_raw="Held Ltd.",
+                                  bid_price="$1.00", source="ep_board"), overwrite=True)
+    # A machine that holds no PDFs derives no rows, and must therefore delete none.
+    assert db.rebuild_agency_bids(conn, "ep_board", []) == 0
+    assert conn.execute("SELECT COUNT(*) FROM agency_bid").fetchone()[0] == 1
+```
+
+Replace `test_store_ep_reports_lands_award_and_bids` in `tests/test_ep_reports.py`:
+
+```python
+def test_store_ep_reports_lands_award_and_bids(conn):
+    from toronto_bids.buyers import seed_buyers
+    from toronto_bids.sources.ep_board import store_ep_reports
+    ids = seed_buyers(conn)
+    conn.execute("INSERT INTO background_pdf (url, kind, sha256, local_path, text) VALUES "
+                 "('https://www.toronto.ca/legdocs/mmis/2023/ep/bgrd/backgroundfile-240943.pdf',"
+                 " 'agency_board', 'x', '/nowhere/x.pdf', ?)",
+                 (_read("ep_award_with_table_2023.txt"),))
+    conn.commit()
+    # The bid table now comes from the PDF's cells, so the reader is injected: a real EP report
+    # is ~113 KB, too heavy to commit as a fixture, and the seam is the same fetch/normalize
+    # boundary sources/base.py draws.
+    got = store_ep_reports(conn, ids["exhibition-place"],
+                           tables_for=lambda _p: _rows("ep_bid_table_2023_three_bidders.json"))
+    assert got["solicitations"] == 1 and got["awards"] == 1 and got["bids"] == 3
+    aw = conn.execute("SELECT supplier_name_raw, award_amount_numeric FROM agency_award "
+                      "WHERE native_ref='EP110-2023'").fetchone()
+    assert aw["supplier_name_raw"] == "Powell Fence Limited"
+    assert aw["award_amount_numeric"] == 1484065.00
+    assert conn.execute("SELECT COUNT(*) FROM agency_bid WHERE bid_price_numeric IS NOT NULL "
+                        "AND native_ref='EP110-2023'").fetchone()[0] == 3
+
+
+def test_store_ep_reports_survives_an_unreadable_pdf(conn):
+    from toronto_bids.buyers import seed_buyers
+    from toronto_bids.sources.ep_board import store_ep_reports
+    ids = seed_buyers(conn)
+    conn.execute("INSERT INTO background_pdf (url, kind, sha256, local_path, text) VALUES "
+                 "('https://www.toronto.ca/legdocs/mmis/2023/ep/bgrd/backgroundfile-240943.pdf',"
+                 " 'agency_board', 'x', '/nowhere/x.pdf', ?)",
+                 (_read("ep_award_with_table_2023.txt"),))
+    conn.commit()
+
+    def boom(_path):
+        raise OSError("no such file")
+
+    logged = []
+    got = store_ep_reports(conn, ids["exhibition-place"], tables_for=boom,
+                           log=logged.append)
+    assert got["awards"] == 1 and got["bids"] == 0     # the award still lands
+    assert any("240943" in m for m in logged)          # and the gap is never silent
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_db.py -k rebuild tests/test_ep_reports.py -k store -v`
+Expected: FAIL — `AttributeError: module 'toronto_bids.store.db' has no attribute 'rebuild_agency_bids'` and `store_ep_reports() got an unexpected keyword argument 'tables_for'`.
+
+- [ ] **Step 3: Add `rebuild_agency_bids`**
+
+Append to `toronto_bids/store/db.py`:
+
+```python
+def rebuild_agency_bids(conn, source: str, rows) -> int:
+    """Replace every `agency_bid` row for one source with a freshly derived set.
+
+    `agency_bid` is DERIVED from held PDFs, so it is rebuilt from the bytes rather than
+    diff-upserted — the sanctioned exception to "rows are never deleted" that
+    `build_supplier_dimension` and `enrich-ariba-attachments --reindex` already take, and for
+    the same reason.
+
+    This is a permanent contract, not a migration. A table whose contents must be corrected
+    once by hand is a table whose derivation should simply be re-run: a migration would encode
+    today's list of known-bad rows and need a successor after the next parser fix. Rebuilding
+    means every parser fix self-heals, with no list written down anywhere.
+
+    **Derive first, delete only on success.** `rows` is already materialised by the caller, and
+    an empty set deletes NOTHING — a machine that does not hold the PDFs re-derives nothing and
+    must not thereby erase the archive. Scoped to one `source`, so rebuilding EP cannot touch
+    TRCA's or the Zoo's rows.
+    """
+    rows = list(rows)
+    if not rows:
+        return 0
+    try:
+        conn.execute("DELETE FROM agency_bid WHERE source=?", (source,))
+        for row in rows:
+            upsert_row(conn, row, overwrite=True)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return len(rows)
+```
+
+- [ ] **Step 4: Rewrite `store_ep_reports`**
+
+Replace `store_ep_reports` in `toronto_bids/sources/ep_board.py`:
+
+```python
+def store_ep_reports(conn, buyer_id: int, tables_for=None, log=lambda _m: None) -> dict:
+    """Parse held EP reports into agency rows. One AgencySolicitation + AgencyAward per award
+    report (confidential ones keep the winner, NULL amount), and one AgencyBid per Table 1 row.
+    Non-award reports are refused by parse_ep_report and contribute nothing.
+
+    Bids are read from the PDF's own CELLS (#151), so `tables_for` is injected: it defaults to
+    `ep_bid_tables` and is overridden in tests, which must not need a 113 KB PDF on disk.
+
+    `agency_bid` for this source is REBUILT, not upserted (see db.rebuild_agency_bids): the
+    whole set is derived first and only then replaces what is stored, so a parser fix
+    self-heals and a missing corpus deletes nothing.
+    """
+    tables_for = tables_for if tables_for is not None else ep_bid_tables
+    counts = {"solicitations": 0, "awards": 0, "bids": 0}
+    bids: list[AgencyBid] = []
+    for row in conn.execute(
+            "SELECT reference, url, text, local_path FROM background_pdf WHERE kind='agency_board' "
+            "AND url LIKE '%/ep/%' AND text IS NOT NULL ORDER BY url").fetchall():
+        got = parse_ep_report(row["text"], fallback_ref=row["reference"] or row["url"],
+                              report_url=row["url"])
+        if got is None:
+            continue
+        db.upsert_row(conn, AgencySolicitation(
+            buyer_id=buyer_id, native_ref=got["native_ref"], title=got["title"],
+            status="awarded", posted_date=None, closing_date=None, portal_url=None,
+            source="ep_board"), overwrite=False)
+        counts["solicitations"] += 1
+        db.upsert_row(conn, AgencyAward(
+            buyer_id=buyer_id, native_ref=got["native_ref"], supplier_name_raw=got["winner"],
+            award_amount=got["amount"], value_confidential=got["confidential"], award_date=None,
+            report_url=got["report_url"], source="ep_board"), overwrite=True)
+        counts["awards"] += 1
+        if not row["local_path"]:
+            continue
+        # `local_path` is an ABSOLUTE path baked in on whichever machine fetched the report, and
+        # this archive is designed to migrate. The file's identity is its content-addressed
+        # <sha256>.pdf name; its location is deterministic under the CURRENT data dir.
+        path = config.EP_REPORTS_DIR / pathlib.Path(row["local_path"]).name
+        try:
+            tables = tables_for(path)
+        except Exception as exc:              # noqa: BLE001 — one unreadable PDF must never
+            # abort the pass, but it must never be silent either: a skip nobody can see is a
+            # skip nobody fixes (#175).
+            log(f"    ep unreadable {row['url'].rsplit('/', 1)[-1]}: {exc}")
+            continue
+        for bidder, price in parse_ep_bid_table(tables):
+            bids.append(AgencyBid(
+                buyer_id=buyer_id, native_ref=got["native_ref"], bidder_name_raw=bidder,
+                bid_price=price, report_url=row["url"], source="ep_board"))
+    conn.commit()
+    counts["bids"] = db.rebuild_agency_bids(conn, "ep_board", bids)
+    return counts
+```
+
+Add `import pathlib` to the top of `ep_board.py`.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toronto_bids/store/db.py toronto_bids/sources/ep_board.py tests/test_db.py tests/test_ep_reports.py
+git commit -m "feat(ep): derive agency_bid from held PDFs every run instead of upserting
+
+agency_bid for a source is now REBUILT from the bytes, the same sanctioned
+exception build_supplier_dimension and --reindex already take. That is a
+permanent contract rather than a migration: a one-off cleanup would encode
+today's list of known-bad rows and need a successor after the next parser fix,
+whereas rebuilding means every fix self-heals. The 13 phantom 'The recommended
+construction price of' rows disappear as an ordinary consequence.
+
+Derive first, delete only on success — an empty derivation deletes nothing, so
+a machine without the PDFs cannot erase the archive.
+
+store_ep_reports takes its table reader as a parameter (defaulting to
+ep_bid_tables): a real EP report is ~113 KB, too heavy to commit, and the seam
+is the fetch/normalize boundary sources/base.py already draws. An unreadable
+PDF is logged and skipped; the award still lands."
+```
+
+---
+
+### Task 6: verify against the live corpus
+
+Tests prove the rules; only the corpus proves the outcome. This task writes no shipped code.
+
+**Files:**
+- Create: `/tmp/claude-1000/-home-alex-toronto-bids/29bdc5d2-8380-4ad0-af3a-6c0de52f2f55/scratchpad/verify_ep.py` (throwaway, not committed)
+
+- [ ] **Step 1: Run the store pass against the real corpus**
+
+```bash
+cd /home/alex/toronto-bids/scrapers
+TB_DATA_DIR=/home/alex/tb-data uv run tb enrich-agencies --only ep
+```
+
+Expected: completes without traceback, and prints an EP line whose bid count is **153** (up from 115 stored under the regex).
+
+- [ ] **Step 2: Confirm the contamination is gone and the gains are present**
+
+```bash
+TB_DATA_DIR=/home/alex/tb-data uv run python -c "
+from toronto_bids.store import db
+from toronto_bids import config
+c = db.connect(config.DB_PATH)
+q = lambda s, *a: c.execute(s, a).fetchone()[0]
+print('ep bids            :', q(\"SELECT COUNT(*) FROM agency_bid WHERE source='ep_board'\"))
+print('prose phantoms     :', q(\"SELECT COUNT(*) FROM agency_bid WHERE source='ep_board' AND bidder_name_raw LIKE 'The recommended%'\"))
+print('truncated fragment :', q(\"SELECT COUNT(*) FROM agency_bid WHERE source='ep_board' AND bidder_name_raw='Triumph Roofing & Sheet'\"))
+print('numeric-led firms  :', q(\"SELECT COUNT(*) FROM agency_bid WHERE source='ep_board' AND bidder_name_raw GLOB '[0-9]*'\"))
+print('null-price bids    :', q(\"SELECT COUNT(*) FROM agency_bid WHERE source='ep_board' AND bid_price IS NULL\"))
+print('trca untouched     :', q(\"SELECT COUNT(*) FROM agency_bid WHERE source='trca_board'\"))
+"
+```
+
+Expected: `ep bids` ≈ 153; `prose phantoms` **0**; `truncated fragment` **0**; `numeric-led firms` ≥ 2; `null-price bids` ≈ 16; `trca untouched` **408**.
+
+- [ ] **Step 3: Confirm idempotency**
+
+Run the same `tb enrich-agencies --only ep` a second time. Expected: the same bid count, not double. This is what the rebuild contract guarantees.
+
+- [ ] **Step 4: Time it**
+
+Expected from the audit: ~15s for the EP store pass. If it materially exceeds that, **do not add a "skip if rows exist" guard** — that breaks the rebuild contract. Record the figure and stop; the cache design (sha256 + parser-version stamp) is a separate decision for the user.
+
+- [ ] **Step 5: Commit nothing; report the numbers**
+
+No code changes here. Report the measured figures — they go into the #151 issue comment in Task 10.
+
+---
+
+### Task 7: audit TRCA (#203) — measure, then decide
+
+**STOP-AND-ASK GATE.** One measurement pass and **one** refinement pass. Track the rule count. If it climbs — each fix revealing a wrinkle somewhere else — **stop, do not write the next rule, report to the user**, and default to keeping the regex. "TRCA cannot be cleanly extracted" is a complete, acceptable answer.
+
+**Files:**
+- Create: `.../scratchpad/audit_trca.py` (throwaway, not committed)
+
+- [ ] **Step 1: Find TRCA's own ground truth**
+
+The incumbent parser is not a baseline. Locate a declared count in the report text:
+
+```bash
+cd /home/alex/toronto-bids/scrapers
+TB_DATA_DIR=/home/alex/tb-data uv run python -c "
+import re
+from toronto_bids.store import db
+from toronto_bids import config
+c = db.connect(config.DB_PATH)
+rows = c.execute(\"SELECT text FROM background_pdf WHERE kind='agency_board' AND url LIKE '%escribemeetings%' AND text IS NOT NULL\").fetchall()
+print('trca reports with text:', len(rows))
+for label, p in {
+  'N bids received': r'(\w+)\s*\(?\d*\)?\s+(?:bids|tenders|proposals|submissions)\s+(?:were|was)\s+received',
+  'Number of Bids': r'Number\s+of\s+(?:Bids|Tenders|Proposals)',
+  'RESULTS table': r'\bRESULTS?\b',
+}.items():
+    print(f'  {label:20s}', sum(1 for r in rows if re.search(p, r['text'], re.I)))
+"
+```
+
+If no ground-truth anchor exists on a usable fraction of the corpus, **say so and stop** — without it, step 3 cannot distinguish a good parser from a confident one, and that is itself a finding worth reporting.
+
+- [ ] **Step 2: Measure ruled-table coverage on the RESULTS table specifically**
+
+Not "any table on the page" — the specific table the parser targets. Adapt `scratchpad/audit_ep.py`, replacing the caption regex with TRCA's results-table caption and pointing `config.TRCA_REPORTS_DIR` at the corpus. Report: reports with the target table / reports where cells found it.
+
+- [ ] **Step 3: Run the four checks**
+
+Junk scan, duplicate scan, declared-count agreement, and disagreement classification against the current parser. Same script shape as `audit_ep.py`.
+
+- [ ] **Step 4: Apply the switch criterion**
+
+Switch iff the target table is found on effectively every report that has one, output carries no junk and no duplicates, it agrees with declared counts except where the document is at fault, and **no real rows are lost**. TRCA's specific sub-fork: its 408 bids currently carry **zero prices** and come from the bullet list, so a good result here is a data *gain*. If cells reach reports the bullet list cannot and vice versa, a union is legitimate — but it ships as **one code path with a documented precedence**, never two parsers racing, and if the numbers land ambiguously **return the choice to the user**.
+
+- [ ] **Step 5: Record the verdict**
+
+Write the measurement into the #203 comment draft (Task 10) whichever way it goes. A corpus abandoned on measurement is a success of this audit.
+
+- [ ] **Step 6: If and only if the criterion is met, implement**
+
+Follow Tasks 4-6's shape exactly: pure parser over cells with JSON-rows fixtures, `tables_for` injection, `db.rebuild_agency_bids(conn, "trca_board", rows)`, corpus verification. Commit separately from the audit.
+
+---
+
+### Task 8: audit Zoo (#203)
+
+- [ ] **Step 1: Repeat Task 7's steps 1-5 against the Zoo corpus**
+
+859 held reports, `config.ZOO_REPORTS_DIR`, `url LIKE '%/zb/%'`, source `zoo_board`. Note the Zoo currently stores **0** `agency_bid` rows, so there is no incumbent output to compare against — ground truth and the junk scan carry the whole verdict here, which makes step 1 mandatory rather than merely advisable.
+
+- [ ] **Step 2: Apply the same gate and criterion**
+
+Same stop-and-ask rule. Same "prose is a valid answer" outcome.
+
+- [ ] **Step 3: Implement only if the criterion is met**, following Tasks 4-6.
+
+---
+
+### Task 9: audit committee award reports (#203)
+
+- [ ] **Step 1: Measure, with the ceiling stated up front**
+
+8 held reports. #164 already measured that **RFTs/RFQs tabulate bids while RFPs narrate them**, and that 6 of 8 yield nothing for that reason. Report the ruled-table finding against that known ceiling rather than presenting 8 reports as a statistical result.
+
+- [ ] **Step 2: Expect and accept "too small to switch"**
+
+A corpus this size cannot justify a parser migration on its own. The likely correct outcome is a recorded measurement and no code change — which is a complete answer, exactly as #83's was.
+
+---
+
+### Task 10: document the outcomes
+
+**Files:**
+- Modify: `CLAUDE.md` (the `### Agency capture` section's EP paragraph, and `### Committee/Council awards` if Task 9 changes anything)
+- Create: `docs/superpowers/notes/2026-07-28-parser-audit-findings.md` (the issue-comment drafts)
+
+- [ ] **Step 1: Update CLAUDE.md's EP paragraph**
+
+`### Agency capture` currently says EP is "the first agency source with a structured bidder price table (Table 1 → `agency_bid` with prices)". Extend it to record that EP reads **cells**, that the corpus is ruled 47/47, and the two rules that carried over rather than being invented (page-break walk; outcome-in-the-price-column is #94's rule). Keep it to the load-bearing facts — the reasoning lives in the spec.
+
+- [ ] **Step 2: Write the issue comments**
+
+Draft one comment for #151 (the EP result: 47/47, 153 rows, 0 junk, 0 duplicates, 32/35 against declared counts, 0 losses, 14+ recoveries, and the three document-defect residuals) and one for #203 (the per-corpus verdicts from Tasks 7-9, including any "kept as prose" outcomes and why).
+
+- [ ] **Step 3: Post them**
+
+The user authorised posting comments to #151 and #203 directly for this task.
+
+```bash
+gh api repos/CivicTechTO/toronto-bids/issues/151/comments -f body="$(cat docs/superpowers/notes/2026-07-28-parser-audit-findings.md)"
+```
+
+Post the #203 half to `issues/203/comments`. Note `gh issue create` is blocked by a classifier — `gh api` is the working path.
+
+- [ ] **Step 4: Commit and open the PR**
+
+```bash
+git add CLAUDE.md docs/
+git commit -m "docs: record the EP cell switch and the #203 per-corpus verdicts"
+git push -u origin fix-151-203-pdf-cells
+gh pr create --title "Read EP bid tables as cells (#151); audit the remaining regex parsers (#203)" --body "..."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** §1 `pdf_tables` → Tasks 1-3. §2 EP cells → Task 4. §3 rebuild contract → Task 5. §4 audit + stop-and-ask gate → Tasks 7-9. §5 testing → folded into each task. §6 sequencing → task order. Risks: caption anchoring → Task 1's decoy-table test plus Task 6; rebuild safety → Task 5's empty-derivation test; pdfplumber cost → Task 6 step 4; partly-ruled corpus → Task 7 step 4's union rule.
+
+**Placeholders.** None. The audit tasks (7-9) specify exact commands and an exact decision rule; their *outcome* is unknown by design, which is what an audit is, and the gate makes both outcomes actionable.
+
+**Type consistency.** `choose_tables(pages)` takes `[(caption_tops, [(table_top, rows)])]` in Task 1 and is called that way by `caption_tables` in Task 3. `parse_ep_bid_table(tables)` takes the list-of-tables `caption_tables` returns in both Task 4 and Task 5. `rebuild_agency_bids(conn, source, rows)` matches between Task 5's definition and its two call sites. `is_price` is used by `is_continuation` (Task 1) and `parse_ep_bid_table` (Task 4) with the same signature.

--- a/docs/superpowers/specs/2026-07-28-pdf-cell-tables-design.md
+++ b/docs/superpowers/specs/2026-07-28-pdf-cell-tables-design.md
@@ -1,0 +1,222 @@
+# Reading cells where the PDF has cells — EP bid tables (#151) and the parser audit (#203)
+
+Date: 2026-07-28
+Issues: [#151](https://github.com/CivicTechTO/toronto-bids/issues/151), [#203](https://github.com/CivicTechTO/toronto-bids/issues/203)
+
+## Background
+
+`#151` began as "the 1,500-char window in `parse_ep_bid_table` will silently truncate a large
+tender". Two rounds of measurement inverted that premise:
+
+- **Nothing is truncated today.** Longest real first table: 732 chars against a 1,500 cap;
+  0 of the 47 EP reports carrying a `Table 1` header are cut off.
+- **The active defect is the opposite — the window over-reaches.** It pulls in `Table 2`
+  (6 duplicate bidders on `backgroundfile-254716`, a 6-bidder tender yielding 12 rows), and it
+  accepts prose as rows (~11 reports store a bidder literally named
+  `The recommended construction price of`, scraped from
+  `The recommended construction price of $X will be funded from…`).
+- Four regex fixes were tried and each failed in a *different* structural place — the named
+  signature of an architectural problem rather than a patchable one.
+
+The third round answered the fork: **EP board reports carry ruled tables in 47/47**, the Award
+Summary Form profile (#116: 229/229 → cells) rather than the staff-report profile (#83: 13–20/229
+→ prose, regex correctly kept). Corpus-wide, the regex produces 143 rows and the first ruled
+table produces 126; the 17-row difference is exactly the contamination already identified. On the
+44 reports where the regex finds bids, its first bidder appears in the cell-derived table in
+**44/44**.
+
+`#203` observes that this conclusion has now been reached twice by identical methodology, and
+asks whether other regex-over-flattened-text parsers in this codebase are sitting on the same
+win — as an **audit**, explicitly not a mandate to rewrite.
+
+## Goals
+
+1. Switch EP bid-table extraction from regex-over-`pdftotext` to pdfplumber cells (#151).
+2. Remove the contamination the regex era already wrote into `agency_bid`.
+3. Audit the remaining candidates (TRCA, Zoo, committee awards) by #151's methodology and switch
+   each one the measurement endorses — documenting the ones it does not, so they are not
+   re-litigated (#203).
+
+## Non-goals
+
+- **A blanket "pdfplumber is better" rule.** CLAUDE.md is explicit that this is a per-corpus
+  finding: #83 measured a corpus where cells are *worse* (4/120 via the text strategy). Each
+  candidate is decided on its own measurement.
+- **Council staff reports (`bgrd`).** #83 already measured them as prose. That is a complete
+  answer for a candidate, not a gap.
+- **Capturing bid compliance markers.** Cells put `*Non-compliant` in its own column for the
+  first time, but adding a column to `AgencyBid` is out of scope here; noted as follow-up.
+- **Refactoring `award_summary.py`.** It is working, tested, heavily documented code carrying
+  form-specific behaviour. It is not touched.
+
+## Design
+
+### 1. `sources/pdf_tables.py` (new)
+
+Three corpus-independent primitives. The split exists so the anchoring rule — the genuinely new
+risk here — is testable without pdfplumber and without a PDF.
+
+```
+caption_tables(path, caption_re) -> list[list[list[str]]]     # I/O only
+choose_tables(caption_tops, tables) -> list[rows]             # PURE
+zip_columns(name_cell, price_cell) -> list[(name, price|None)] # PURE
+```
+
+- **`caption_tables`** opens the PDF and, per page, locates each caption match's y-position and
+  each table's bounding box, delegating the pairing to `choose_tables`. This is the only function
+  that touches a file, mirroring `award_summary.form_rows` and the `Source` protocol's
+  fetch/normalize split.
+- **`choose_tables`** takes caption y-positions and `(top, rows)` pairs and returns the first
+  table below each caption, in document order. Verified against `backgroundfile-254716`:
+
+  | | y |
+  |---|---|
+  | caption `Table 1: Tender Price Submission` | 195.2 |
+  | its table | 219.8 |
+  | caption `Table 2: Tender Separate Price Submission` | 386.5 |
+  | its table | 411.1 |
+
+  A caption with no table below it on its page yields nothing rather than reaching onto the next
+  table — a missing table must read as absent, never as some other table's rows.
+- **`zip_columns`** is #94's rule verbatim, for the reason #94 and #116 both give: pairing is
+  positional, so one stray line misattributes every bid after it.
+  - One price line → **one bid**, joining the name's wrapped lines. `#116` measured that reading
+    a wrapped name's two lines as two names silently dropped a bidder from each of 4 forms.
+  - Many price lines → the row is a multi-package column: zip positionally and **refuse an
+    unequal pair** rather than guess.
+
+  This duplicates `award_summary._zip_cell`'s core deliberately. The alternative — rewiring
+  `award_summary.py` onto the shared copy — modifies correct #116/#177 code as a side effect of
+  an issue that did not ask for it. If a third caller confirms the rule is identical everywhere,
+  collapsing them later is mechanical and by then covered by tests on both sides.
+
+### 2. #151 — EP reads cells
+
+**`parse_ep_bid_table` changes signature from `(text)` to `(rows)`** and becomes pure over
+cells. A new `ep_bid_tables(path)` does the I/O via `caption_tables`.
+
+- The caption regex `_EP_TABLE_HEAD` is **unchanged**. It already excludes
+  `Table 2: Tender Separate Price Submission` (after `Table 2`, the text reads
+  `Tender Separate Price Submission` — there is no `Tender Price Submission` to match), which is
+  what makes "Table 1" identifiable without hardcoding the digit `1`. Where several captions
+  match, the **first** is taken.
+- Column 0 is the bidder, column 1 the base bid price — the current "take the FIRST `$`"
+  semantics, now structural rather than positional-within-flattened-text. The header row
+  (`Bidder`, `Bid Price Received`, `Recommended\nContract Price`) is skipped by its own cells,
+  not by a denylist of header strings.
+- Wrapped names arrive whole inside one cell
+  (`Enercare Home and\nCommercial Services Limited Partnership`), so the intra-cell newline is
+  collapsed rather than treated as a row boundary.
+- **The 1,500-char window disappears entirely.** There is no window to size, because there is no
+  window — which is what makes #151's original framing moot rather than merely fixed.
+- `store_ep_reports` resolves the PDF by **basename under `config.EP_REPORTS_DIR`**, not by the
+  stored `local_path`. `_store_pending_pdfs` bakes in an absolute path on whichever machine
+  fetched the report, and this archive is designed to migrate (server becomes primary); the file's
+  identity is its content-addressed `<sha256>.pdf` name and its location is deterministic under
+  the current data dir. Same reasoning, same shape as `store_award_summary_bids`.
+- A PDF pdfplumber cannot read is **logged and skipped**, never silent — the award report itself
+  still stores, only its bids are absent.
+
+Expected outcome, from the measurement: 143 rows → 126, the difference being 6 `Table 2`
+duplicates and ~11 prose phantoms. **Those are rows *parsed*, not rows *stored*:** `agency_bid`
+upserts on its key, so the store currently holds 115 EP rows against 143 parsed. Verification
+must compare like with like — parsed against parsed, or stored against stored — or the switch
+will read as a larger loss than it is. The 2 reports whose ruled table holds no bid-shaped rows
+(`backgroundfile-139154`, `backgroundfile-229405`) produce 0 bids under the current regex too —
+no regression.
+
+Unrelated and deliberately not "fixed": `backgroundfile-254543` yields 0 bids because the City's
+own PDF carries a malformed price (`$1,479,386,.57`, stray comma before the decimal).
+
+### 3. Rebuilding `agency_bid` for a switched source
+
+Switching the parser stops *new* contamination. The 13 phantom
+`The recommended construction price of` rows and the truncated fragments
+(`Triumph Roofing & Sheet`, `Vanguard Mechanical` beside `Vanguard Mechanical Inc.`) are already
+in the store, and this archive never deletes rows.
+
+`rebuild_agency_bids(conn, source)` is a **narrow, sanctioned exception**, in the shape of
+`build_supplier_dimension` and `enrich-ariba-attachments --reindex`: `agency_bid` is *derived
+from held PDFs*, so it is rebuilt from the bytes rather than diff-upserted.
+
+**Derive first, delete only on success.** The full new row set is collected in memory; only if
+derivation completed without exception *and* produced rows does the delete + insert run, inside
+one transaction. A machine that does not hold the PDFs re-derives nothing and therefore deletes
+nothing — the failure mode that would otherwise turn a missing corpus into data loss.
+
+Scoped to one `source` at a time, so switching EP cannot touch TRCA's or the Zoo's rows.
+
+### 4. #203 — the audit
+
+Per candidate, #151's four steps, unchanged because they are what made that measurement
+trustworthy rather than suggestive:
+
+1. Ruled-table coverage on the **specific table type the parser targets** — not "any table on
+   the page".
+2. Corpus-wide comparison of cell-derived rows against the current parser's output: count
+   agreements, and look hard at every disagreement to establish which side is contamination and
+   which is real loss.
+3. Validate that cells land on the **right** table (#151's 44/44 check), since a
+   first-table-with-money heuristic could in principle pick up something unrelated.
+4. Decide per-source.
+
+**The switch criterion is fixed here, in advance, so the numbers decide rather than preference:**
+
+> Switch iff (a) ruled-table coverage holds on the specific target table across the reports the
+> current parser finds rows in, (b) the right-table check reproduces the current parser's first
+> bidder with no unexplained mismatch, and (c) every disagreement resolves as
+> contamination-removed or data-added rather than real loss. Otherwise: document the corpus as
+> prose, keep the regex, and record the measurement so it is not re-litigated.
+
+Candidates:
+
+| source | corpus (held, with text) | current approach |
+|---|---|---|
+| TRCA eSCRIBE | 3,411 | regex; results table "fused pdftotext and never mined" |
+| Zoo ZB legdocs | 859 | regex, shared `agency_report.py` primitives |
+| committee award reports | 8 | regex, `_BID_TABLE_ANCHORS` |
+
+**TRCA carries an anticipated sub-fork, named now rather than discovered mid-implementation.**
+Its 408 `agency_bid` rows carry **zero prices** — bidders come from the bullet list and the
+results table is never mined. So a successful measurement there is not a de-contamination but a
+data *gain*, and the outcome may be a **union** (cells where the results table is ruled, the
+bullet list as fallback for reports where it is not) rather than a replacement. That is the
+measurement's call. If the numbers land ambiguously — coverage good but the two sources
+disagreeing about *who bid* rather than merely about price — the choice returns to the user
+rather than being settled by the implementer.
+
+The committee corpus is 8 reports, of which #164 measured that 6 of 8 yield nothing because
+**RFTs/RFQs tabulate bids while RFPs narrate them**. A ruled-table finding there is likely to be
+bounded by the same ceiling; the audit records that rather than treating 8 reports as a
+statistical result.
+
+### 5. Testing
+
+- **Pure parsers get JSON-rows fixtures**, so tests need neither pdfplumber nor a PDF — the
+  `award_summary.py` discipline, and the reason its fixtures survive a dependency change.
+- **`choose_tables` gets real unit tests** over synthetic `(caption_top, table_top)` geometry,
+  including the no-table-below-this-caption case. This is the new logic and the one place a
+  silent mis-anchor could hide.
+- **`zip_columns` gets the #94/#116 cases**: wrapped name with one price (one bid), multi-package
+  column (positional zip), unequal columns (refused).
+- **An integration test over a held EP report**, skipped when the corpus is absent — the existing
+  pattern for council tests without `pdftotext`.
+- Existing EP bid-table tests are updated to the new `(rows)` signature; their *assertions* about
+  what should be extracted stay, since the point is that cells extract at least as much.
+
+### 6. Sequencing
+
+`pdf_tables` → EP switch + rebuild → audit TRCA → audit Zoo → audit committee → CLAUDE.md +
+issue comments on #151/#203.
+
+Work lands on `fix-151-203-pdf-cells`, off `main`. This checkout is production: `main` deploys to
+live systemd timers.
+
+## Risks
+
+| risk | mitigation |
+|---|---|
+| Caption anchoring picks the wrong table on an unmeasured report | `choose_tables` is pure and unit-tested; step 3 of the audit re-runs #151's right-table check corpus-wide after the switch, not just before |
+| The rebuild deletes rows it cannot re-derive | Derive-first, delete-only-on-success, in one transaction, scoped to one source |
+| pdfplumber is slower than regex over cached text | Measured concern from #177 (~41s over 229 forms). EP is 47 reports with a table; if the nightly cost is material, the same "already stored, skip without opening the PDF" guard #177 added applies — recorded as a follow-up if measurement shows it matters |
+| The audit finds a corpus that is *partly* ruled | The criterion admits this: a union outcome is legitimate (see TRCA), but it must be measured and stated, not assumed |

--- a/docs/superpowers/specs/2026-07-28-pdf-cell-tables-design.md
+++ b/docs/superpowers/specs/2026-07-28-pdf-cell-tables-design.md
@@ -46,8 +46,23 @@ win — as an **audit**, explicitly not a mandate to rewrite.
   answer for a candidate, not a gap.
 - **Capturing bid compliance markers.** Cells put `*Non-compliant` in its own column for the
   first time, but adding a column to `AgencyBid` is out of scope here; noted as follow-up.
-- **Refactoring `award_summary.py`.** It is working, tested, heavily documented code carrying
-  form-specific behaviour. It is not touched.
+
+## Governing principle
+
+**Future maintainability, not past compatibility.** Backwards compatibility is not merely
+unneeded here — it is actively undesirable. Concretely, in this change:
+
+- No shim, no deprecated alias, no old-signature wrapper. `parse_ep_bid_table` changes shape and
+  every caller changes with it.
+- **No regex fallback when the cell path finds nothing.** A "try cells, fall back to the old
+  parser" arrangement would quietly reimport the exact contamination this change removes, and
+  would make the contaminated path permanent by making it unreachable to testing.
+- Dead code goes, rather than being left inert: `_EP_BID_ROW` and the 1,500-char window are
+  deleted, not retained behind a flag.
+- Where a rule now has two implementations, they are **collapsed to one** rather than allowed to
+  drift — see §1.
+- No one-off migration script. State that has to be corrected once is a sign the derivation
+  should be re-run every time; see §3.
 
 ## Design
 
@@ -57,8 +72,9 @@ Three corpus-independent primitives. The split exists so the anchoring rule — 
 risk here — is testable without pdfplumber and without a PDF.
 
 ```
-caption_tables(path, caption_re) -> list[list[list[str]]]     # I/O only
-choose_tables(caption_tops, tables) -> list[rows]             # PURE
+all_tables(path) -> list[list[list[str]]]                      # I/O only
+caption_tables(path, caption_re) -> list[list[list[str]]]      # I/O only
+choose_tables(caption_tops, tables) -> list[rows]              # PURE
 zip_columns(name_cell, price_cell) -> list[(name, price|None)] # PURE
 ```
 
@@ -85,10 +101,22 @@ zip_columns(name_cell, price_cell) -> list[(name, price|None)] # PURE
   - Many price lines → the row is a multi-package column: zip positionally and **refuse an
     unequal pair** rather than guess.
 
-  This duplicates `award_summary._zip_cell`'s core deliberately. The alternative — rewiring
-  `award_summary.py` onto the shared copy — modifies correct #116/#177 code as a side effect of
-  an issue that did not ask for it. If a third caller confirms the rule is identical everywhere,
-  collapsing them later is mechanical and by then covered by tests on both sides.
+  It also drops a multi-package heading line (a name line ending in `:`, with no price beside
+  it), which is part of the rule as #116 measured it rather than a form-specific quirk.
+
+**`award_summary.py` is rewired onto these primitives.** Its `_zip_cell` is deleted and it
+imports `zip_columns`; its `form_rows` becomes a thin call to the shared reader's
+all-tables variant. Only what is genuinely specific to that form stays behind in
+`award_summary.py` — the section-5 state machine, the `Range:`/`NOTE` skips, the numbering
+strip, the declared-count check.
+
+This reverses the initial instinct to leave that file alone on the grounds that it is working,
+tested, hard-won code. That instinct optimises for not disturbing the past. The cost it accepts
+is two copies of #94's positional-zip rule that are correct today and will diverge the first time
+one of them is fixed — and the rule has already been re-derived independently three times
+(#94's BD tables, #116's forms, now EP), which is the signal that it is one rule, not three
+similar ones. One canonical implementation, with both corpora's cases in one test file, is the
+maintainable shape.
 
 ### 2. #151 — EP reads cells
 
@@ -107,8 +135,11 @@ cells. A new `ep_bid_tables(path)` does the I/O via `caption_tables`.
 - Wrapped names arrive whole inside one cell
   (`Enercare Home and\nCommercial Services Limited Partnership`), so the intra-cell newline is
   collapsed rather than treated as a row boundary.
-- **The 1,500-char window disappears entirely.** There is no window to size, because there is no
-  window — which is what makes #151's original framing moot rather than merely fixed.
+- **The 1,500-char window disappears entirely, along with `_EP_BID_ROW`.** There is no window to
+  size, because there is no window — which is what makes #151's original framing moot rather
+  than merely fixed. Both are deleted outright: no flag, no fallback, no inert copy. A report
+  whose ruled table yields nothing yields **no bids**, and says so in the log; it does not fall
+  back to the regex, which would reimport precisely the prose contamination this removes.
 - `store_ep_reports` resolves the PDF by **basename under `config.EP_REPORTS_DIR`**, not by the
   stored `local_path`. `_store_pending_pdfs` bakes in an absolute path on whichever machine
   fetched the report, and this archive is designed to migrate (server becomes primary); the file's
@@ -128,16 +159,27 @@ no regression.
 Unrelated and deliberately not "fixed": `backgroundfile-254543` yields 0 bids because the City's
 own PDF carries a malformed price (`$1,479,386,.57`, stray comma before the decimal).
 
-### 3. Rebuilding `agency_bid` for a switched source
+### 3. `agency_bid` becomes derived-every-run, per source
 
 Switching the parser stops *new* contamination. The 13 phantom
 `The recommended construction price of` rows and the truncated fragments
 (`Triumph Roofing & Sheet`, `Vanguard Mechanical` beside `Vanguard Mechanical Inc.`) are already
 in the store, and this archive never deletes rows.
 
-`rebuild_agency_bids(conn, source)` is a **narrow, sanctioned exception**, in the shape of
-`build_supplier_dimension` and `enrich-ariba-attachments --reindex`: `agency_bid` is *derived
-from held PDFs*, so it is rebuilt from the bytes rather than diff-upserted.
+The tempting fix is a one-off migration that removes those known-bad rows. **That is the wrong
+shape**, and the principle above says why: a table whose contents have to be corrected once by
+hand is a table whose derivation should simply be re-run. A migration also encodes today's list
+of known contamination, so the next parser improvement needs another one.
+
+So `rebuild_agency_bids(conn, source)` is not a migration but the **permanent contract**:
+`agency_bid` for a given source is rebuilt from the held PDFs on every store pass, exactly as
+`build_supplier_dimension` rebuilds the supplier dimension from scratch every sync and
+`enrich-ariba-attachments --reindex` rebuilds `ariba_attachment` from the on-disk zips. It is a
+sanctioned exception to "rows are never deleted" for the same reason those are: the table is
+*derived*, and the bytes it derives from are what the archive actually holds.
+
+The existing contamination then disappears as an ordinary consequence of the first run, with no
+list of bad rows written down anywhere — and every future parser fix self-heals the same way.
 
 **Derive first, delete only on success.** The full new row set is collected in memory; only if
 derivation completed without exception *and* produced rows does the delete + insert run, inside
@@ -185,6 +227,13 @@ measurement's call. If the numbers land ambiguously — coverage good but the tw
 disagreeing about *who bid* rather than merely about price — the choice returns to the user
 rather than being settled by the implementer.
 
+**A union is justified only by reports cells cannot reach, never as a safety net.** Keeping the
+bullet-list path "just in case" would be the same past-facing instinct the governing principle
+rules out: two extraction paths for one corpus, one of them unmeasured and permanent. If a union
+is what the measurement supports, it ships as a **single code path with a documented
+precedence** — cells where the results table is ruled, bullets where it is not, stated as a rule
+someone can read — rather than two parsers whose interaction has to be reconstructed later.
+
 The committee corpus is 8 reports, of which #164 measured that 6 of 8 yield nothing because
 **RFTs/RFQs tabulate bids while RFPs narrate them**. A ruled-table finding there is likely to be
 bounded by the same ceiling; the audit records that rather than treating 8 reports as a
@@ -199,10 +248,20 @@ statistical result.
   silent mis-anchor could hide.
 - **`zip_columns` gets the #94/#116 cases**: wrapped name with one price (one bid), multi-package
   column (positional zip), unequal columns (refused).
-- **An integration test over a held EP report**, skipped when the corpus is absent — the existing
+- **The EP bid-table tests are rewritten, not adapted.** They currently feed `.txt` pdftotext
+  fixtures to `parse_ep_bid_table(text)`; the new pure parser takes rows, so they get new
+  JSON-rows fixtures extracted from the real PDFs. Their assertions are re-derived from the
+  cells rather than carried over — some encode regex-era artifacts (a price capture "stopping
+  before the `*`" describes a flattened-text hazard that does not exist when the marker has its
+  own cell). The `.txt` fixtures stay, because `parse_ep_report` still reads prose and is
+  correctly regex.
+- **`store_ep_reports` takes its table reader as a parameter**, defaulting to `ep_bid_tables`.
+  A real EP report is ~113 KB, too heavy to commit as a fixture, and the alternative — a test
+  that inserts `background_pdf.text` and expects bids — would be asserting against a path that
+  no longer exists. The parameter is an explicit I/O seam of the kind `Source.fetch`/`normalize`
+  already draws, not a test shim: it is what lets the store pass be exercised without a PDF.
+- **An integration test over the held EP corpus**, skipped when it is absent — the existing
   pattern for council tests without `pdftotext`.
-- Existing EP bid-table tests are updated to the new `(rows)` signature; their *assertions* about
-  what should be extracted stay, since the point is that cells extract at least as much.
 
 ### 6. Sequencing
 
@@ -218,5 +277,5 @@ live systemd timers.
 |---|---|
 | Caption anchoring picks the wrong table on an unmeasured report | `choose_tables` is pure and unit-tested; step 3 of the audit re-runs #151's right-table check corpus-wide after the switch, not just before |
 | The rebuild deletes rows it cannot re-derive | Derive-first, delete-only-on-success, in one transaction, scoped to one source |
-| pdfplumber is slower than regex over cached text | Measured concern from #177 (~41s over 229 forms). EP is 47 reports with a table; if the nightly cost is material, the same "already stored, skip without opening the PDF" guard #177 added applies — recorded as a follow-up if measurement shows it matters |
+| pdfplumber is slower than regex over cached text, and §3 re-derives every run | Real tension, resolved deliberately. #177 measured ~41s per night re-parsing 229 forms and fixed it with a "already stored, skip without opening the PDF" guard — **that guard is incompatible with the rebuild contract** and must not be copied here, since skipping is what lets stale rows persist. EP opens ~107 PDFs per run (the reports that parse as awards), which is to be timed during implementation. If the cost is material — and it is far likelier to be for TRCA's 3,411 than EP's — the answer is a cache keyed on the PDF's **`sha256` *and* a parser-version stamp** — the hash alone is not enough, since it does not change when the parser is fixed, which is exactly when re-derivation matters. Bumping the stamp invalidates the whole corpus, preserving the contract. What must *not* be copied is a skip keyed on "rows already exist", which breaks it |
 | The audit finds a corpus that is *partly* ruled | The criterion admits this: a union outcome is legitimate (see TRCA), but it must be measured and stated, not assumed |

--- a/docs/superpowers/specs/2026-07-28-pdf-cell-tables-design.md
+++ b/docs/superpowers/specs/2026-07-28-pdf-cell-tables-design.md
@@ -20,10 +20,15 @@ tender". Two rounds of measurement inverted that premise:
 
 The third round answered the fork: **EP board reports carry ruled tables in 47/47**, the Award
 Summary Form profile (#116: 229/229 → cells) rather than the staff-report profile (#83: 13–20/229
-→ prose, regex correctly kept). Corpus-wide, the regex produces 143 rows and the first ruled
-table produces 126; the 17-row difference is exactly the contamination already identified. On the
-44 reports where the regex finds bids, its first bidder appears in the cell-derived table in
-**44/44**.
+→ prose, regex correctly kept).
+
+A fourth round, run while writing this spec, completed the rule set and measured it against the
+corpus's **own** ground truth rather than against the regex. Four rules — caption anchor,
+page-break walk, row = name + price-or-outcome, normalize — give 47/47 tables found, 0 junk
+rows, 0 duplicates, 32/35 exact agreement with declared bid counts, and **0 real bidders lost**.
+It also corrected the earlier framing: the switch is not a net removal of 17 contaminated rows
+but a removal of 19 alongside a **recovery of 14+ real bidders the regex was silently dropping**.
+Details in §2.
 
 `#203` observes that this conclusion has now been reached twice by identical methodology, and
 asks whether other regex-over-flattened-text parsers in this codebase are sitting on the same
@@ -44,8 +49,12 @@ win — as an **audit**, explicitly not a mandate to rewrite.
   candidate is decided on its own measurement.
 - **Council staff reports (`bgrd`).** #83 already measured them as prose. That is a complete
   answer for a candidate, not a gap.
-- **Capturing bid compliance markers.** Cells put `*Non-compliant` in its own column for the
-  first time, but adding a column to `AgencyBid` is out of scope here; noted as follow-up.
+- **A compliance FIELD on `AgencyBid`.** A non-compliant bidder is stored as a bid with
+  `bid_price` NULL (§2), which is #94's existing treatment; recording *why* the price is NULL
+  would need a new column and is a separate issue.
+- **Chasing edge cases.** Governed by CLAUDE.md's "Parsing discipline" section: the question is
+  whether a small stated rule set extracts a corpus cleanly, and if it cannot, the answer is to
+  stop and report — not to add rules. See §4's stop-and-ask gate.
 
 ## Governing principle
 
@@ -92,8 +101,23 @@ zip_columns(name_cell, price_cell) -> list[(name, price|None)] # PURE
   | caption `Table 2: Tender Separate Price Submission` | 386.5 |
   | its table | 411.1 |
 
-  A caption with no table below it on its page yields nothing rather than reaching onto the next
-  table — a missing table must read as absent, never as some other table's rows.
+  Within a page, a caption with no table below it yields nothing rather than reaching sideways to
+  some other table — a missing table must read as absent, never as another table's rows.
+
+  **A bid table breaks across pages in two shapes, and they are one event.** Measured on the
+  corpus:
+
+  - the caption sits at the foot of its page and the whole table is overleaf
+    (`backgroundfile-131331`: caption at y=705.8 on page 1, table at y=54.2 on page 2);
+  - the caption's table starts on its page and its remaining rows land at the top of the next
+    page as a **separate table object with no header row**
+    (`backgroundfile-244929`: 2 rows on page 1, then 7 more on page 2; `backgroundfile-167548`
+    likewise).
+
+  Both are handled by one walk: take the caption's table, then keep absorbing the next page's
+  first table for as long as that page has **no caption of its own** competing for it and its
+  first row is a **headerless continuation** (its price column already holds a price). Without
+  this, `131331` loses its only bidder and `244929` loses seven of nine.
 - **`zip_columns`** is #94's rule verbatim, for the reason #94 and #116 both give: pairing is
   positional, so one stray line misattributes every bid after it.
   - One price line → **one bid**, joining the name's wrapped lines. `#116` measured that reading
@@ -129,9 +153,25 @@ cells. A new `ep_bid_tables(path)` does the I/O via `caption_tables`.
   what makes "Table 1" identifiable without hardcoding the digit `1`. Where several captions
   match, the **first** is taken.
 - Column 0 is the bidder, column 1 the base bid price — the current "take the FIRST `$`"
-  semantics, now structural rather than positional-within-flattened-text. The header row
-  (`Bidder`, `Bid Price Received`, `Recommended\nContract Price`) is skipped by its own cells,
-  not by a denylist of header strings.
+  semantics, now structural rather than positional-within-flattened-text.
+- **The header row is rejected structurally, never by a denylist of header strings.** Column 0
+  is variously `Bidder` and `Tenderer`, and column 1 variously `Bid Price Received`,
+  `Base Bid Price\nReceived`, `Tender Price\nReceived` and `Initial Base Bid\nPrice Received`.
+  A row qualifies because its price column *holds a price*, not because its name column avoids a
+  known word.
+- **A price cell that holds an OUTCOME instead of a number is still a bid**, stored with
+  `bid_price` NULL. The City writes `*Non-compliant` / `** Non-Compliant` in the price column —
+  the same practice #94 documented on the BD agendas, where the raw string is kept and
+  `bid_price_numeric` is NULL for exactly those. This is not a new rule; it is an existing one
+  carried over. **It is worth 16 rows and it is what makes the corpus agree with its own declared
+  counts** — without it, `238906` yields 6 against a declared 8 and `285781` yields 7 against 9,
+  in both cases because the missing bidders are the non-compliant ones.
+- **Prices come with and without cents, and with markers on either side.** `$4,365,534` and
+  `$2,619,221` are real prices (`139154`, `229405` — the old regex required `\.\d{2}` and so
+  found neither, reporting those reports as bid-free). The compliance marker attaches before the
+  `$` (`*$792,900.00`) or after the amount (`$470,700.00*`); it is stripped from the stored
+  price. It is **not** captured as its own field — that would need a column on `AgencyBid` and is
+  a separate issue.
 - Wrapped names arrive whole inside one cell
   (`Enercare Home and\nCommercial Services Limited Partnership`), so the intra-cell newline is
   collapsed rather than treated as a row boundary.
@@ -148,16 +188,36 @@ cells. A new `ep_bid_tables(path)` does the I/O via `caption_tables`.
 - A PDF pdfplumber cannot read is **logged and skipped**, never silent — the award report itself
   still stores, only its bids are absent.
 
-Expected outcome, from the measurement: 143 rows → 126, the difference being 6 `Table 2`
-duplicates and ~11 prose phantoms. **Those are rows *parsed*, not rows *stored*:** `agency_bid`
-upserts on its key, so the store currently holds 115 EP rows against 143 parsed. Verification
-must compare like with like — parsed against parsed, or stored against stored — or the switch
-will read as a larger loss than it is. The 2 reports whose ruled table holds no bid-shaped rows
-(`backgroundfile-139154`, `backgroundfile-229405`) produce 0 bids under the current regex too —
-no regression.
+**Measured outcome of the completed rule set**, over all 1,200 held EP reports:
 
-Unrelated and deliberately not "fixed": `backgroundfile-254543` yields 0 bids because the City's
-own PDF carries a malformed price (`$1,479,386,.57`, stray comma before the decimal).
+| | |
+|---|---|
+| reports carrying a `Table 1` caption | 47 |
+| of those, reports where the anchor found the table | **47/47** |
+| rows extracted | **153** (regex: 143) |
+| rows failing a name sanity check | **0** |
+| duplicate rows within a report | **0** |
+| agreement with the reports' own declared bid counts | **32/35 exact** |
+| real bidders lost against the regex | **0** |
+
+The row count *rises* rather than falls, which inverts the earlier reading of this switch as
+pure removal. Both things happen at once: 13 prose phantoms and 6 `Table 2` duplicates go, and
+**14+ real bidders the regex silently dropped are recovered** — firms whose name begins with a
+digit (`1214592 Ontario Limited o/a Colonial Building Restoration`, `965046 Ontario Inc. o/a
+Quality Allied Elevator` — the #87/#116 lesson that a numeric-leading name is a real firm),
+firms whose price carries a leading marker (`*$792,900.00`, which cost `244900` its *winning*
+bidder), and prices without cents.
+
+**Those are rows *parsed*, not rows *stored*:** `agency_bid` upserts on its key, so the store
+currently holds 115 EP rows against 143 parsed. Verification must compare like with like — or
+the change will read as a loss where it is a gain.
+
+**The 3 residual count disagreements are the documents, not the parser, and no rule will be
+added for them** (the parsing discipline in CLAUDE.md: a disagreement with ground truth is often
+the document's own defect). `238908` and `244923` say outright that they tabulate only the
+compliant subset — *"four (4) submissions were received, three (3) of which were compliant"* —
+and `254543` carries a malformed price in the City's own PDF (`$1,479,386,.57`, stray comma
+before the decimal), which rule 3 refuses rather than guessing at. Each is logged, never silent.
 
 ### 3. `agency_bid` becomes derived-every-run, per source
 
@@ -195,20 +255,37 @@ trustworthy rather than suggestive:
 
 1. Ruled-table coverage on the **specific table type the parser targets** — not "any table on
    the page".
-2. Corpus-wide comparison of cell-derived rows against the current parser's output: count
-   agreements, and look hard at every disagreement to establish which side is contamination and
-   which is real loss.
-3. Validate that cells land on the **right** table (#151's 44/44 check), since a
-   first-table-with-money heuristic could in principle pick up something unrelated.
-4. Decide per-source.
+2. Find the corpus's own **ground truth** (a declared bid or item count in the report text) and
+   measure the candidate rules against *that*. The incumbent parser is not a baseline; it is the
+   thing under suspicion. EP's ground truth is "N submissions were received", present on 35 of
+   47; each corpus needs its own equivalent located before the comparison means anything.
+3. Scan the output for **junk and duplicates** — rows that are not (bidder, price) at all.
+4. Compare against the current parser only to classify *disagreements*: which side is
+   contamination, which is real loss, which is the document's own defect.
+5. Decide per-source.
 
 **The switch criterion is fixed here, in advance, so the numbers decide rather than preference:**
 
-> Switch iff (a) ruled-table coverage holds on the specific target table across the reports the
-> current parser finds rows in, (b) the right-table check reproduces the current parser's first
-> bidder with no unexplained mismatch, and (c) every disagreement resolves as
-> contamination-removed or data-added rather than real loss. Otherwise: document the corpus as
-> prose, keep the regex, and record the measurement so it is not re-litigated.
+> Switch iff (a) the target table is found on effectively every report that has one, (b) the
+> output carries no junk and no duplicates, (c) it agrees with the corpus's own declared counts
+> except where the disagreement is traceable to the document, and (d) **no real rows are lost**
+> against the incumbent. Otherwise: document the corpus as prose, keep the regex, and record the
+> measurement so it is not re-litigated.
+
+**The stop-and-ask gate (CLAUDE.md, "Parsing discipline").** This audit is explicitly *not* a
+licence to chase edge cases across three more corpora. Each candidate gets a measurement pass
+and **one** pass of rule refinement, with the **rule count** as the governing signal:
+
+- **Convergent** — each new wrinkle collapses into a rule already written, and the count holds
+  flat. That is what EP did: four rules in, four rules out, with the two page-break shapes
+  becoming one walk and the `Non-compliant` case turning out to be #94's existing rule. Proceed.
+- **Divergent** — the count climbs and each fix reveals a wrinkle elsewhere. **Stop. Do not
+  write rule five. Report back to the user**, with the measurement, and default to keeping the
+  regex.
+
+"This corpus cannot be cleanly extracted" is a complete and acceptable answer for any candidate
+— #83 reached exactly that for staff reports and it stands. A corpus abandoned on measurement is
+a success of this audit, not a failure of it.
 
 Candidates:
 
@@ -275,7 +352,7 @@ live systemd timers.
 
 | risk | mitigation |
 |---|---|
-| Caption anchoring picks the wrong table on an unmeasured report | `choose_tables` is pure and unit-tested; step 3 of the audit re-runs #151's right-table check corpus-wide after the switch, not just before |
+| Caption anchoring picks the wrong table on an unmeasured report | `choose_tables` is pure and unit-tested; the junk/duplicate scan and the declared-count check (§4 steps 2–3) are re-run corpus-wide after the switch, not just before. Already exercised: the anchor is what keeps `139154`'s unrelated page-4 cost-breakdown table (`Item`/`Amount`/`Comments`) out of the bids, which a "first table containing money" heuristic would have taken |
 | The rebuild deletes rows it cannot re-derive | Derive-first, delete-only-on-success, in one transaction, scoped to one source |
-| pdfplumber is slower than regex over cached text, and §3 re-derives every run | Real tension, resolved deliberately. #177 measured ~41s per night re-parsing 229 forms and fixed it with a "already stored, skip without opening the PDF" guard — **that guard is incompatible with the rebuild contract** and must not be copied here, since skipping is what lets stale rows persist. EP opens ~107 PDFs per run (the reports that parse as awards), which is to be timed during implementation. If the cost is material — and it is far likelier to be for TRCA's 3,411 than EP's — the answer is a cache keyed on the PDF's **`sha256` *and* a parser-version stamp** — the hash alone is not enough, since it does not change when the parser is fixed, which is exactly when re-derivation matters. Bumping the stamp invalidates the whole corpus, preserving the contract. What must *not* be copied is a skip keyed on "rows already exist", which breaks it |
+| pdfplumber is slower than regex over cached text, and §3 re-derives every run | Real tension, resolved deliberately. #177 measured ~41s per night re-parsing 229 forms and fixed it with a "already stored, skip without opening the PDF" guard — **that guard is incompatible with the rebuild contract** and must not be copied here, since skipping is what lets stale rows persist. Measured during the audit: 6.5s to open and extract all 47 caption-bearing EP reports, so the ~107 that parse as awards land around 15s per run — acceptable, and to be confirmed on the real store pass. If the cost is material — and it is far likelier to be for TRCA's 3,411 than EP's — the answer is a cache keyed on the PDF's **`sha256` *and* a parser-version stamp** — the hash alone is not enough, since it does not change when the parser is fixed, which is exactly when re-derivation matters. Bumping the stamp invalidates the whole corpus, preserving the contract. What must *not* be copied is a skip keyed on "rows already exist", which breaks it |
 | The audit finds a corpus that is *partly* ruled | The criterion admits this: a union outcome is legitimate (see TRCA), but it must be measured and stated, not assumed |

--- a/scrapers/tests/fixtures/agencies/ep_bid_table_2019_five_bidders.json
+++ b/scrapers/tests/fixtures/agencies/ep_bid_table_2019_five_bidders.json
@@ -1,0 +1,6 @@
+[[["Tenderer", "Tender Price\nReceived", "Recommended\nContract Price"],
+  ["Sutherland-Schultz Ltd.", "$418,854.47", "$403,854.47"],
+  ["Ontario Electrical Construction Co. Ltd.", "$461,522.00", ""],
+  ["Modern Niagara Toronto Inc.", "$470,700.00*", ""],
+  ["Stevens & Black Electrical Contractors Ltd.", "$518,000.00", ""],
+  ["Rogol Electric Company Limited", "$546,350.00", ""]]]

--- a/scrapers/tests/fixtures/agencies/ep_bid_table_2023_three_bidders.json
+++ b/scrapers/tests/fixtures/agencies/ep_bid_table_2023_three_bidders.json
@@ -1,0 +1,4 @@
+[[["Bidder", "Base Bid Price\nReceived", "Recommended\nContract Price"],
+  ["Powell Fence Limited", "$1,484,065.00", "$1,484,065.00"],
+  ["M.J.K. Construction Incorporated", "$1,619,001.00", ""],
+  ["Clearway Construction Incorporated", "$1,851,100.00", ""]]]

--- a/scrapers/tests/fixtures/agencies/ep_bid_table_no_cents.json
+++ b/scrapers/tests/fixtures/agencies/ep_bid_table_no_cents.json
@@ -1,0 +1,2 @@
+[[["Bidder", "Base Bid Price\nReceived", "Recommended Contract\nPrice"],
+  ["Black & McDonald Limited", "$2,619,221", "$2,619,221"]]]

--- a/scrapers/tests/fixtures/agencies/ep_bid_table_noncompliant.json
+++ b/scrapers/tests/fixtures/agencies/ep_bid_table_noncompliant.json
@@ -1,0 +1,9 @@
+[[["Bidder", "Base Bid Price\nReceived", "Additional\nPrices\nIncluded", "Recommended\nTotal Contract\nPrice"],
+  ["CMS Electrical Group Ltd.", "$1,095,900.00", "$860,239.00", "$1,956,139.00"],
+  ["Energy Network Services Inc.", "$1,223,029.36", "", ""],
+  ["Kudlak-Baird (1982) Limited", "$2,334,973.00", "", ""],
+  ["Modern Niagara Toronto Inc.", "$1,496,274.61", "", ""],
+  ["OZZ Electric Inc.", "$1,328,914.00", "", ""],
+  ["Stevens & Black Electrical\nContractors Ltd.", "$1,576,400.00", "", ""],
+  ["* Plaza Electric Ltd.", "*Non-compliant", "", ""],
+  ["* Trade Electrical Contractors Inc.", "*Non-compliant", "", ""]]]

--- a/scrapers/tests/test_db.py
+++ b/scrapers/tests/test_db.py
@@ -216,3 +216,29 @@ def test_solicitation_link_table_exists_and_is_counted(conn):
                  "VALUES ('2016.BD106.3', '5672751291', 'council_pre_ariba')")
     conn.commit()
     assert db.counts(conn)["solicitation_link"] == 1
+
+
+def test_rebuild_agency_bids_replaces_only_its_own_source(conn):
+    from toronto_bids.models import AgencyBid
+    from toronto_bids.store import db
+    keep = AgencyBid(buyer_id=1, native_ref="T-1", bidder_name_raw="Keep Ltd.",
+                     bid_price="$1.00", source="trca_board")
+    stale = AgencyBid(buyer_id=1, native_ref="E-1", bidder_name_raw="Phantom",
+                      bid_price="$2.00", source="ep_board")
+    db.upsert_row(conn, keep, overwrite=True)
+    db.upsert_row(conn, stale, overwrite=True)
+    fresh = [AgencyBid(buyer_id=1, native_ref="E-1", bidder_name_raw="Real Ltd.",
+                       bid_price="$3.00", source="ep_board")]
+    assert db.rebuild_agency_bids(conn, "ep_board", fresh) == 1
+    names = {r["bidder_name_raw"] for r in conn.execute("SELECT bidder_name_raw FROM agency_bid")}
+    assert names == {"Keep Ltd.", "Real Ltd."}          # phantom gone, TRCA untouched
+
+
+def test_rebuild_agency_bids_deletes_nothing_when_it_derived_nothing(conn):
+    from toronto_bids.models import AgencyBid
+    from toronto_bids.store import db
+    db.upsert_row(conn, AgencyBid(buyer_id=1, native_ref="E-1", bidder_name_raw="Held Ltd.",
+                                  bid_price="$1.00", source="ep_board"), overwrite=True)
+    # A machine that holds no PDFs derives no rows, and must therefore delete none.
+    assert db.rebuild_agency_bids(conn, "ep_board", []) == 0
+    assert conn.execute("SELECT COUNT(*) FROM agency_bid").fetchone()[0] == 1

--- a/scrapers/tests/test_ep_reports.py
+++ b/scrapers/tests/test_ep_reports.py
@@ -166,16 +166,39 @@ def test_store_ep_reports_lands_award_and_bids(conn):
     from toronto_bids.buyers import seed_buyers
     from toronto_bids.sources.ep_board import store_ep_reports
     ids = seed_buyers(conn)
-    conn.execute("INSERT INTO background_pdf (url, kind, sha256, text) VALUES "
+    conn.execute("INSERT INTO background_pdf (url, kind, sha256, local_path, text) VALUES "
                  "('https://www.toronto.ca/legdocs/mmis/2023/ep/bgrd/backgroundfile-240943.pdf',"
-                 " 'agency_board', 'x', ?)", (_read("ep_award_with_table_2023.txt"),))
+                 " 'agency_board', 'x', '/nowhere/x.pdf', ?)",
+                 (_read("ep_award_with_table_2023.txt"),))
     conn.commit()
-    got = store_ep_reports(conn, ids["exhibition-place"])
+    # The bid table now comes from the PDF's cells, so the reader is injected: a real EP report
+    # is ~113 KB, too heavy to commit as a fixture, and the seam is the same fetch/normalize
+    # boundary sources/base.py draws.
+    got = store_ep_reports(conn, ids["exhibition-place"],
+                           tables_for=lambda _p: _rows("ep_bid_table_2023_three_bidders.json"))
     assert got["solicitations"] == 1 and got["awards"] == 1 and got["bids"] == 3
     aw = conn.execute("SELECT supplier_name_raw, award_amount_numeric FROM agency_award "
                       "WHERE native_ref='EP110-2023'").fetchone()
     assert aw["supplier_name_raw"] == "Powell Fence Limited"
     assert aw["award_amount_numeric"] == 1484065.00
-    bids = conn.execute("SELECT COUNT(*) FROM agency_bid WHERE bid_price_numeric IS NOT NULL "
-                        "AND native_ref='EP110-2023'").fetchone()[0]
-    assert bids == 3
+    assert conn.execute("SELECT COUNT(*) FROM agency_bid WHERE bid_price_numeric IS NOT NULL "
+                        "AND native_ref='EP110-2023'").fetchone()[0] == 3
+
+
+def test_store_ep_reports_survives_an_unreadable_pdf(conn):
+    from toronto_bids.buyers import seed_buyers
+    from toronto_bids.sources.ep_board import store_ep_reports
+    ids = seed_buyers(conn)
+    conn.execute("INSERT INTO background_pdf (url, kind, sha256, local_path, text) VALUES "
+                 "('https://www.toronto.ca/legdocs/mmis/2023/ep/bgrd/backgroundfile-240943.pdf',"
+                 " 'agency_board', 'x', '/nowhere/x.pdf', ?)",
+                 (_read("ep_award_with_table_2023.txt"),))
+    conn.commit()
+
+    def boom(_path):
+        raise OSError("no such file")
+
+    logged = []
+    got = store_ep_reports(conn, ids["exhibition-place"], tables_for=boom, log=logged.append)
+    assert got["awards"] == 1 and got["bids"] == 0     # the award still lands
+    assert any("240943" in m for m in logged)          # and the gap is never silent

--- a/scrapers/tests/test_ep_reports.py
+++ b/scrapers/tests/test_ep_reports.py
@@ -34,6 +34,7 @@ def test_ep_buyer_seeded():
     conn.close()
 
 
+import json
 import pathlib
 
 from toronto_bids.sources.ep_board import parse_ep_bid_table, parse_ep_report
@@ -105,31 +106,60 @@ def test_confidential_non_procurement_matter_is_refused():
                            fallback_ref="2024.EP3.5") is None
 
 
+def _rows(name):
+    return json.loads((FIXTURES / name).read_text())
+
+
 def test_bid_table_extracts_all_three_bidders_with_prices():
-    rows = parse_ep_bid_table(_read("ep_award_with_table_2023.txt"))
-    assert rows == [
+    assert parse_ep_bid_table(_rows("ep_bid_table_2023_three_bidders.json")) == [
         ("Powell Fence Limited", "$1,484,065.00"),
         ("M.J.K. Construction Incorporated", "$1,619,001.00"),
         ("Clearway Construction Incorporated", "$1,851,100.00"),
     ]
 
 
-def test_bid_table_2019_five_bidders_with_footnote_marker():
-    # 2019 "Table 1: Tender Price Submissions" (plural), 5 bidders, a `*` revised-price marker on
-    # one row — the price capture must stop before the `*`.
-    rows = parse_ep_bid_table(_read("ep_award_2019_multi_bidder.txt"))
-    assert rows == [
+def test_bid_table_2019_five_bidders_strips_a_marker_inside_the_price_cell():
+    # The header here says "Tenderer", not "Bidder" — the header row is rejected because its
+    # price column holds no price, never by a denylist of header words.
+    assert parse_ep_bid_table(_rows("ep_bid_table_2019_five_bidders.json")) == [
         ("Sutherland-Schultz Ltd.", "$418,854.47"),
         ("Ontario Electrical Construction Co. Ltd.", "$461,522.00"),
-        ("Modern Niagara Toronto Inc.", "$470,700.00"),      # the trailing * is dropped
+        ("Modern Niagara Toronto Inc.", "$470,700.00"),      # trailing * stripped
         ("Stevens & Black Electrical Contractors Ltd.", "$518,000.00"),
         ("Rogol Electric Company Limited", "$546,350.00"),
     ]
 
 
+def test_bid_table_keeps_a_non_compliant_bidder_with_a_null_price():
+    # #94's rule: the City writes OUTCOMES in the price column. The bidder is still a bid.
+    # backgroundfile-238906 declares 8 bids and only reaches 8 because these two count.
+    got = parse_ep_bid_table(_rows("ep_bid_table_noncompliant.json"))
+    assert len(got) == 8
+    assert got[-2:] == [("Plaza Electric Ltd.", None),      # leading marker stripped from name
+                        ("Trade Electrical Contractors Inc.", None)]
+
+
+def test_bid_table_accepts_a_price_with_no_cents():
+    # The old regex required \.\d{2} and read this report as having no bids at all.
+    assert parse_ep_bid_table(_rows("ep_bid_table_no_cents.json")) == [
+        ("Black & McDonald Limited", "$2,619,221")]
+
+
+def test_bid_table_wrapped_name_arrives_whole():
+    rows = [[["Bidder", "Bid Price Received", "Recommended\nContract Price"],
+             ["Enercare Home and\nCommercial Services Limited Partnership", "$653,323.00", ""]]]
+    assert parse_ep_bid_table(rows) == [
+        ("Enercare Home and Commercial Services Limited Partnership", "$653,323.00")]
+
+
 def test_bid_table_absent_returns_empty():
-    rows = parse_ep_bid_table(_read("ep_non_award_wsib_report.txt"))
-    assert rows == []                                    # no Table 1 -> no bids
+    assert parse_ep_bid_table([]) == []
+
+
+def test_bid_table_refuses_a_row_whose_price_column_is_neither_price_nor_outcome():
+    # Refuse, never guess — a row we cannot read is a gap, not an invented bid.
+    rows = [[["Bidder", "Bid Price Received"], ["Some Firm Ltd.", "see Appendix B"]]]
+    assert parse_ep_bid_table(rows) == []
 
 
 def test_store_ep_reports_lands_award_and_bids(conn):

--- a/scrapers/tests/test_pdf_tables.py
+++ b/scrapers/tests/test_pdf_tables.py
@@ -1,4 +1,5 @@
-from toronto_bids.sources.pdf_tables import choose_tables, is_continuation, is_price
+from toronto_bids.sources.pdf_tables import (choose_tables, is_continuation, is_price,
+                                             zip_columns)
 
 HDR = ["Bidder", "Bid Price Received", "Recommended\nContract Price"]
 R1 = ["Powell Fence Limited", "$1,484,065.00", "$1,484,065.00"]
@@ -62,3 +63,31 @@ def test_is_continuation_needs_a_price_in_the_second_column():
     assert is_continuation([["Crawford Roofing Corporation", "$1,660,000.00", ""]])
     assert not is_continuation([HDR])
     assert not is_continuation([])
+
+
+def test_one_price_line_is_one_bid_even_when_the_name_wraps():
+    # #116: reading a wrapped name's two lines as two names dropped a bidder from 4 forms.
+    assert zip_columns("2489960 Ontario Inc.\no/a Kore Infrastructure Group",
+                       "$3,198,000.00") == [
+        ("2489960 Ontario Inc. o/a Kore Infrastructure Group", "$3,198,000.00")]
+
+
+def test_a_multi_package_column_zips_positionally():
+    assert zip_columns("26TW-CPI-17CWD (Package A):\nClean Water Works Inc.*\nAqua Tech Inc.",
+                       "$3,551,718.88\n$3,978,656.19") == [
+        ("Clean Water Works Inc.*", "$3,551,718.88"),
+        ("Aqua Tech Inc.", "$3,978,656.19")]
+
+
+def test_unequal_columns_are_refused_rather_than_guessed():
+    # #94: pairing is positional, so one stray line misattributes every bid after it.
+    assert zip_columns("A Ltd.\nB Ltd.\nC Ltd.", "$1.00\n$2.00") == []
+
+
+def test_a_proponent_with_no_price_at_all_is_still_a_bid():
+    # An RFP publishes proponents with "NOTE: Not applicable for RFP" (#84 stores price NULL).
+    assert zip_columns("Some Consulting Inc.", "") == [("Some Consulting Inc.", None)]
+
+
+def test_an_empty_name_yields_nothing():
+    assert zip_columns("", "$1.00") == []

--- a/scrapers/tests/test_pdf_tables.py
+++ b/scrapers/tests/test_pdf_tables.py
@@ -1,0 +1,64 @@
+from toronto_bids.sources.pdf_tables import choose_tables, is_continuation, is_price
+
+HDR = ["Bidder", "Bid Price Received", "Recommended\nContract Price"]
+R1 = ["Powell Fence Limited", "$1,484,065.00", "$1,484,065.00"]
+R2 = ["M.J.K. Construction Incorporated", "$1,619,001.00", ""]
+
+
+def test_is_price_accepts_the_shapes_the_city_publishes():
+    assert is_price("$1,484,065.00")
+    assert is_price("$4,365,534")            # no cents (backgroundfile-229405)
+    assert is_price("*$792,900.00")          # leading marker (backgroundfile-244900)
+    assert is_price("$470,700.00*")          # trailing marker (backgroundfile-137241)
+    assert is_price("$ 449,000.00")          # space after the sign
+    assert not is_price("*Non-compliant")
+    assert not is_price("Bid Price Received")
+    assert not is_price("")
+    assert not is_price(None)
+
+
+def test_choose_tables_takes_the_first_table_below_each_caption():
+    # backgroundfile-254716: two captions, two tables, on one page.
+    pages = [([195.2, 386.5], [(219.8, [HDR, R1]), (411.1, [HDR, R2])])]
+    assert choose_tables(pages) == [[HDR, R1], [HDR, R2]]
+
+
+def test_choose_tables_ignores_a_table_above_its_caption():
+    # backgroundfile-139154: an unrelated cost-breakdown table sits above the caption.
+    decoy = [["Item", "Amount", "Comments"], ["Exterior Windows", "373,000", "..."]]
+    pages = [([427.6], [(54.3, decoy), (452.6, [HDR, R1])])]
+    assert choose_tables(pages) == [[HDR, R1]]
+
+
+def test_caption_at_page_foot_finds_its_table_overleaf():
+    # backgroundfile-131331: caption at y=705.8 on page 1, whole table at y=54.2 on page 2.
+    pages = [([705.8], []), ([], [(54.2, [HDR, R1])])]
+    assert choose_tables(pages) == [[HDR, R1]]
+
+
+def test_a_table_broken_across_a_page_absorbs_its_continuation():
+    # backgroundfile-244929: 2 rows on page 1, 7 more on page 2 as a headerless table.
+    cont = [["Crawford Roofing Corporation", "$1,660,000.00", "$1,720,000.00"]]
+    pages = [([624.7], [(635.5, [HDR, R1])]), ([], [(54.2, cont[0:1])])]
+    assert choose_tables(pages) == [[HDR, R1, cont[0]]]
+
+
+def test_a_next_page_with_its_own_caption_is_not_absorbed():
+    # The next page's table belongs to that page's caption, not to ours.
+    pages = [([624.7], [(635.5, [HDR, R1])]), ([100.0], [(120.0, [HDR, R2])])]
+    assert choose_tables(pages) == [[HDR, R1], [HDR, R2]]
+
+
+def test_a_next_page_opening_with_a_header_is_a_new_table_not_a_continuation():
+    pages = [([624.7], [(635.5, [HDR, R1])]), ([], [(54.2, [HDR, R2])])]
+    assert choose_tables(pages) == [[HDR, R1]]
+
+
+def test_a_caption_with_no_table_anywhere_yields_nothing():
+    assert choose_tables([([100.0], [])]) == []
+
+
+def test_is_continuation_needs_a_price_in_the_second_column():
+    assert is_continuation([["Crawford Roofing Corporation", "$1,660,000.00", ""]])
+    assert not is_continuation([HDR])
+    assert not is_continuation([])

--- a/scrapers/tests/test_pdf_tables.py
+++ b/scrapers/tests/test_pdf_tables.py
@@ -1,5 +1,12 @@
+import pathlib
+import re
+
+import pytest
+
 from toronto_bids.sources.pdf_tables import (choose_tables, is_continuation, is_price,
                                              zip_columns)
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
 
 HDR = ["Bidder", "Bid Price Received", "Recommended\nContract Price"]
 R1 = ["Powell Fence Limited", "$1,484,065.00", "$1,484,065.00"]
@@ -91,3 +98,9 @@ def test_a_proponent_with_no_price_at_all_is_still_a_bid():
 
 def test_an_empty_name_yields_nothing():
     assert zip_columns("", "$1.00") == []
+
+
+def test_caption_tables_on_a_pdf_with_no_tables_returns_nothing():
+    pytest.importorskip("pdfplumber")
+    from toronto_bids.sources.pdf_tables import caption_tables
+    assert caption_tables(FIXTURES / "tiny.pdf", re.compile(r"Table\s+1", re.I)) == []

--- a/scrapers/toronto_bids/sources/award_summary.py
+++ b/scrapers/toronto_bids/sources/award_summary.py
@@ -165,17 +165,9 @@ _WS = re.compile(r"\s+")
 
 def form_rows(path) -> list[list[str]]:
     """Every non-empty row of every ruled table in the form, as stripped cells. Does I/O."""
-    import pdfplumber
+    from toronto_bids.sources.pdf_tables import all_tables
 
-    rows = []
-    with pdfplumber.open(path) as pdf:
-        for page in pdf.pages:
-            for table in page.extract_tables() or []:
-                for row in table:
-                    cells = [(c or "").strip() for c in row]
-                    if any(cells):
-                        rows.append([c for c in cells if c])
-    return rows
+    return all_tables(path)
 
 
 def parse_award_summary(rows) -> dict | None:

--- a/scrapers/toronto_bids/sources/award_summary.py
+++ b/scrapers/toronto_bids/sources/award_summary.py
@@ -34,6 +34,7 @@ from urllib.parse import quote
 from toronto_bids import config
 from toronto_bids.linking.document_number import normalize_document_number
 from toronto_bids.models import BackgroundPdf, Bid
+from toronto_bids.sources.pdf_tables import zip_columns
 from toronto_bids.store import db
 
 _DATA = ("https://secure.toronto.ca/c3api_data/v2/DataAccess.svc/pmmd_solicitations/"
@@ -177,44 +178,6 @@ def form_rows(path) -> list[list[str]]:
     return rows
 
 
-def _zip_cell(name_cell: str, price_cell: str) -> list[tuple[str, str | None]]:
-    """Pair one row's bidder lines against its price lines.
-
-    Usually a row is one bidder. A multi-package tender instead puts a whole column in a single
-    cell, exactly as the BD agendas did (#94):
-
-        ['26TW-CPI-17CWD (Package A):\nClean Water Works Inc.*\nAqua Tech...',
-         '$3,551,718.88\n$3,978,656.19\n$5,381,389.24\n$5,668,197.16']
-
-    Same rule as #94, and for the same reason: pairing is positional, so one stray line
-    misattributes every bid after it. Zip the columns and REFUSE an unequal pair rather than
-    guess. The package heading is dropped first — it ends in ':' and has no price beside it.
-
-    **THE PRICE CELL'S LINE COUNT SAYS HOW MANY BIDS THE ROW HOLDS.** A newline inside a name
-    cell is otherwise ambiguous, and guessing costs real bids: pdfplumber wraps a long name
-    within its own cell, so
-
-        ['2489960 Ontario Inc.\no/a Kore Infrastructure Group', '$3,198,000.00']
-
-    is ONE bidder, and reading its two lines as two names against one price refused the pair
-    and silently dropped a bidder from each of 4 forms. One price, one bid — join the name.
-    """
-    prices = [ln.strip() for ln in price_cell.split("\n") if ln.strip()]
-    names = [ln.strip() for ln in name_cell.split("\n") if ln.strip()]
-    names = [n for n in names if not n.endswith(":")]
-    if len(prices) <= 1:
-        name = " ".join(names)
-        if not name:
-            return []
-        # An RFP publishes its proponents with NO price at all ("NOTE: Not applicable for
-        # RFP"). #84 already stores those as bid_price NULL — requiring a price here dropped
-        # every proponent on every scored RFP.
-        return [(name, prices[0] if prices else None)]
-    if len(names) != len(prices):
-        return []
-    return list(zip(names, prices))
-
-
 def parse_award_summary(rows) -> dict | None:
     """{document_number, price_header, hst_basis, declared_bids, bids: [...]} or None.
 
@@ -247,7 +210,7 @@ def parse_award_summary(rows) -> dict | None:
             continue
         if label.lower().startswith(("range:", "note")):
             continue
-        for name, price in _zip_cell(label, value):
+        for name, price in zip_columns(label, value):
             name = _NAME_MARKERS.sub("", _WS.sub(" ", _NUMBERING.sub("", name)).strip())
             if not name:
                 continue          # an empty numbered row: the City leaves '5.' blank

--- a/scrapers/toronto_bids/sources/ep_board.py
+++ b/scrapers/toronto_bids/sources/ep_board.py
@@ -10,6 +10,7 @@ import re
 
 from toronto_bids import config
 from toronto_bids.models import AgencyAward, AgencyBid, AgencySolicitation, BackgroundPdf
+from toronto_bids.sources import pdf_tables
 from toronto_bids.sources.agency_report import AMOUNT_RE, CONFIDENTIAL_RE, amount_or_none
 from toronto_bids.sources.bid_award_panel import (cached_agendas, parse_agenda_pdfs,
                                                   scrape_agendas)
@@ -138,33 +139,58 @@ def parse_ep_report(text: str, fallback_ref: str, report_url: str | None = None)
     }
 
 
-# A Table 1 row: a bidder name (letters/&/./,/spaces) followed by its first $ price. The winner
-# row carries a second $ (recommended contract price); take the FIRST. Column-header lines
-# ("Base Bid Price", "Received", "Recommended Contract Price") have no leading firm name + price
-# on the same run and are skipped by requiring a name that ends in a company word OR a name-then-$
-# on one line. Refuse a line that isn't a clean name+price (the #94 rule).
-_EP_BID_ROW = re.compile(
-    r"^\s*([A-Z][A-Za-z0-9&.,'’ \-]{3,60}?)\s+(\$\s?\d{1,3}(?:,\d{3})*\.\d{2})", re.M)
+# The Table 1 caption. UNCHANGED from the regex era, and it already excludes
+# "Table 2: Tender Separate Price Submission" — after "Table 2" that text reads "Tender
+# Separate Price Submission", so there is no "Tender Price Submission" to match. That is what
+# identifies Table 1 without hardcoding the digit.
 _EP_TABLE_HEAD = re.compile(r"Table\s+\d[^\n]*Tender\s+Price\s+Submission", re.I)
+# The City writes OUTCOMES in the price column instead of a number — the same practice #94
+# documented on the BD agendas, where the raw string is kept and bid_price_numeric is NULL for
+# exactly those. Such a row is still a bid; its price is simply not a number.
+_EP_OUTCOME = re.compile(r"^[*\s]*(?:non[-\s]?compliant|no\s+bid|not\s+applicable|withdrawn|"
+                         r"disqualified|incomplete)\b", re.I)
+# Compliance markers leading or trailing a name ("* Plaza Electric Ltd."), stripped so the firm
+# keys consistently in the supplier dimension.
+_MARKERS = re.compile(r"^[\s*^+\u2020\u2021\u00a7]+|[\s*^+\u2020\u2021\u00a7]+$")
 
 
-def parse_ep_bid_table(text: str) -> list[tuple[str, str]]:
-    """Every (bidder, base-bid-price) in an EP 'Table 1: Tender Price Submission'. Empty if the
-    report has no such table."""
-    head = _EP_TABLE_HEAD.search(text)
-    if not head:
+def ep_bid_tables(path):
+    """The report's 'Table 1: Tender Price Submission' as cells. Does I/O."""
+    return pdf_tables.caption_tables(path, _EP_TABLE_HEAD)
+
+
+def parse_ep_bid_table(tables) -> list[tuple[str, str | None]]:
+    """Every (bidder, price) in an EP Table 1. Pure over the cells ep_bid_tables() read.
+
+    Four rules, and they were measured to converge rather than proliferate (#151): the caption
+    anchor and the page-break walk live in pdf_tables.choose_tables; this function is the row
+    rule and the normalisation.
+
+    A row is a bid when column 0 names something and column 1 holds either a price or an
+    outcome. The header row is rejected structurally by that same test, never by a denylist of
+    header words — column 0 is variously "Bidder" and "Tenderer", and column 1 variously
+    "Bid Price Received", "Base Bid Price\\nReceived" and "Initial Base Bid\\nPrice Received".
+
+    Anything else is REFUSED rather than guessed at: backgroundfile-254543 carries a malformed
+    price in the City's own PDF ($1,479,386,.57) and yields one bid instead of two, which is
+    the document's own defect and is not something to add a rule for.
+    """
+    if not tables:
         return []
-    # Scope to the region after the header up to a blank-line gap / the next section.
-    tail = text[head.end():head.end() + 1500]
-    rows = []
-    for m in _EP_BID_ROW.finditer(tail):
-        name = re.sub(r"\s+", " ", m.group(1)).strip()
-        price = m.group(2).replace(" ", "")
-        # Skip a column-header fragment that slipped through (no company suffix and generic words).
-        if name.lower() in {"base bid price", "recommended contract price", "received"}:
+    out = []
+    for row in tables[0]:
+        cells = [(c or "").strip() for c in row]
+        if len(cells) < 2 or not cells[0]:
             continue
-        rows.append((name, price))
-    return rows
+        name = _MARKERS.sub("", _WS.sub(" ", cells[0]).strip())
+        if not name:
+            continue
+        if pdf_tables.is_price(cells[1]):
+            out.append((name, cells[1].strip("* ").replace(" ", "")))
+        elif _EP_OUTCOME.match(cells[1]):
+            out.append((name, None))
+    return out
+
 
 
 def store_ep_reports(conn, buyer_id: int) -> dict:

--- a/scrapers/toronto_bids/sources/ep_board.py
+++ b/scrapers/toronto_bids/sources/ep_board.py
@@ -6,6 +6,7 @@ the bid_award_panel prober; the EP reference format is YYYY.EP<meeting>.<item> (
 live). Most EP board reports are NOT procurement awards, so the parsers (added next) refuse
 non-awards.
 """
+import pathlib
 import re
 
 from toronto_bids import config
@@ -193,14 +194,25 @@ def parse_ep_bid_table(tables) -> list[tuple[str, str | None]]:
 
 
 
-def store_ep_reports(conn, buyer_id: int) -> dict:
+def store_ep_reports(conn, buyer_id: int, tables_for=None, log=lambda _m: None) -> dict:
     """Parse held EP reports into agency rows. One AgencySolicitation + AgencyAward per award
     report (confidential ones keep the winner, NULL amount), and one AgencyBid per Table 1 row.
-    Non-award reports are refused by parse_ep_report and contribute nothing."""
+    Non-award reports are refused by parse_ep_report and contribute nothing.
+
+    Bids are read from the PDF's own CELLS (#151), so `tables_for` is injected: it defaults to
+    `ep_bid_tables` and is overridden in tests, which must not need a 113 KB PDF on disk.
+
+    `agency_bid` for this source is REBUILT, not upserted (see db.rebuild_agency_bids): the
+    whole set is derived first and only then replaces what is stored, so a parser fix self-heals
+    and a missing corpus deletes nothing.
+    """
+    tables_for = tables_for if tables_for is not None else ep_bid_tables
     counts = {"solicitations": 0, "awards": 0, "bids": 0}
+    bids: list[AgencyBid] = []
     for row in conn.execute(
-            "SELECT reference, url, text FROM background_pdf WHERE kind='agency_board' "
-            "AND url LIKE '%/ep/%' AND text IS NOT NULL ORDER BY url").fetchall():
+            "SELECT reference, url, text, local_path FROM background_pdf "
+            "WHERE kind='agency_board' AND url LIKE '%/ep/%' AND text IS NOT NULL "
+            "ORDER BY url").fetchall():
         got = parse_ep_report(row["text"], fallback_ref=row["reference"] or row["url"],
                               report_url=row["url"])
         if got is None:
@@ -215,10 +227,23 @@ def store_ep_reports(conn, buyer_id: int) -> dict:
             award_amount=got["amount"], value_confidential=got["confidential"], award_date=None,
             report_url=got["report_url"], source="ep_board"), overwrite=True)
         counts["awards"] += 1
-        for bidder, price in parse_ep_bid_table(row["text"]):
-            db.upsert_row(conn, AgencyBid(
+        if not row["local_path"]:
+            continue
+        # `local_path` is an ABSOLUTE path baked in on whichever machine fetched the report, and
+        # this archive is designed to migrate. The file's identity is its content-addressed
+        # <sha256>.pdf name; its location is deterministic under the CURRENT data dir.
+        path = config.EP_REPORTS_DIR / pathlib.Path(row["local_path"]).name
+        try:
+            tables = tables_for(path)
+        except Exception as exc:              # noqa: BLE001 — one unreadable PDF must never
+            # abort the pass, but it must never be silent either: a skip nobody can see is a
+            # skip nobody fixes (#175).
+            log(f"    ep unreadable {row['url'].rsplit('/', 1)[-1]}: {exc}")
+            continue
+        for bidder, price in parse_ep_bid_table(tables):
+            bids.append(AgencyBid(
                 buyer_id=buyer_id, native_ref=got["native_ref"], bidder_name_raw=bidder,
-                bid_price=price, report_url=row["url"], source="ep_board"), overwrite=True)
-            counts["bids"] += 1
+                bid_price=price, report_url=row["url"], source="ep_board"))
     conn.commit()
+    counts["bids"] = db.rebuild_agency_bids(conn, "ep_board", bids)
     return counts

--- a/scrapers/toronto_bids/sources/pdf_tables.py
+++ b/scrapers/toronto_bids/sources/pdf_tables.py
@@ -1,0 +1,68 @@
+"""Reading tables out of PDFs that HAVE tables (#151, #203).
+
+The rule this module serves is #116's: **read cells where the PDF HAS cells** — never
+"pdfplumber is better". Whether a given corpus qualifies is a per-corpus measurement
+(CLAUDE.md, "Parsing discipline"); #83 measured a corpus where cells are *worse*. This module
+is only the machinery for the corpora that qualify.
+
+Split so the risky part needs no PDF to test: `choose_tables` and `zip_columns` are pure and
+carry every structural rule; `all_tables`/`caption_tables` do the I/O and nothing else — the
+same fetch/normalize seam `sources/base.py` draws for a Source.
+"""
+import re
+
+# A published price, with or without cents, with a compliance marker on either side, and with
+# or without a space after the sign. Every shape here is live-measured on the EP corpus: the
+# old regex required `\.\d{2}` and so read `$4,365,534` (backgroundfile-229405) as "no bids".
+_PRICE = re.compile(r"^[*\s]*\$\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})?[*\s]*$")
+
+
+def is_price(cell) -> bool:
+    return bool(_PRICE.match((cell or "").strip()))
+
+
+def is_continuation(rows) -> bool:
+    """True when a table opens with DATA rather than a header — the signature of a table that
+    broke across a page boundary and resumed at the top of the next page."""
+    return bool(rows) and len(rows[0]) > 1 and is_price(rows[0][1])
+
+
+def choose_tables(pages):
+    """One table per caption, page-break continuations absorbed.
+
+    `pages` is `[(caption_tops, [(table_top, rows), ...]), ...]` in document order — the
+    geometry, with pdfplumber already out of the picture.
+
+    A caption claims the first table BELOW it on its own page. Two page-break shapes then
+    complicate that, and both are the same event so both are handled by one walk:
+
+      - the caption sits at the foot of its page and the whole table is overleaf
+        (backgroundfile-131331: caption y=705.8 page 1, table y=54.2 page 2);
+      - the caption's table starts on its page and the remaining rows land at the top of the
+        next page as a SEPARATE table object with no header row
+        (backgroundfile-244929: 2 rows, then 7).
+
+    Absorption requires the next page to have no caption of its own competing for the table,
+    and the table to open with data rather than a header. Without this, 131331 loses its only
+    bidder and 244929 seven of its nine.
+    """
+    out = []
+    for i, (captions, tables) in enumerate(pages):
+        for top in sorted(captions):
+            below = [t for t in tables if t[0] > top]
+            j = i
+            if below:
+                rows = list(min(below, key=lambda t: t[0])[1])
+            elif i + 1 < len(pages) and pages[i + 1][1] and not pages[i + 1][0]:
+                j = i + 1
+                rows = list(min(pages[j][1], key=lambda t: t[0])[1])
+            else:
+                continue          # a caption with no table is absent, not someone else's rows
+            while j + 1 < len(pages) and pages[j + 1][1] and not pages[j + 1][0]:
+                nxt = min(pages[j + 1][1], key=lambda t: t[0])[1]
+                if not is_continuation(nxt):
+                    break
+                rows.extend(nxt)
+                j += 1
+            out.append(rows)
+    return out

--- a/scrapers/toronto_bids/sources/pdf_tables.py
+++ b/scrapers/toronto_bids/sources/pdf_tables.py
@@ -66,3 +66,36 @@ def choose_tables(pages):
                 j += 1
             out.append(rows)
     return out
+
+
+def zip_columns(name_cell, price_cell):
+    """Pair one row's bidder lines against its price lines.
+
+    Usually a row is one bidder. A multi-package tender instead puts a whole column in a single
+    cell, exactly as the BD agendas did (#94). Same rule, same reason: pairing is positional, so
+    one stray line misattributes every bid after it. Zip the columns and REFUSE an unequal pair
+    rather than guess. A package heading is dropped first — it ends in ':' and has no price.
+
+    **THE PRICE CELL'S LINE COUNT SAYS HOW MANY BIDS THE ROW HOLDS.** A newline inside a name
+    cell is otherwise ambiguous, and guessing costs real bids: pdfplumber wraps a long name
+    within its own cell, so
+
+        ['2489960 Ontario Inc.\\no/a Kore Infrastructure Group', '$3,198,000.00']
+
+    is ONE bidder, and reading its two lines as two names refused the pair and silently dropped
+    a bidder from each of 4 forms (#116). One price, one bid — join the name.
+    """
+    prices = [ln.strip() for ln in (price_cell or "").split("\n") if ln.strip()]
+    names = [ln.strip() for ln in (name_cell or "").split("\n") if ln.strip()]
+    names = [n for n in names if not n.endswith(":")]
+    if len(prices) <= 1:
+        name = " ".join(names)
+        if not name:
+            return []
+        # An RFP publishes its proponents with NO price at all ("NOTE: Not applicable for
+        # RFP"). #84 already stores those as bid_price NULL — requiring a price here dropped
+        # every proponent on every scored RFP.
+        return [(name, prices[0] if prices else None)]
+    if len(names) != len(prices):
+        return []
+    return list(zip(names, prices))

--- a/scrapers/toronto_bids/sources/pdf_tables.py
+++ b/scrapers/toronto_bids/sources/pdf_tables.py
@@ -99,3 +99,41 @@ def zip_columns(name_cell, price_cell):
     if len(names) != len(prices):
         return []
     return list(zip(names, prices))
+
+
+def all_tables(path):
+    """Every non-empty row of every table in the PDF, as stripped cells with empties DROPPED.
+
+    Column position is not preserved — this is for forms read as (label, value) pairs, where a
+    blank trailing cell is noise. Use `caption_tables` when column INDEX matters. Does I/O.
+    """
+    import pdfplumber
+
+    rows = []
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            for table in page.extract_tables() or []:
+                for row in table:
+                    cells = [(c or "").strip() for c in row]
+                    if any(cells):
+                        rows.append([c for c in cells if c])
+    return rows
+
+
+def caption_tables(path, caption_re):
+    """The table under each `caption_re` match, as RAW cells — empties KEPT.
+
+    Column index is load-bearing here (column 1 is the price column whether or not column 2 is
+    blank), so unlike `all_tables` this must not compact a row. Does I/O; every structural
+    decision belongs to `choose_tables`, which is pure.
+    """
+    import pdfplumber
+
+    pages = []
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            captions = [m["top"] for m in
+                        page.search(caption_re.pattern, regex=True, case=False)]
+            tables = [(t.bbox[1], t.extract()) for t in page.find_tables()]
+            pages.append((captions, tables))
+    return choose_tables(pages)

--- a/scrapers/toronto_bids/store/db.py
+++ b/scrapers/toronto_bids/store/db.py
@@ -300,3 +300,35 @@ def sync_runs_since(conn, after_id: int) -> list[dict]:
         "FROM sync_run WHERE id > ? ORDER BY id", (after_id,))
     cols = [c[0] for c in cur.description]
     return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def rebuild_agency_bids(conn, source: str, rows) -> int:
+    """Replace every `agency_bid` row for one source with a freshly derived set.
+
+    `agency_bid` is DERIVED from held PDFs, so it is rebuilt from the bytes rather than
+    diff-upserted — the sanctioned exception to "rows are never deleted" that
+    `build_supplier_dimension` and `enrich-ariba-attachments --reindex` already take, and for
+    the same reason.
+
+    This is a permanent contract, not a migration. A table whose contents must be corrected once
+    by hand is a table whose derivation should simply be re-run: a migration would encode today's
+    list of known-bad rows and need a successor after the next parser fix. Rebuilding means every
+    parser fix self-heals, with no list written down anywhere.
+
+    **Derive first, delete only on success.** `rows` is already materialised by the caller, and
+    an empty set deletes NOTHING — a machine that does not hold the PDFs re-derives nothing and
+    must not thereby erase the archive. Scoped to one `source`, so rebuilding EP cannot touch
+    TRCA's or the Zoo's rows.
+    """
+    rows = list(rows)
+    if not rows:
+        return 0
+    try:
+        conn.execute("DELETE FROM agency_bid WHERE source=?", (source,))
+        for row in rows:
+            upsert_row(conn, row, overwrite=True)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return len(rows)


### PR DESCRIPTION
Closes #151. Closes #203.

## What changed

**EP board-report bid tables are read as PDF cells instead of regex over `pdftotext`.** #151's
1,500-char window truncated nothing (longest real table: 732 chars) and instead *over-reached*,
pulling `Table 2` duplicates and prose sentences into `agency_bid`. Cells make both impossible
by construction, so the window is deleted rather than resized.

**#203's audit measured the other four candidates. Three stay on regex.** That ratio is the
finding: "read cells where the PDF HAS cells" is a per-corpus fact, and those corpora do not
have them.

| corpus | held | ruled bid tables | verdict |
|---|---|---|---|
| EP board reports | 1,200 | **47/47** of those with a caption | **switched** |
| TRCA eSCRIBE | 3,411 | 95 tables, 30 documents unattributable | regex stays |
| Zoo ZB | 859 | **6** | regex stays |
| committee awards | 8 | 0 real bid tables | regex stays |

## EP result, measured against the reports' own declared counts

47/47 tables found · 153 rows · **0 junk** · **0 duplicates** · **32/35** exact agreement with
declared bid counts · **0 real bidders lost**. Stored `agency_bid` rows 115 → 129.

Not a net removal: 19 contaminated rows go (13 prose phantoms literally named
`The recommended construction price of`, 6 `Table 2` duplicates) and **14+ real bidders the
regex silently dropped come back** — numeric-leading firm names, prices with a leading marker
(`*$792,900.00`, which cost one report its *winning* bidder), and prices published without
cents. The 3 residual disagreements are the City's own documents and got no rule.

## Architecture

- `sources/pdf_tables.py` (new) — every structural rule **pure** and tested with no PDF:
  caption anchoring with a page-break walk, and one canonical copy of #94's positional-zip rule.
  `award_summary.py` is rewired onto it; its `_zip_cell` is deleted. The rule had been
  independently re-derived three times, which made it one rule rather than three similar ones.
- `agency_bid` is now **derived**, rebuilt per source from the held PDFs on every store pass —
  a permanent contract rather than a one-off migration, so every future parser fix self-heals.
  It derives first and deletes only on success, so a machine without the PDFs deletes nothing.
- No shims, no fallbacks, no inert code. `_EP_BID_ROW` and the window are gone; a fallback
  would have reimported exactly the contamination this removes.

## Follow-ups found, deliberately not fixed here

- **24 real EP bids discarded** across 5 reports whose bid table parses correctly but whose
  *prose award-clause* parser (`parse_ep_report`, #130) refuses the report as a non-award.
- **TRCA prices**: its 408 stored bids carry zero prices, and 25 documents have an unambiguous
  single bid table where cells could add them with no attribution risk.

## Verification

800 tests pass. Verified against the live 1,200-report corpus: idempotent on re-run (+0),
TRCA's 408 rows untouched, ~15s for the EP store pass.

A new CLAUDE.md section, **"Parsing discipline: prove clean extraction, or come back — never
chase edge cases"**, records the method this used, since it is the reusable part.
